### PR TITLE
feat(tool): support instance-level actions attached via setattr

### DIFF
--- a/src/cube/tool.py
+++ b/src/cube/tool.py
@@ -210,6 +210,10 @@ class Tool(AbstractTool):
         - Method that does not exist on the class at all.
         - Method that exists but is not decorated with @tool_action.
         """
+        # Check instance dict first — catches dynamically attached actions (not in any class dict)
+        method = self.__dict__.get(action.name)
+        if method and callable(method) and getattr(method, "_is_action", False):
+            return method
         method = getattr(self, action.name, None)
         if not method:
             raise ValueError(f"Action {action.name} does not exist in {self.__class__.__name__}.")
@@ -279,6 +283,11 @@ class Tool(AbstractTool):
                 if attr_name in cls.__dict__
             )
             if callable(attr) and is_action:
+                actions.append(ActionSchema.from_function(attr))
+
+        # Also discover instance-level actions attached via setattr (not in any class dict)
+        for name, attr in self.__dict__.items():
+            if not name.startswith("_") and callable(attr) and getattr(attr, "_is_action", False):
                 actions.append(ActionSchema.from_function(attr))
 
         return actions


### PR DESCRIPTION
Tool now discovers and dispatches actions that are attached to an instance at runtime (via setattr), not just those defined as class methods with @tool_action.
Example use case
```python

class CounterTool(Tool):
    def __init__(self, config: CounterToolConfig | None = None):
        self._env = CounterEnv()  

        if config is None:
            config = CounterToolConfig()  # default config if none provided.

        if config.enable_decrement:
            self.add_tool_action(decrement)

        if config.enable_increment_by:
            self.add_tool_action(increment_by)

    def reset(self):
        self._env.reset()

    # default actions
    @tool_action
    def increment(self) -> str:
        """Increment the counter by 1."""
        self._env.counter += 1
        return f"Counter value is: {self._env.counter}"

    def add_tool_action(self, func) -> None:
        """Dynamically add a plain function as an action on this instance.

        func must accept env as its first argument. All remaining parameters
        become the agent-visible arguments in the ActionSchema.
        """
        bound: Callable = partial(func, self._env)
        bound._is_action = True
        bound.__name__ = func.__name__
        bound.__doc__ = func.__doc__
        setattr(self, bound.__name__, bound)

```

**Dynamic action discovery**

* The `get_action_method` method now first checks the instance dictionary (`__dict__`) for a method matching the action name, ensuring dynamically attached actions are found and validated as tool actions before falling back to class-level lookup.
* The `action_set` method now also iterates through the instance dictionary to discover and include any dynamically attached actions that are callable and decorated as tool actions, in addition to class-level actions.