### PR TITLE
cube-vm-backend Bump version from 0.2.0 to 0.2.1

### DIFF
--- a/cube-resources/cube-vm-backend/pyproject.toml
+++ b/cube-resources/cube-vm-backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cube-vm-backend"
-version = "0.2.0"
+version = "0.2.1"
 description = "VM backend implementations for CUBE desktop-automation benchmarks"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
Click the `Preview` tab and select a PR template:

- [Docs/Website-only change](?expand=1&template=docs_website_pr.md)
- [Other change](?expand=1&template=general_code_pr.md)

[//]: # (Dumb that we have to do this hack, see https://github.com/orgs/community/discussions/4620 for progress on github fixing this)