### PR TITLE
feat: NeMo Gym integration

### DIFF
--- a/src/cube/core.py
+++ b/src/cube/core.py
@@ -139,6 +139,26 @@ class Action(TypedBaseModel):
     name: str
     arguments: dict[str, Any] = Field(default_factory=dict)
 
+    @classmethod
+    def from_openai_tool_call(cls, tool_call: dict) -> Self:
+        """Create an Action from an OpenAI tool call dict.
+
+        Supports both Chat Completions format:
+            {"id": "call_xxx", "type": "function", "function": {"name": "click", "arguments": "{...}"}}
+        and flat/Responses API format:
+            {"id": "call_xxx", "name": "click", "arguments": "{...}"}
+        """
+        if "function" in tool_call:
+            func = tool_call["function"]
+            name = func["name"]
+            raw_args = func.get("arguments", "{}")
+        else:
+            name = tool_call["name"]
+            raw_args = tool_call.get("arguments", "{}")
+
+        arguments = json.loads(raw_args) if isinstance(raw_args, str) else raw_args
+        return cls(id=tool_call.get("id") or tool_call.get("call_id"), name=name, arguments=arguments)
+
 
 class Content(TypedBaseModel, ABC):
     """

--- a/src/cube/core.py
+++ b/src/cube/core.py
@@ -151,10 +151,10 @@ class Action(TypedBaseModel):
         if "function" in tool_call:
             func = tool_call["function"]
             name = func["name"]
-            raw_args = func.get("arguments", "{}")
+            raw_args = func.get("arguments") or "{}"
         else:
             name = tool_call["name"]
-            raw_args = tool_call.get("arguments", "{}")
+            raw_args = tool_call.get("arguments") or "{}"
 
         arguments = json.loads(raw_args) if isinstance(raw_args, str) else raw_args
         return cls(id=tool_call.get("id") or tool_call.get("call_id"), name=name, arguments=arguments)

--- a/src/cube/integrations/nemogym.py
+++ b/src/cube/integrations/nemogym.py
@@ -1,0 +1,209 @@
+"""
+NeMo Gym integration for CUBE.
+
+Provides a CubeResourcesServer that wraps any CUBE Benchmark as an HTTP server
+compatible with NeMo Gym's resource server protocol. NeMo Gym's CubeAgent calls
+these endpoints over HTTP — no NeMo Gym Python dependency required.
+
+Endpoints:
+    POST /seed_session  — pick a task, reset it, return initial observation + tools
+    POST /step          — execute an action, return next observation + reward + done
+    POST /verify        — evaluate the current task state, return reward
+    POST /close         — close a task and free resources
+
+Usage:
+    from cube.integrations.nemogym import CubeResourcesServer
+
+    server = CubeResourcesServer(benchmark=my_benchmark)
+    server.run(host="0.0.0.0", port=8080)
+
+Or programmatically:
+    app = server.make_app()  # returns a FastAPI instance
+"""
+
+import atexit
+import logging
+import uuid
+from contextlib import asynccontextmanager
+
+import uvicorn
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from cube.benchmark import Benchmark
+from cube.core import Action
+from cube.task import Task, TaskConfig
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Request / Response schemas
+# ---------------------------------------------------------------------------
+
+
+class SeedSessionRequest(BaseModel):
+    task_idx: int
+
+
+class SeedSessionResponse(BaseModel):
+    env_id: str
+    observation: list[dict]
+    tools: list[dict]
+
+
+class StepRequest(BaseModel):
+    env_id: str
+    action: dict
+
+
+class StepResponse(BaseModel):
+    observation: list[dict]
+    reward: float
+    done: bool
+
+
+class VerifyRequest(BaseModel):
+    env_id: str
+
+
+class VerifyResponse(BaseModel):
+    reward: float
+    reward_info: dict = {}
+
+
+class CloseRequest(BaseModel):
+    env_id: str
+
+
+# ---------------------------------------------------------------------------
+# Server
+# ---------------------------------------------------------------------------
+
+
+class CubeResourcesServer:
+    """Wraps a CUBE Benchmark as a NeMo Gym-compatible HTTP resource server.
+
+    Manages multiple concurrent sessions (env_id → Task), each corresponding
+    to one episode. The benchmark must be set up before constructing this server.
+
+    Args:
+        benchmark: A CUBE Benchmark instance (already set up via benchmark.setup()).
+    """
+
+    def __init__(self, benchmark: Benchmark) -> None:
+        self.benchmark = benchmark
+        self._task_configs: list[TaskConfig] = list(benchmark.get_task_configs())
+        self._sessions: dict[str, Task] = {}
+        self._last_obs: dict[str, object] = {}  # env_id → last Observation for verify
+
+        if not self._task_configs:
+            raise ValueError(f"Benchmark '{benchmark.name}' has no task configs")
+
+        logger.info("CubeResourcesServer loaded %d tasks from '%s'", len(self._task_configs), benchmark.name)
+
+    # -- Lifecycle -----------------------------------------------------------
+
+    def _close_all(self) -> None:
+        """Best-effort cleanup of all open sessions."""
+        for env_id, task in list(self._sessions.items()):
+            try:
+                task.close()
+                logger.debug("Closed session %s", env_id)
+            except Exception:
+                logger.exception("Error closing session %s", env_id)
+        self._sessions.clear()
+        self._last_obs.clear()
+
+    # -- Endpoints -----------------------------------------------------------
+
+    def seed_session(self, body: SeedSessionRequest) -> SeedSessionResponse:
+        if body.task_idx < 0 or body.task_idx >= len(self._task_configs):
+            raise HTTPException(status_code=400, detail=f"task_idx {body.task_idx} out of range [0, {len(self._task_configs)})")
+
+        task_config = self._task_configs[body.task_idx]
+        task = task_config.make(
+            runtime_context=self.benchmark._runtime_context,
+            container_backend=self.benchmark.container_backend,
+        )
+
+        obs, _info = task.reset()
+        env_id = str(uuid.uuid4())
+
+        self._sessions[env_id] = task
+        self._last_obs[env_id] = obs
+
+        return SeedSessionResponse(
+            env_id=env_id,
+            observation=obs.to_llm_messages(),
+            tools=[schema.as_dict() for schema in task.action_set],
+        )
+
+    def step(self, body: StepRequest) -> StepResponse:
+        task = self._sessions.get(body.env_id)
+        if task is None:
+            raise HTTPException(status_code=404, detail=f"Unknown env_id: {body.env_id}")
+
+        action = Action.from_openai_tool_call(body.action)
+        env_output = task.step(action)
+
+        self._last_obs[body.env_id] = env_output.obs
+
+        return StepResponse(
+            observation=env_output.obs.to_llm_messages(),
+            reward=env_output.reward,
+            done=env_output.done,
+        )
+
+    def verify(self, body: VerifyRequest) -> VerifyResponse:
+        task = self._sessions.get(body.env_id)
+        if task is None:
+            raise HTTPException(status_code=404, detail=f"Unknown env_id: {body.env_id}")
+
+        obs = self._last_obs.get(body.env_id)
+        if obs is None:
+            raise HTTPException(status_code=400, detail=f"No observation recorded for env_id: {body.env_id}")
+
+        reward, info = task.evaluate(obs)
+        return VerifyResponse(reward=reward, reward_info=info)
+
+    def close_session(self, body: CloseRequest) -> dict:
+        task = self._sessions.pop(body.env_id, None)
+        self._last_obs.pop(body.env_id, None)
+        if task is not None:
+            task.close()
+        return {"status": "ok"}
+
+    # -- App factory ---------------------------------------------------------
+
+    def make_app(self) -> FastAPI:
+        """Build a FastAPI application wired to this server's endpoints."""
+        server = self
+
+        @asynccontextmanager
+        async def lifespan(app: FastAPI):
+            yield
+            server._close_all()
+
+        app = FastAPI(
+            title=f"CUBE Resources Server — {self.benchmark.name}",
+            lifespan=lifespan,
+        )
+        atexit.register(self._close_all)
+
+        app.post("/seed_session", response_model=SeedSessionResponse)(self.seed_session)
+        app.post("/step", response_model=StepResponse)(self.step)
+        app.post("/verify", response_model=VerifyResponse)(self.verify)
+        app.post("/close")(self.close_session)
+
+        # Health check
+        @app.get("/health")
+        def health():
+            return {"status": "ok", "benchmark": self.benchmark.name, "num_tasks": len(self._task_configs)}
+
+        return app
+
+    def run(self, host: str = "0.0.0.0", port: int = 8080) -> None:
+        """Start the server (blocking)."""
+        app = self.make_app()
+        uvicorn.run(app, host=host, port=port)

--- a/src/cube/integrations/nemogym.py
+++ b/src/cube/integrations/nemogym.py
@@ -3,13 +3,14 @@ NeMo Gym integration for CUBE.
 
 Provides a CubeResourcesServer that wraps any CUBE Benchmark as an HTTP server
 compatible with NeMo Gym's resource server protocol. NeMo Gym's CubeAgent calls
-these endpoints over HTTP — no NeMo Gym Python dependency required.
+these endpoints over HTTP -- no NeMo Gym Python dependency required.
 
 Endpoints:
-    POST /seed_session  — pick a task, reset it, return initial observation + tools
-    POST /step          — execute an action, return next observation + reward + done
-    POST /verify        — evaluate the current task state, return reward
-    POST /close         — close a task and free resources
+    POST /seed_session  -- pick a task, reset it, return initial observation + tools
+    POST /step          -- execute an action, return next observation + reward + done
+    POST /verify        -- evaluate the current task state, return reward
+    POST /close         -- close a task and free resources
+    GET  /tasks         -- list available tasks and their indices
 
 Usage:
     from cube.integrations.nemogym import CubeResourcesServer
@@ -21,7 +22,6 @@ Or programmatically:
     app = server.make_app()  # returns a FastAPI instance
 """
 
-import atexit
 import logging
 import uuid
 from contextlib import asynccontextmanager
@@ -61,6 +61,7 @@ class StepResponse(BaseModel):
     observation: list[dict]
     reward: float
     done: bool
+    error: str | None = None
 
 
 class VerifyRequest(BaseModel):
@@ -76,6 +77,11 @@ class CloseRequest(BaseModel):
     env_id: str
 
 
+class TaskListItem(BaseModel):
+    idx: int
+    task_id: str
+
+
 # ---------------------------------------------------------------------------
 # Server
 # ---------------------------------------------------------------------------
@@ -84,7 +90,7 @@ class CloseRequest(BaseModel):
 class CubeResourcesServer:
     """Wraps a CUBE Benchmark as a NeMo Gym-compatible HTTP resource server.
 
-    Manages multiple concurrent sessions (env_id → Task), each corresponding
+    Manages multiple concurrent sessions (env_id -> Task), each corresponding
     to one episode. The benchmark must be set up before constructing this server.
 
     Args:
@@ -95,7 +101,7 @@ class CubeResourcesServer:
         self.benchmark = benchmark
         self._task_configs: list[TaskConfig] = list(benchmark.get_task_configs())
         self._sessions: dict[str, Task] = {}
-        self._last_obs: dict[str, object] = {}  # env_id → last Observation for verify
+        self._last_obs: dict[str, object] = {}  # env_id -> last Observation for verify
 
         if not self._task_configs:
             raise ValueError(f"Benchmark '{benchmark.name}' has no task configs")
@@ -117,6 +123,9 @@ class CubeResourcesServer:
 
     # -- Endpoints -----------------------------------------------------------
 
+    def list_tasks(self) -> list[TaskListItem]:
+        return [TaskListItem(idx=i, task_id=tc.task_id) for i, tc in enumerate(self._task_configs)]
+
     def seed_session(self, body: SeedSessionRequest) -> SeedSessionResponse:
         if body.task_idx < 0 or body.task_idx >= len(self._task_configs):
             raise HTTPException(
@@ -128,10 +137,13 @@ class CubeResourcesServer:
             runtime_context=self.benchmark._runtime_context,
             container_backend=self.benchmark.container_backend,
         )
+        try:
+            obs, _info = task.reset()
+        except Exception:
+            task.close()
+            raise
 
-        obs, _info = task.reset()
         env_id = str(uuid.uuid4())
-
         self._sessions[env_id] = task
         self._last_obs[env_id] = obs
 
@@ -149,12 +161,19 @@ class CubeResourcesServer:
         action = Action.from_openai_tool_call(body.action)
         env_output = task.step(action)
 
+        # Note: env_output.obs is already post-processed by task.obs_postprocess().
+        # task.step() calls evaluate() on the raw obs (before postprocessing), so
+        # calling task.evaluate(env_output.obs) in /verify is slightly inconsistent
+        # for tasks whose obs_postprocess mutates the observation. In practice most
+        # evaluate() implementations inspect the environment state rather than the
+        # obs argument, so this is rarely observable.
         self._last_obs[body.env_id] = env_output.obs
 
         return StepResponse(
             observation=env_output.obs.to_llm_messages(),
             reward=env_output.reward,
             done=env_output.done,
+            error=str(env_output.error) if env_output.error else None,
         )
 
     def verify(self, body: VerifyRequest) -> VerifyResponse:
@@ -188,17 +207,16 @@ class CubeResourcesServer:
             server._close_all()
 
         app = FastAPI(
-            title=f"CUBE Resources Server — {self.benchmark.name}",
+            title=f"CUBE Resources Server -- {self.benchmark.name}",
             lifespan=lifespan,
         )
-        atexit.register(self._close_all)
 
+        app.get("/tasks", response_model=list[TaskListItem])(self.list_tasks)
         app.post("/seed_session", response_model=SeedSessionResponse)(self.seed_session)
         app.post("/step", response_model=StepResponse)(self.step)
         app.post("/verify", response_model=VerifyResponse)(self.verify)
         app.post("/close")(self.close_session)
 
-        # Health check
         @app.get("/health")
         def health():
             return {"status": "ok", "benchmark": self.benchmark.name, "num_tasks": len(self._task_configs)}

--- a/src/cube/integrations/nemogym.py
+++ b/src/cube/integrations/nemogym.py
@@ -91,14 +91,16 @@ class CubeResourcesServer:
     """Wraps a CUBE Benchmark as a NeMo Gym-compatible HTTP resource server.
 
     Manages multiple concurrent sessions (env_id -> Task), each corresponding
-    to one episode. The benchmark must be set up before constructing this server.
+    to one episode. Calls benchmark.install() and benchmark.setup() automatically.
 
     Args:
-        benchmark: A CUBE Benchmark instance (already set up via benchmark.setup()).
+        benchmark: A CUBE Benchmark instance (not yet set up).
     """
 
     def __init__(self, benchmark: Benchmark) -> None:
         self.benchmark = benchmark
+        benchmark.install()
+        benchmark.setup()
         self._task_configs: list[TaskConfig] = list(benchmark.get_task_configs())
         self._sessions: dict[str, Task] = {}
         self._last_obs: dict[str, object] = {}  # env_id -> last Observation for verify
@@ -182,9 +184,6 @@ class CubeResourcesServer:
             raise HTTPException(status_code=404, detail=f"Unknown env_id: {body.env_id}")
 
         obs = self._last_obs.get(body.env_id)
-        if obs is None:
-            raise HTTPException(status_code=400, detail=f"No observation recorded for env_id: {body.env_id}")
-
         reward, info = task.evaluate(obs)
         return VerifyResponse(reward=reward, reward_info=info)
 

--- a/src/cube/integrations/nemogym.py
+++ b/src/cube/integrations/nemogym.py
@@ -119,7 +119,9 @@ class CubeResourcesServer:
 
     def seed_session(self, body: SeedSessionRequest) -> SeedSessionResponse:
         if body.task_idx < 0 or body.task_idx >= len(self._task_configs):
-            raise HTTPException(status_code=400, detail=f"task_idx {body.task_idx} out of range [0, {len(self._task_configs)})")
+            raise HTTPException(
+                status_code=400, detail=f"task_idx {body.task_idx} out of range [0, {len(self._task_configs)})"
+            )
 
         task_config = self._task_configs[body.task_idx]
         task = task_config.make(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -95,6 +95,12 @@ def test_action_from_openai_tool_call_call_id():
     assert action.id == "resp_call_1"
 
 
+def test_action_from_openai_tool_call_null_arguments():
+    """Explicit null arguments falls back to empty dict."""
+    action = Action.from_openai_tool_call({"id": "call_4", "name": "stop", "arguments": None})
+    assert action.arguments == {}
+
+
 # --- Content.from_data dispatch ---
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -71,11 +71,13 @@ def test_action_from_openai_tool_call_flat_format():
 
 def test_action_from_openai_tool_call_chat_completions_format():
     """Parse nested Chat Completions format."""
-    action = Action.from_openai_tool_call({
-        "id": "call_2",
-        "type": "function",
-        "function": {"name": "type_text", "arguments": '{"text": "hello"}'},
-    })
+    action = Action.from_openai_tool_call(
+        {
+            "id": "call_2",
+            "type": "function",
+            "function": {"name": "type_text", "arguments": '{"text": "hello"}'},
+        }
+    )
     assert action.id == "call_2"
     assert action.name == "type_text"
     assert action.arguments == {"text": "hello"}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -58,6 +58,41 @@ def test_action_schema_as_dict_llm_format():
     }
 
 
+# --- Action.from_openai_tool_call ---
+
+
+def test_action_from_openai_tool_call_flat_format():
+    """Parse flat/Responses API format."""
+    action = Action.from_openai_tool_call({"id": "call_1", "name": "click", "arguments": '{"x": 10, "y": 20}'})
+    assert action.id == "call_1"
+    assert action.name == "click"
+    assert action.arguments == {"x": 10, "y": 20}
+
+
+def test_action_from_openai_tool_call_chat_completions_format():
+    """Parse nested Chat Completions format."""
+    action = Action.from_openai_tool_call({
+        "id": "call_2",
+        "type": "function",
+        "function": {"name": "type_text", "arguments": '{"text": "hello"}'},
+    })
+    assert action.id == "call_2"
+    assert action.name == "type_text"
+    assert action.arguments == {"text": "hello"}
+
+
+def test_action_from_openai_tool_call_dict_arguments():
+    """Arguments can be a dict (already parsed) instead of a JSON string."""
+    action = Action.from_openai_tool_call({"id": "call_3", "name": "greet", "arguments": {"name": "World"}})
+    assert action.arguments == {"name": "World"}
+
+
+def test_action_from_openai_tool_call_call_id():
+    """Responses API uses call_id instead of id."""
+    action = Action.from_openai_tool_call({"call_id": "resp_call_1", "name": "click", "arguments": "{}"})
+    assert action.id == "resp_call_1"
+
+
 # --- Content.from_data dispatch ---
 
 

--- a/tests/test_nemogym.py
+++ b/tests/test_nemogym.py
@@ -46,9 +46,7 @@ class _TaskConfig(TaskConfig):
 
 
 class _Benchmark(Benchmark):
-    benchmark_metadata = BenchmarkMetadata(
-        name="test-bench", version="0.1.0", description="test", num_tasks=2
-    )
+    benchmark_metadata = BenchmarkMetadata(name="test-bench", version="0.1.0", description="test", num_tasks=2)
     task_metadata = {
         "t1": TaskMetadata(id="t1"),
         "t2": TaskMetadata(id="t2"),
@@ -114,10 +112,13 @@ def test_step():
         seed = c.post("/seed_session", json={"task_idx": 0}).json()
         env_id = seed["env_id"]
 
-        r = c.post("/step", json={
-            "env_id": env_id,
-            "action": {"id": "call_1", "name": "greet", "arguments": "{\"name\": \"World\"}"},
-        })
+        r = c.post(
+            "/step",
+            json={
+                "env_id": env_id,
+                "action": {"id": "call_1", "name": "greet", "arguments": '{"name": "World"}'},
+            },
+        )
         assert r.status_code == 200
         data = r.json()
         assert "observation" in data
@@ -130,14 +131,17 @@ def test_step_chat_completions_format():
     with _make_client() as c:
         seed = c.post("/seed_session", json={"task_idx": 0}).json()
 
-        r = c.post("/step", json={
-            "env_id": seed["env_id"],
-            "action": {
-                "id": "call_2",
-                "type": "function",
-                "function": {"name": "greet", "arguments": "{\"name\": \"World\"}"},
+        r = c.post(
+            "/step",
+            json={
+                "env_id": seed["env_id"],
+                "action": {
+                    "id": "call_2",
+                    "type": "function",
+                    "function": {"name": "greet", "arguments": '{"name": "World"}'},
+                },
             },
-        })
+        )
         assert r.status_code == 200
 
 
@@ -161,10 +165,13 @@ def test_close():
         assert r.status_code == 200
 
         # Subsequent step should return 404
-        r = c.post("/step", json={
-            "env_id": env_id,
-            "action": {"id": "call_1", "name": "greet", "arguments": "{}"},
-        })
+        r = c.post(
+            "/step",
+            json={
+                "env_id": env_id,
+                "action": {"id": "call_1", "name": "greet", "arguments": "{}"},
+            },
+        )
         assert r.status_code == 404
 
 
@@ -178,10 +185,13 @@ def test_full_episode():
         assert len(seed["tools"]) > 0
 
         # Step
-        step = c.post("/step", json={
-            "env_id": env_id,
-            "action": {"id": "call_1", "name": "greet", "arguments": "{\"name\": \"CUBE\"}"},
-        }).json()
+        step = c.post(
+            "/step",
+            json={
+                "env_id": env_id,
+                "action": {"id": "call_1", "name": "greet", "arguments": '{"name": "CUBE"}'},
+            },
+        ).json()
         assert isinstance(step["reward"], (int, float))
 
         # Verify
@@ -201,13 +211,19 @@ def test_multiple_concurrent_sessions():
         assert s1["env_id"] != s2["env_id"]
 
         # Both can step independently
-        r1 = c.post("/step", json={
-            "env_id": s1["env_id"],
-            "action": {"id": "c1", "name": "greet", "arguments": "{\"name\": \"A\"}"},
-        })
-        r2 = c.post("/step", json={
-            "env_id": s2["env_id"],
-            "action": {"id": "c2", "name": "greet", "arguments": "{\"name\": \"B\"}"},
-        })
+        r1 = c.post(
+            "/step",
+            json={
+                "env_id": s1["env_id"],
+                "action": {"id": "c1", "name": "greet", "arguments": '{"name": "A"}'},
+            },
+        )
+        r2 = c.post(
+            "/step",
+            json={
+                "env_id": s2["env_id"],
+                "action": {"id": "c2", "name": "greet", "arguments": '{"name": "B"}'},
+            },
+        )
         assert r1.status_code == 200
         assert r2.status_code == 200

--- a/tests/test_nemogym.py
+++ b/tests/test_nemogym.py
@@ -1,0 +1,213 @@
+"""Tests for cube.integrations.nemogym — CubeResourcesServer."""
+
+from fastapi.testclient import TestClient
+
+from cube.benchmark import Benchmark, BenchmarkMetadata, RuntimeContext
+from cube.container import Container, ContainerBackend
+from cube.core import Observation
+from cube.integrations.nemogym import CubeResourcesServer
+from cube.task import Task, TaskConfig, TaskMetadata
+from cube.tool import Tool, ToolConfig, tool_action
+
+# ---------------------------------------------------------------------------
+# Minimal benchmark fixtures (same pattern as test_benchmark_server.py)
+# ---------------------------------------------------------------------------
+
+
+class _Tool(Tool):
+    @tool_action
+    def greet(self, name: str) -> str:
+        """Say hello."""
+        return f"Hello, {name}!"
+
+
+class _ToolConfig(ToolConfig):
+    def make(self, container: Container | None = None) -> Tool:
+        return _Tool()
+
+
+class _Task(Task):
+    def reset(self):
+        self.tool.reset()
+        return Observation.from_text("Welcome! What would you like to do?"), {}
+
+    def evaluate(self, obs: Observation):
+        return 0.5, {"score": 0.5}
+
+
+class _TaskConfig(TaskConfig):
+    def make(self, runtime_context: RuntimeContext | None = None, container_backend: ContainerBackend | None = None):
+        return _Task(
+            metadata=TaskMetadata(id=self.task_id),
+            tool_config=self.tool_config or _ToolConfig(),
+            runtime_context=runtime_context,
+            container_backend=container_backend,
+        )
+
+
+class _Benchmark(Benchmark):
+    benchmark_metadata = BenchmarkMetadata(
+        name="test-bench", version="0.1.0", description="test", num_tasks=2
+    )
+    task_metadata = {
+        "t1": TaskMetadata(id="t1"),
+        "t2": TaskMetadata(id="t2"),
+    }
+    task_config_class = _TaskConfig
+
+    def _setup(self):
+        pass
+
+    def close(self):
+        pass
+
+
+def _make_server() -> CubeResourcesServer:
+    bench = _Benchmark()
+    bench.setup()
+    return CubeResourcesServer(benchmark=bench)
+
+
+def _make_client() -> TestClient:
+    server = _make_server()
+    return TestClient(server.make_app())
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_health():
+    with _make_client() as c:
+        r = c.get("/health")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["benchmark"] == "test-bench"
+        assert data["num_tasks"] == 2
+
+
+def test_seed_session_returns_obs_and_tools():
+    with _make_client() as c:
+        r = c.post("/seed_session", json={"task_idx": 0})
+        assert r.status_code == 200
+        data = r.json()
+        assert "env_id" in data
+        assert isinstance(data["observation"], list)
+        assert len(data["observation"]) > 0
+        assert isinstance(data["tools"], list)
+        assert len(data["tools"]) > 0
+        # Tools should be OpenAI function format
+        tool = data["tools"][0]
+        assert tool["type"] == "function"
+        assert "function" in tool
+
+
+def test_seed_session_invalid_idx():
+    with _make_client() as c:
+        r = c.post("/seed_session", json={"task_idx": 999})
+        assert r.status_code == 400
+
+
+def test_step():
+    with _make_client() as c:
+        seed = c.post("/seed_session", json={"task_idx": 0}).json()
+        env_id = seed["env_id"]
+
+        r = c.post("/step", json={
+            "env_id": env_id,
+            "action": {"id": "call_1", "name": "greet", "arguments": "{\"name\": \"World\"}"},
+        })
+        assert r.status_code == 200
+        data = r.json()
+        assert "observation" in data
+        assert "reward" in data
+        assert "done" in data
+
+
+def test_step_chat_completions_format():
+    """Step accepts Chat Completions tool call format too."""
+    with _make_client() as c:
+        seed = c.post("/seed_session", json={"task_idx": 0}).json()
+
+        r = c.post("/step", json={
+            "env_id": seed["env_id"],
+            "action": {
+                "id": "call_2",
+                "type": "function",
+                "function": {"name": "greet", "arguments": "{\"name\": \"World\"}"},
+            },
+        })
+        assert r.status_code == 200
+
+
+def test_verify():
+    with _make_client() as c:
+        seed = c.post("/seed_session", json={"task_idx": 0}).json()
+        env_id = seed["env_id"]
+
+        r = c.post("/verify", json={"env_id": env_id})
+        assert r.status_code == 200
+        data = r.json()
+        assert data["reward"] == 0.5
+
+
+def test_close():
+    with _make_client() as c:
+        seed = c.post("/seed_session", json={"task_idx": 0}).json()
+        env_id = seed["env_id"]
+
+        r = c.post("/close", json={"env_id": env_id})
+        assert r.status_code == 200
+
+        # Subsequent step should return 404
+        r = c.post("/step", json={
+            "env_id": env_id,
+            "action": {"id": "call_1", "name": "greet", "arguments": "{}"},
+        })
+        assert r.status_code == 404
+
+
+def test_full_episode():
+    """Simulate a full episode: seed → step × N → verify → close."""
+    with _make_client() as c:
+        # Seed
+        seed = c.post("/seed_session", json={"task_idx": 1}).json()
+        env_id = seed["env_id"]
+        assert len(seed["observation"]) > 0
+        assert len(seed["tools"]) > 0
+
+        # Step
+        step = c.post("/step", json={
+            "env_id": env_id,
+            "action": {"id": "call_1", "name": "greet", "arguments": "{\"name\": \"CUBE\"}"},
+        }).json()
+        assert isinstance(step["reward"], (int, float))
+
+        # Verify
+        verify = c.post("/verify", json={"env_id": env_id}).json()
+        assert verify["reward"] == 0.5
+        assert "score" in verify["reward_info"]
+
+        # Close
+        close = c.post("/close", json={"env_id": env_id}).json()
+        assert close["status"] == "ok"
+
+
+def test_multiple_concurrent_sessions():
+    with _make_client() as c:
+        s1 = c.post("/seed_session", json={"task_idx": 0}).json()
+        s2 = c.post("/seed_session", json={"task_idx": 1}).json()
+        assert s1["env_id"] != s2["env_id"]
+
+        # Both can step independently
+        r1 = c.post("/step", json={
+            "env_id": s1["env_id"],
+            "action": {"id": "c1", "name": "greet", "arguments": "{\"name\": \"A\"}"},
+        })
+        r2 = c.post("/step", json={
+            "env_id": s2["env_id"],
+            "action": {"id": "c2", "name": "greet", "arguments": "{\"name\": \"B\"}"},
+        })
+        assert r1.status_code == 200
+        assert r2.status_code == 200

--- a/tests/test_nemogym.py
+++ b/tests/test_nemogym.py
@@ -85,6 +85,16 @@ def test_health():
         assert data["num_tasks"] == 2
 
 
+def test_list_tasks():
+    with _make_client() as c:
+        r = c.get("/tasks")
+        assert r.status_code == 200
+        tasks = r.json()
+        assert len(tasks) == 2
+        assert tasks[0] == {"idx": 0, "task_id": "t1"}
+        assert tasks[1] == {"idx": 1, "task_id": "t2"}
+
+
 def test_seed_session_returns_obs_and_tools():
     with _make_client() as c:
         r = c.post("/seed_session", json={"task_idx": 0})

--- a/tests/test_nemogym.py
+++ b/tests/test_nemogym.py
@@ -61,9 +61,7 @@ class _Benchmark(Benchmark):
 
 
 def _make_server() -> CubeResourcesServer:
-    bench = _Benchmark()
-    bench.setup()
-    return CubeResourcesServer(benchmark=bench)
+    return CubeResourcesServer(benchmark=_Benchmark())
 
 
 def _make_client() -> TestClient:


### PR DESCRIPTION
## Summary

- Adds `CubeResourcesServer` in `cube.integrations.nemogym` that wraps any CUBE `Benchmark` as an HTTP server compatible with NeMo Gym's resource server protocol (`/seed_session`, `/step`, `/verify`, `/close`)
- Adds `Action.from_openai_tool_call()` to parse both Chat Completions and Responses API tool call formats into CUBE `Action` objects
- No NeMo Gym Python dependency required -- pure HTTP contract

This lets NeMo Gym's `CubeAgent` orchestrate multi-step rollouts against any CUBE benchmark without importing CUBE internals. Related: NVIDIA-NeMo/Gym#1006

## Test plan

- [x] 4 unit tests for `Action.from_openai_tool_call()` (flat, nested, dict args, call_id)
- [x] 9 integration tests for `CubeResourcesServer` (health, seed, step, verify, close, full episode, concurrent sessions, error cases)
- [x] All 77 existing tests still pass
- [x] Ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)