### PR TITLE
feat(chat-tool): add report_infeasible action

### DIFF
--- a/cube-tools/cube-chat-tool/src/cube_chat_tool/chat_tool.py
+++ b/cube-tools/cube-chat-tool/src/cube_chat_tool/chat_tool.py
@@ -2,7 +2,7 @@
 
 Provides ``ChatToolConfig`` and ``ChatTool``, a concrete implementation of the
 ``Tool`` base class that wraps a ``ChatSession`` and exposes ``send_message``
-as the single agent-facing action.
+and ``report_infeasible`` as the agent-facing actions.
 """
 
 import datetime
@@ -123,4 +123,20 @@ class ChatTool(Tool):
             Message content to send.
         """
         self._session.send_message(text)
+        return self.chat_obs()
+
+    @tool_action
+    def report_infeasible(self, reason: str) -> str:
+        """Report that the current task instructions are infeasible.
+
+        Use this action when the task cannot be completed as described,
+        for example due to missing information, contradictory instructions,
+        or unavailable resources.
+
+        Parameters
+        ----------
+        reason : str
+            Explanation of why the task is infeasible.
+        """
+        self._session.add_message("infeasible", reason)
         return self.chat_obs()

--- a/cube-tools/cube-chat-tool/tests/test_chat_tool.py
+++ b/cube-tools/cube-chat-tool/tests/test_chat_tool.py
@@ -26,10 +26,10 @@ def test_config_serialization_round_trip() -> None:
     assert type(restored.chat) is BasicChatConfig
 
 
-def test_action_set_contains_only_send_message() -> None:
+def test_action_set_contains_expected_actions() -> None:
     tool, _ = _make_tool()
     names = {a.name for a in tool.action_set}
-    assert names == {"send_message"}
+    assert names == {"send_message", "report_infeasible"}
 
 
 def test_execute_action_dispatches_send_message() -> None:
@@ -50,6 +50,26 @@ def test_execute_action_appends_chat_obs() -> None:
     # The observation should contain a chat_history content
     names = {c.name for c in result.contents if hasattr(c, "name")}
     assert "chat_history" in names
+
+
+def test_execute_action_dispatches_report_infeasible() -> None:
+    tool, mock_session = _make_tool()
+    mock_session.messages = [{"role": "infeasible", "timestamp": 0.0, "message": "no login page"}]
+    action = Action(name="report_infeasible", arguments={"reason": "no login page"})
+    result = tool.execute_action(action)
+    mock_session.add_message.assert_called_once_with("infeasible", "no login page")
+    assert isinstance(result, Observation)
+
+
+def test_report_infeasible_returns_observation_with_chat_history() -> None:
+    tool, mock_session = _make_tool()
+    mock_session.messages = [
+        {"role": "infeasible", "timestamp": 0.0, "message": "impossible task"},
+    ]
+    action = Action(name="report_infeasible", arguments={"reason": "impossible task"})
+    result = tool.execute_action(action)
+    assert isinstance(result, Observation)
+    assert "infeasible: impossible task" in result.contents[0].data
 
 
 def test_execute_action_returns_step_error_on_session_error() -> None:


### PR DESCRIPTION
## Summary

- Add `report_infeasible` action to `ChatTool`, following the same pattern as the existing `send_message` action
- The action posts a message with role `"infeasible"` to the chat session and returns the updated chat history
- This separates communication actions from browser-only actions, aligning with BrowserGym's action model where `send_msg_to_user` and `report_infeasible` are distinct from browser navigation/interaction actions

## Details

The `ChatSession` protocol already supports `role="infeasible"` via `ChatRole = Literal["user", "assistant", "info", "infeasible"]`, so no changes to the session layer were needed. The new action uses `self._session.add_message("infeasible", reason)` rather than `send_message()` since it is a one-way report, not a conversational message that should unblock `wait_for_user_message()`.

## Test plan

- [x] New test: `test_execute_action_dispatches_report_infeasible` -- verifies `add_message` is called with `("infeasible", reason)`
- [x] New test: `test_report_infeasible_returns_observation_with_chat_history` -- verifies the observation contains the formatted chat history
- [x] Updated test: `test_action_set_contains_expected_actions` -- verifies both `send_message` and `report_infeasible` are in the action set
- [x] All pre-existing tests remain unchanged and pass
- [x] `ruff check` and `ruff format` pass with no issues

Generated with [Claude Code](https://claude.com/claude-code)