### PR TITLE
Fix documentation internal links to work with Jekyll permalink configuration

### DIFF
--- a/docs/api/benchmark-level.md
+++ b/docs/api/benchmark-level.md
@@ -10,7 +10,7 @@ nav_order: 2
 The Benchmark-Level API defines how evaluation harnesses discover, spawn, and manage task instances. This layer handles shared infrastructure, resource allocation, and task lifecycle management.
 
 {: .note }
-> This API describes benchmark orchestration. For agent-task interaction, see the [Task-Level API](task-level.html).
+> This API describes benchmark orchestration. For agent-task interaction, see the [Task-Level API]({{site.baseurl}}/api/task-level).
 
 ## Overview
 
@@ -704,6 +704,6 @@ server.start()
 
 ## Next Steps
 
-- **[Task-Level API](task-level.html)**: Learn the agent-task interaction protocol
-- **[Package-Level Standard](package-level.html)**: Learn deployment requirements
-- **[Benchmark Author Guide](../guides/benchmark-authors.html)**: Complete implementation tutorial
+- **[Task-Level API]({{site.baseurl}}/api/task-level)**: Learn the agent-task interaction protocol
+- **[Package-Level Standard]({{site.baseurl}}/api/package-level)**: Learn deployment requirements
+- **[Benchmark Author Guide]({{site.baseurl}}/guides/benchmark-authors)**: Complete implementation tutorial

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -13,10 +13,10 @@ The CUBE standard defines four layers of API specifications. Each layer serves a
 
 | Layer | Purpose | Audience |
 |-------|---------|----------|
-| [Task Level](task-level.html) | Define how agents interact with individual task instances | Agent developers, benchmark authors |
-| [Benchmark Level](benchmark-level.html) | Define task discovery, spawning, and lifecycle management | Platform developers, benchmark authors |
-| [Package Level](package-level.html) | Define installation, deployment, and parallelization | Infrastructure engineers, benchmark authors |
-| [Registry](registry.html) | Define metadata schema for benchmark discovery | All users, registry maintainers |
+| [Task Level]({{site.baseurl}}/api/task-level) | Define how agents interact with individual task instances | Agent developers, benchmark authors |
+| [Benchmark Level]({{site.baseurl}}/api/benchmark-level) | Define task discovery, spawning, and lifecycle management | Platform developers, benchmark authors |
+| [Package Level]({{site.baseurl}}/api/package-level) | Define installation, deployment, and parallelization | Infrastructure engineers, benchmark authors |
+| [Registry]({{site.baseurl}}/api/registry) | Define metadata schema for benchmark discovery | All users, registry maintainers |
 
 ## Quick Reference
 
@@ -32,7 +32,7 @@ The agent-environment interaction layer. Combines MCP for actions and CUBE for e
 - `cube/reset` - Reset task to initial state
 - `cube/close` - Cleanup task resources
 
-**[Full Task-Level Specification →](task-level.html)**
+**[Full Task-Level Specification →]({{site.baseurl}}/api/task-level)**
 
 ### Benchmark-Level API
 
@@ -45,7 +45,7 @@ The task orchestration layer. Manages shared infrastructure and task spawning.
 - `cube/status` - Check health of running tasks
 - `cube/shutdown` - Cleanup task instances
 
-**[Full Benchmark-Level Specification →](benchmark-level.html)**
+**[Full Benchmark-Level Specification →]({{site.baseurl}}/api/benchmark-level)**
 
 ### Package-Level Standard
 
@@ -57,7 +57,7 @@ The deployment and installation layer. Defines how benchmarks are packaged and d
 - Parallelization support
 - Deployment models (local, containerized, remote)
 
-**[Full Package-Level Specification →](package-level.html)**
+**[Full Package-Level Specification →]({{site.baseurl}}/api/package-level)**
 
 ### Registry Standard
 
@@ -69,7 +69,7 @@ The discovery and metadata layer. Enables filtering and automated installation.
 - Requirements (runtime, hardware)
 - Economics (task_count, estimated_tokens)
 
-**[Full Registry Specification →](registry.html)**
+**[Full Registry Specification →]({{site.baseurl}}/api/registry)**
 
 ## Design Principles
 
@@ -105,7 +105,7 @@ You implement CUBE by providing:
 3. **A package setup** following Package-Level requirements
 4. **Registry metadata** for discovery
 
-See the [Benchmark Author Guide](../guides/benchmark-authors.html) for step-by-step instructions.
+See the [Benchmark Author Guide]({{site.baseurl}}/guides/benchmark-authors) for step-by-step instructions.
 
 ### For Platform Developers
 
@@ -116,7 +116,7 @@ You integrate CUBE by:
 3. **Interacting with tasks** via the Task-Level API
 4. **Filtering benchmarks** via the Registry API
 
-See the [Platform Developer Guide](../guides/platform-developers.html) for integration patterns.
+See the [Platform Developer Guide]({{site.baseurl}}/guides/platform-developers) for integration patterns.
 
 ### For End Users (Researchers)
 
@@ -126,7 +126,7 @@ You use CUBE by:
 2. **Installing benchmarks** via pip
 3. **Running evaluations** using Task-Level methods
 
-See the [Quick Start Guide](../quickstart.html) for examples.
+See the [Quick Start Guide]({{site.baseurl}}/quickstart) for examples.
 
 ## API Conventions
 
@@ -193,11 +193,11 @@ class TaskInfo:
 
 ## Next Steps
 
-- **[Task-Level API](task-level.html)**: Learn the agent-environment interaction protocol
-- **[Benchmark-Level API](benchmark-level.html)**: Learn task orchestration
-- **[Package-Level Standard](package-level.html)**: Learn deployment requirements
-- **[Registry Standard](registry.html)**: Learn metadata schema
+- **[Task-Level API]({{site.baseurl}}/api/task-level)**: Learn the agent-environment interaction protocol
+- **[Benchmark-Level API]({{site.baseurl}}/api/benchmark-level)**: Learn task orchestration
+- **[Package-Level Standard]({{site.baseurl}}/api/package-level)**: Learn deployment requirements
+- **[Registry Standard]({{site.baseurl}}/api/registry)**: Learn metadata schema
 
 Or jump to the guides:
-- **[Benchmark Author Guide](../guides/benchmark-authors.html)**: Wrap your benchmark
-- **[Platform Developer Guide](../guides/platform-developers.html)**: Integrate CUBE support
+- **[Benchmark Author Guide]({{site.baseurl}}/guides/benchmark-authors)**: Wrap your benchmark
+- **[Platform Developer Guide]({{site.baseurl}}/guides/platform-developers)**: Integrate CUBE support

--- a/docs/api/package-level.md
+++ b/docs/api/package-level.md
@@ -195,10 +195,10 @@ This specification is being developed collaboratively. To contribute:
 
 ## Related Documentation
 
-- [Task-Level API](task-level.html) - How agents interact with tasks
-- [Benchmark-Level API](benchmark-level.html) - How tasks are orchestrated
-- [Registry Standard](registry.html) - How benchmarks are discovered
-- [Benchmark Author Guide](../guides/benchmark-authors.html) - Implementation guide
+- [Task-Level API]({{site.baseurl}}/api/task-level) - How agents interact with tasks
+- [Benchmark-Level API]({{site.baseurl}}/api/benchmark-level) - How tasks are orchestrated
+- [Registry Standard]({{site.baseurl}}/api/registry) - How benchmarks are discovered
+- [Benchmark Author Guide]({{site.baseurl}}/guides/benchmark-authors) - Implementation guide
 
 ---
 

--- a/docs/api/registry.md
+++ b/docs/api/registry.md
@@ -217,7 +217,7 @@ validate_metadata(metadata)
 
 ## Submission Process (Proposed)
 
-1. **Implement CUBE Wrapper**: Follow [Benchmark Author Guide](../guides/benchmark-authors.html)
+1. **Implement CUBE Wrapper**: Follow [Benchmark Author Guide]({{site.baseurl}}/guides/benchmark-authors)
 2. **Create Metadata**: Fill out registry metadata JSON
 3. **Validate Locally**: Run compliance tests
 4. **Submit PR**: Add metadata to registry repository
@@ -330,10 +330,10 @@ To contribute to the Registry Standard:
 
 ## Related Documentation
 
-- [Task-Level API](task-level.html) - How agents interact with tasks
-- [Benchmark-Level API](benchmark-level.html) - How tasks are orchestrated
-- [Package-Level Standard](package-level.html) - Installation and deployment
-- [Benchmark Author Guide](../guides/benchmark-authors.html) - How to submit benchmarks
+- [Task-Level API]({{site.baseurl}}/api/task-level) - How agents interact with tasks
+- [Benchmark-Level API]({{site.baseurl}}/api/benchmark-level) - How tasks are orchestrated
+- [Package-Level Standard]({{site.baseurl}}/api/package-level) - Installation and deployment
+- [Benchmark Author Guide]({{site.baseurl}}/guides/benchmark-authors) - How to submit benchmarks
 
 ---
 

--- a/docs/api/task-level.md
+++ b/docs/api/task-level.md
@@ -10,7 +10,7 @@ nav_order: 1
 The Task-Level API defines how agents interact with individual task instances. It combines the Model Context Protocol (MCP) for action execution with CUBE extensions for evaluation semantics.
 
 {: .note }
-> This API describes a single task instance. For managing multiple tasks and shared infrastructure, see the [Benchmark-Level API](benchmark-level.html).
+> This API describes a single task instance. For managing multiple tasks and shared infrastructure, see the [Benchmark-Level API]({{site.baseurl}}/api/benchmark-level).
 
 ## Overview
 
@@ -632,7 +632,7 @@ The server automatically exposes all methods as RPC endpoints with the same sign
 
 ## Next Steps
 
-- **[Benchmark-Level API](benchmark-level.html)**: Learn how to manage multiple tasks
-- **[Benchmark Author Guide](../guides/benchmark-authors.html)**: Complete tutorial on wrapping a benchmark
+- **[Benchmark-Level API]({{site.baseurl}}/api/benchmark-level)**: Learn how to manage multiple tasks
+- **[Benchmark Author Guide]({{site.baseurl}}/guides/benchmark-authors)**: Complete tutorial on wrapping a benchmark
 - **[Examples](../examples/)**: See complete implementation examples
 

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -11,7 +11,7 @@ Step-by-step guides for different CUBE user personas.
 
 ## Available Guides
 
-### [Benchmark Author Guide](benchmark-authors.html)
+### [Benchmark Author Guide]({{site.baseurl}}/guides/benchmark-authors)
 
 **For**: Researchers and developers who have created a benchmark and want to make it CUBE-compliant
 
@@ -24,7 +24,7 @@ Step-by-step guides for different CUBE user personas.
 
 **Time**: 1-2 hours to wrap a simple benchmark
 
-### [Platform Developer Guide](platform-developers.html) *(Coming Soon)*
+### [Platform Developer Guide]({{site.baseurl}}/guides/platform-developers) *(Coming Soon)*
 
 **For**: Developers building evaluation harnesses, training platforms, or agent frameworks
 
@@ -93,32 +93,32 @@ Before integrating CUBE, you should have:
 
 If you just want to get started quickly:
 
-1. Read the [Overview](../overview.html) (10 min)
-2. Follow the [Quick Start](../quickstart.html) to see CUBE in action (10 min)
-3. Start the [Benchmark Author Guide](benchmark-authors.html) tutorial (10 min initial setup)
+1. Read the [Overview]({{site.baseurl}}/overview) (10 min)
+2. Follow the [Quick Start]({{site.baseurl}}/quickstart) to see CUBE in action (10 min)
+3. Start the [Benchmark Author Guide]({{site.baseurl}}/guides/benchmark-authors) tutorial (10 min initial setup)
 
 ### Path 2: Understand Before Implementing (1 hour)
 
 If you prefer to understand the full picture first:
 
-1. Read the [Overview](../overview.html) (10 min)
-2. Study the [API Reference](../api/) (30 min)
-   - [Task-Level API](../api/task-level.html)
-   - [Benchmark-Level API](../api/benchmark-level.html)
-3. Review the [Quick Start](../quickstart.html) examples (10 min)
+1. Read the [Overview]({{site.baseurl}}/overview) (10 min)
+2. Study the [API Reference]({{site.baseurl}}/api/) (30 min)
+   - [Task-Level API]({{site.baseurl}}/api/task-level)
+   - [Benchmark-Level API]({{site.baseurl}}/api/benchmark-level)
+3. Review the [Quick Start]({{site.baseurl}}/quickstart) examples (10 min)
 4. Begin the appropriate guide (10 min)
 
 ### Path 3: Deep Dive (2-3 hours)
 
 For a comprehensive understanding:
 
-1. Read the [Overview](../overview.html) (10 min)
-2. Complete the [Quick Start](../quickstart.html) tutorial (20 min)
-3. Read all [API Reference](../api/) pages (45 min)
-   - [Task-Level API](../api/task-level.html)
-   - [Benchmark-Level API](../api/benchmark-level.html)
-   - [Package-Level Standard](../api/package-level.html)
-   - [Registry Standard](../api/registry.html)
+1. Read the [Overview]({{site.baseurl}}/overview) (10 min)
+2. Complete the [Quick Start]({{site.baseurl}}/quickstart) tutorial (20 min)
+3. Read all [API Reference]({{site.baseurl}}/api/) pages (45 min)
+   - [Task-Level API]({{site.baseurl}}/api/task-level)
+   - [Benchmark-Level API]({{site.baseurl}}/api/benchmark-level)
+   - [Package-Level Standard]({{site.baseurl}}/api/package-level)
+   - [Registry Standard]({{site.baseurl}}/api/registry)
 4. Review community examples (30 min)
 5. Complete the relevant guide (1-2 hours)
 
@@ -138,7 +138,7 @@ Learn from existing CUBE-compliant benchmarks:
 
 As you work through the guides:
 
-- **API Questions**: Check the [API Reference](../api/)
+- **API Questions**: Check the [API Reference]({{site.baseurl}}/api/)
 - **Implementation Issues**: Search [GitHub Issues](https://github.com/The-AI-Alliance/cube-standard/issues)
 - **Community Discussion**: Join [GitHub Discussions](https://github.com/The-AI-Alliance/cube-standard/discussions)
 - **Direct Help**: Email [contact@thealliance.ai](mailto:contact@thealliance.ai?subject=CUBE%20Guide%20Question)
@@ -157,5 +157,5 @@ We're constantly improving these guides based on community feedback!
 ---
 
 **Ready to start?**
-- [Benchmark Author Guide →](benchmark-authors.html)
-- [Platform Developer Guide →](platform-developers.html) *(Coming Soon)*
+- [Benchmark Author Guide →]({{site.baseurl}}/guides/benchmark-authors)
+- [Platform Developer Guide →]({{site.baseurl}}/guides/platform-developers) *(Coming Soon)*

--- a/docs/guides/platform-developers.md
+++ b/docs/guides/platform-developers.md
@@ -313,10 +313,10 @@ Want to help shape this guide?
 
 ## Related Documentation
 
-- [Overview](../overview.html) - Understanding CUBE's architecture
-- [API Reference](../api/) - Complete API specifications
-- [Benchmark Author Guide](benchmark-authors.html) - For benchmark implementers
-- [Quick Start](../quickstart.html) - Basic usage examples
+- [Overview]({{site.baseurl}}/overview) - Understanding CUBE's architecture
+- [API Reference]({{site.baseurl}}/api/) - Complete API specifications
+- [Benchmark Author Guide]({{site.baseurl}}/guides/benchmark-authors) - For benchmark implementers
+- [Quick Start]({{site.baseurl}}/quickstart) - Basic usage examples
 
 ---
 
@@ -327,9 +327,9 @@ Want to help shape this guide?
 
 Until this full guide is available, refer to:
 
-1. **[Quick Start Guide](../quickstart.html)** - Basic usage patterns
-2. **[API Reference](../api/)** - Complete API specifications
-3. **[Benchmark Author Guide](benchmark-authors.html)** - Shows the other side of integration
+1. **[Quick Start Guide]({{site.baseurl}}/quickstart)** - Basic usage patterns
+2. **[API Reference]({{site.baseurl}}/api/)** - Complete API specifications
+3. **[Benchmark Author Guide]({{site.baseurl}}/guides/benchmark-authors)** - Shows the other side of integration
 4. **[GitHub Discussions](https://github.com/The-AI-Alliance/cube-standard/discussions)** - Ask specific questions
 
 ## Contributing

--- a/docs/index.markdown
+++ b/docs/index.markdown
@@ -9,6 +9,9 @@ has_children: false
 
 **Common Unified Benchmark Environments**
 
+{: .warning }
+> **Early Documentation**: This specification is in active development. APIs and documentation may change as we gather community feedback and refine the standard. Code examples are placeholders and may not work until the specification is finalized.
+
 A protocol standard that eliminates the integration tax of agentic benchmarks by providing a universal interface between benchmarks and evaluation frameworks.
 
 {: .note }
@@ -80,21 +83,21 @@ for bench_info in benchmarks:
 
 ### Getting Started
 
-- **[Overview](overview.html)** - Understanding CUBE's architecture and design
-- **[Quick Start](quickstart.html)** - Get running in 5 minutes
+- **[Overview]({{site.baseurl}}/overview)** - Understanding CUBE's architecture and design
+- **[Quick Start]({{site.baseurl}}/quickstart)** - Get running in 5 minutes
 
 ### API Reference
 
-- **[API Overview](api/)** - Complete specification
-  - [Task-Level API](api/task-level.html) - Agent-environment interaction
-  - [Benchmark-Level API](api/benchmark-level.html) - Task orchestration
-  - [Package-Level Standard](api/package-level.html) - Installation & deployment
-  - [Registry Standard](api/registry.html) - Discovery & metadata
+- **[API Overview]({{site.baseurl}}/api/)** - Complete specification
+  - [Task-Level API]({{site.baseurl}}/api/task-level) - Agent-environment interaction
+  - [Benchmark-Level API]({{site.baseurl}}/api/benchmark-level) - Task orchestration
+  - [Package-Level Standard]({{site.baseurl}}/api/package-level) - Installation & deployment
+  - [Registry Standard]({{site.baseurl}}/api/registry) - Discovery & metadata
 
 ### Implementation Guides
 
-- **[Benchmark Author Guide](guides/benchmark-authors.html)** - Wrap your benchmark for CUBE
-- **[Platform Developer Guide](guides/platform-developers.html)** - Integrate CUBE support *(Coming Soon)*
+- **[Benchmark Author Guide]({{site.baseurl}}/guides/benchmark-authors)** - Wrap your benchmark for CUBE
+- **[Platform Developer Guide]({{site.baseurl}}/guides/platform-developers)** - Integrate CUBE support *(Coming Soon)*
 
 ## Core Principles
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -170,10 +170,10 @@ A CUBE-compliant benchmark must:
 
 Ready to use or create CUBE-compliant benchmarks?
 
-- **[Quick Start Guide](quickstart.html)**: Get up and running in 5 minutes
-- **[API Reference](api/)**: Complete specification of all APIs
-- **[Benchmark Author Guide](guides/benchmark-authors.html)**: Wrap your first benchmark
-- **[Platform Developer Guide](guides/platform-developers.html)**: Integrate CUBE support into your harness
+- **[Quick Start Guide]({{site.baseurl}}/quickstart)**: Get up and running in 5 minutes
+- **[API Reference]({{site.baseurl}}/api/)**: Complete specification of all APIs
+- **[Benchmark Author Guide]({{site.baseurl}}/guides/benchmark-authors)**: Wrap your first benchmark
+- **[Platform Developer Guide]({{site.baseurl}}/guides/platform-developers)**: Integrate CUBE support into your harness
 
 ## Community & Governance
 
@@ -184,7 +184,7 @@ CUBE is an open standard developed under [The AI Alliance](https://aialliance.or
 - **Vendor-neutral**: No single company controls the standard
 - **Apache 2.0 licensed**: Free to implement and extend
 
-See our [Contributing Guide](contributing.html) to get involved.
+See our [Contributing Guide]({{site.baseurl}}/contributing) to get involved.
 
 ## FAQ
 
@@ -209,6 +209,6 @@ A: No. While CUBE builds on Gym concepts, it's designed for diverse agentic benc
 ---
 
 **Next Steps**:
-- Try the [Quick Start](quickstart.html) to see CUBE in action
-- Explore the [API Reference](api/) to understand the specification
+- Try the [Quick Start]({{site.baseurl}}/quickstart) to see CUBE in action
+- Explore the [API Reference]({{site.baseurl}}/api/) to understand the specification
 - Join the discussion on [GitHub](https://github.com/The-AI-Alliance/cube-standard)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -25,7 +25,7 @@ pip install cube-benchmark-miniwob
 ```
 
 {: .tip }
-> You can discover all available CUBE benchmarks using the registry (see [Registry Guide](api/registry.html)).
+> You can discover all available CUBE benchmarks using the registry (see [Registry Guide]({{site.baseurl}}/api/registry)).
 
 ## Your First Evaluation
 
@@ -263,9 +263,9 @@ safe_benchmarks = registry.list(
 
 Now that you've run your first CUBE evaluation:
 
-1. **Understand the APIs**: Read the [API Reference](api/) to learn about all available methods
-2. **Create your own wrapper**: Follow the [Benchmark Author Guide](guides/benchmark-authors.html) to make your benchmark CUBE-compliant
-3. **Integrate with your platform**: See the [Platform Developer Guide](guides/platform-developers.html) to add CUBE support to your evaluation harness
+1. **Understand the APIs**: Read the [API Reference]({{site.baseurl}}/api/) to learn about all available methods
+2. **Create your own wrapper**: Follow the [Benchmark Author Guide]({{site.baseurl}}/guides/benchmark-authors) to make your benchmark CUBE-compliant
+3. **Integrate with your platform**: See the [Platform Developer Guide]({{site.baseurl}}/guides/platform-developers) to add CUBE support to your evaluation harness
 4. **Explore examples**: Check out [Examples](examples/) for more advanced use cases
 
 ## Common Issues
@@ -321,6 +321,6 @@ task = benchmark.spawn(task_id="slow-task", timeout=600)  # 10 minutes for this 
 ---
 
 **Continue learning**:
-- [Overview](overview.html): Understand CUBE's architecture
-- [API Reference](api/): Complete specification
-- [Benchmark Authors Guide](guides/benchmark-authors.html): Create CUBE benchmarks
+- [Overview]({{site.baseurl}}/overview): Understand CUBE's architecture
+- [API Reference]({{site.baseurl}}/api/): Complete specification
+- [Benchmark Authors Guide]({{site.baseurl}}/guides/benchmark-authors): Create CUBE benchmarks


### PR DESCRIPTION
## Summary

This PR fixes broken internal navigation links in the documentation. The links were not working because they used `.html` extensions, but the Jekyll site is configured with `permalink: pretty` which removes `.html` from URLs.

## Changes

### Link Fixes
- Converted all internal `.html` links to use `{{site.baseurl}}` format
- Removed `.html` extensions from links to work with `permalink: pretty` configuration
- Updated 58 total links across 10 documentation files

### Documentation Notice
- Added early documentation warning notice to the index page
- Clarified that the specification is in active development
- Noted that code examples are placeholders until the specification is finalized

## Files Changed

- `docs/index.markdown` - 8 links + warning notice
- `docs/overview.md` - 6 links
- `docs/quickstart.md` - 6 links
- `docs/guides/index.md` - 15 links
- `docs/guides/platform-developers.md` - 7 links
- `docs/api/index.md` - 10 links
- `docs/api/task-level.md` - 3 links
- `docs/api/benchmark-level.md` - 4 links
- `docs/api/package-level.md` - 4 links
- `docs/api/registry.md` - 5 links

## Testing

Links now correctly resolve with Jekyll's `baseurl: "/cube-standard"` and `permalink: pretty` configuration. All internal navigation should work correctly when deployed to GitHub Pages.

## Example

**Before:**
```markdown
[Task Level API](task-level.html)
```

**After:**
```markdown
[Task Level API]({{site.baseurl}}/api/task-level)
```

This ensures links work correctly at `https://the-ai-alliance.github.io/cube-standard/`.