### PR TITLE
security: address OSCR scan findings

### DIFF
--- a/src/cube/backends/local.py
+++ b/src/cube/backends/local.py
@@ -197,8 +197,8 @@ class LocalContainerBackend(ContainerBackend):
             kwargs["ports"] = {f"{p}/tcp": None for p in config.ports}
 
         try:
-            docker_container = client.containers.run(
-                config.image,
+            docker_container = client.containers.run(  # nosemgrep: docker-arbitrary-container-run
+                config.image,  # trusted: DockerConfig is authored by the benchmark developer, not end-user input
                 command="sleep infinity",
                 detach=True,
                 network_mode=self.network_mode,

--- a/src/cube/cli.py
+++ b/src/cube/cli.py
@@ -286,7 +286,9 @@ def cmd_test(module_name: str, *, max_steps: int = 20) -> None:
         )
 
     try:
-        module = importlib.import_module(resolved)
+        module = importlib.import_module(
+            resolved
+        )  # nosemgrep: non-literal-import  # trusted: module path from CLI user who already has local shell access
     except ModuleNotFoundError as exc:
         err_console.print(
             Panel(

--- a/src/cube/core.py
+++ b/src/cube/core.py
@@ -59,8 +59,10 @@ class TypedBaseModel(BaseModel):
         if isinstance(value, dict) and "_type" in value:
             type_path = value.pop("_type")
             module_name, class_name = type_path.rsplit(".", 1)
-            module = importlib.import_module(module_name)
+            module = importlib.import_module(module_name)  # nosemgrep: non-literal-import
             actual_cls = getattr(module, class_name)
+            if not (isinstance(actual_cls, type) and issubclass(actual_cls, TypedBaseModel)):
+                raise ValueError(f"Refusing to deserialize '{type_path}': class must be a TypedBaseModel subclass.")
             return actual_cls.model_validate(value)
         if isinstance(value, dict) and inspect.isabstract(cls):
             raise ValueError(


### PR DESCRIPTION
## Summary

- **`core.py`**: Add a `TypedBaseModel` subclass guard in `_deserialize_with_type`. After importing the module named in `_type`, the resolved class is verified to be a `TypedBaseModel` subclass before `model_validate` is called. This blocks deserialization gadget attacks where a crafted `_type` value (e.g. pointing to a stdlib or third-party class) could be used to instantiate arbitrary Python objects. Suppress semgrep `non-literal-import` (dynamic import is intentional; `_type` is written by `TypedBaseModel` itself).
- **`local.py`**: Suppress semgrep `docker-arbitrary-container-run`. `config.image` comes from a benchmark author's `DockerConfig`, not end-user input.
- **`cli.py`**: Suppress semgrep `non-literal-import`. Module path comes from a CLI user who already has local shell access.

## Test plan

- [x] All 17 existing `tests/test_core.py` tests pass
- [x] Ruff clean
- [ ] Verify semgrep no longer flags these lines
- [ ] Confirm deserialization of all known TypedBaseModel subclasses (ContainerBackend, AgentConfig, Content, etc.) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)