### PR TITLE
New glossary URL

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -27,7 +27,7 @@ exclude: ["node_modules/", "*.gemspec", "*.gem", "Gemfile", "Gemfile.lock", "pac
 
 # Added by AI Alliance: a glossary URL, which in this case is internal
 # to this site!
-glossaryurl: https://the-ai-alliance.github.io/glossary/glossary
+glossaryurl: https://the-ai-alliance.github.io/glossary
 
 # Regression tests
 # By default, the pages in /docs/tests are excluded when the site is built.


### PR DESCRIPTION
# Documentation/Website Change - "Glossary" URL

The `docs/_config.yml` for the GitHub Pages has a definition for the URL for the AI Alliance's Glossary. This PR updates that URL, which changed.