### PR TITLE
Fix Content serialization by explicit typing

### DIFF
--- a/src/cube/core.py
+++ b/src/cube/core.py
@@ -23,7 +23,15 @@ from abc import ABC, abstractmethod
 from typing import Any, Callable, ClassVar, Self
 
 from PIL import Image as PILImage
-from pydantic import BaseModel, Field, field_serializer, field_validator, model_serializer, model_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    SerializeAsAny,
+    field_serializer,
+    field_validator,
+    model_serializer,
+    model_validator,
+)
 
 from cube.utils import function_to_dict
 
@@ -328,9 +336,7 @@ class Observation(TypedBaseModel):
         contents (list[Content]): List of content pieces that make up this observation.
     """
 
-    contents: list[TextContent | StructuredContent | ImageContent | AudioContent | VideoContent] = Field(
-        default_factory=list
-    )
+    contents: list[SerializeAsAny[Content]] = Field(default_factory=list)
 
     @classmethod
     def from_text(cls, text: str) -> Self:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -150,11 +150,15 @@ def test_observation_from_text_and_add():
     assert combined.contents == [TextContent(data="hello"), TextContent(data="world")]
 
 
-def test_observation_json_serialization_with_image():
-    img = PILImage.new("RGB", (10, 10))
+def test_observation_round_trip_with_image():
+    img = PILImage.new("RGB", (10, 10), color=(0, 0, 255))
     obs = Observation(contents=[ImageContent(data=img)])
     data = obs.model_dump_json()
     assert ImageContent._image_prefix in data
+    restored = Observation.model_validate_json(data)
+    assert isinstance(restored.contents[0], ImageContent)
+    assert restored.contents[0].data.size == img.size
+    assert restored.contents[0].data.getpixel((0, 0)) == (0, 0, 255)
 
 
 # --- StepError ---


### PR DESCRIPTION
# PR Template: New Function or Feature

## Description of Changes

Content in Observation is typed as the base class Content. Thus, for serialization, this is the class that will be used, and custom methods in ImageContent is ignored. By using a union of the types, this is fixed as now Pydantic is able to infer the type using TypedBaseModel feature.

## Testing Performed
Added test revealing the bug

## Code Changes
Use Union to type the content in Observation, instead of base class Content.

## Example Usage

Check test with and without fix 
`uv run pytest tests/test_core.py::test_observation_json_serialization_with_image`
