### PR TITLE
feat(infra): add Docker container support to LocalInfraConfig

### DIFF
--- a/src/cube/infra_local.py
+++ b/src/cube/infra_local.py
@@ -5,15 +5,21 @@ No cloud credentials required. This is the default infra and the reference
 implementation of the InfraConfig interface.
 
 Supported resource types:
-    VMResourceConfig  — boots a QEMU VM from a local qcow2 image.
-    (DockerImageConfig / DockerServiceConfig — deferred to a later phase.)
+    VMResourceConfig    — boots a QEMU VM from a local qcow2 image.
+    DockerImageConfig   — runs a Docker container from a pulled image.
 
 Image storage: CUBE_LOCAL_IMAGE_DIR env var, defaults to ~/.cube/images/.
-Active resource tracking: ~/.cube/active.json (PID + port per run_id entry).
+Active resource tracking: ~/.cube/active.json.
+  Each entry has a "type" field: "vm" (QEMU) or "docker".
+  VM entries carry: pid, overlay_path, port, endpoint, created_at, expires_at.
+  Docker entries carry: container_name, port_map, endpoint, created_at, expires_at.
 
-System requirements:
+System requirements (VM):
     qemu-img             — image conversion (brew install qemu / apt install qemu-utils)
     qemu-system-x86_64  — VM execution  (brew install qemu / apt install qemu-system-x86)
+
+System requirements (Docker):
+    docker               — container runtime (docker.com/get-started)
 """
 
 from __future__ import annotations
@@ -31,6 +37,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 from cube.resource import (
+    DockerImageConfig,
     InfraConfig,
     ResourceConfig,
     ResourceHandle,
@@ -73,7 +80,7 @@ def _deregister_active(entry_id: str) -> None:
     _save_active(data)
 
 
-# ── Helpers ───────────────────────────────────────────────────────────────────
+# ── VM Helpers ───────────────────────────────────────────────────────────────────
 
 
 def _free_port(start: int = 15000, count: int = 200) -> int:
@@ -191,6 +198,46 @@ def _create_overlay(base_image: Path, run_id: str) -> Path:
     return overlay
 
 
+# ── Docker Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _stop_docker_container(container_name: str) -> None:
+    """Stop and remove a Docker container by name. Idempotent."""
+    for cmd in (["docker", "stop", container_name], ["docker", "rm", container_name]):
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0 and "No such container" not in result.stderr:
+            logger.warning(f"{' '.join(cmd)} failed: {result.stderr.strip()}")
+    logger.info(f"Stopped and removed Docker container {container_name}")
+
+
+def _wait_for_docker_http(url: str, timeout: int = 60) -> None:
+    """Poll url until HTTP status < 500 or timeout expires.
+
+    Accepts any 1xx–4xx response as "container is up" — only 5xx and
+    connection errors are treated as not-yet-ready.
+    """
+    import urllib.error
+    import urllib.request
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(urllib.request.Request(url), timeout=5) as resp:
+                if resp.status < 500:
+                    logger.info(f"Container ready at {url} (status {resp.status})")
+                    return
+        except urllib.error.HTTPError as e:
+            if e.code < 500:
+                logger.info(f"Container ready at {url} (status {e.code}: {e.reason})")
+                return
+        except Exception:
+            pass
+        remaining = int(deadline - time.time())
+        logger.debug(f"Waiting for container… ({remaining}s left)")
+        time.sleep(2)
+    raise TimeoutError(f"Container not ready after {timeout}s at {url}")
+
+
 # ── LocalResourceHandle ───────────────────────────────────────────────────────
 
 
@@ -221,6 +268,22 @@ class LocalResourceHandle(ResourceHandle):
             logger.debug("Removed overlay %s", self._overlay_path)
             self._overlay_path = None
 
+        _deregister_active(self._entry_id)
+
+
+@dataclass
+class LocalDockerResourceHandle(ResourceHandle):
+    """ResourceHandle for a locally-running Docker container."""
+
+    _entry_id: str = field(default="", repr=False)
+    _container_name: str = field(default="", repr=False)
+    port_map: dict[int, int] = field(default_factory=dict, repr=False)
+    """Maps container port → allocated host port."""
+
+    def close(self) -> None:
+        """Stop and remove the Docker container."""
+        if self._container_name:
+            _stop_docker_container(self._container_name)
         _deregister_active(self._entry_id)
 
 
@@ -272,12 +335,22 @@ class LocalInfraConfig(InfraConfig):
         return caps
 
     def provision(self, resource: ResourceConfig) -> None:
-        """Download and convert the image locally, then register it.
+        """Download/prepare the image locally, then register it.
 
         For VMResourceConfig: downloads the qcow2 (or zip of qcow2) from
         source_url and stores it at image_dir/{resource.name}.qcow2.
         Idempotent — skips download/convert if the image already exists.
+
+        For DockerImageConfig: pulls the image from the registry.
+        Idempotent — docker pull is a no-op when the image is already present.
         """
+        if isinstance(resource, DockerImageConfig):
+            logger.info(f"Pulling Docker image {resource.image!r}...")
+            subprocess.run(["docker", "pull", resource.image], check=True)
+            self.register(resource, {"image": resource.image})
+            logger.info(f"Pulled Docker image {resource.image!r}")
+            return
+
         if not isinstance(resource, VMResourceConfig):
             raise UnsupportedResourceType(resource, self)
 
@@ -305,7 +378,26 @@ class LocalInfraConfig(InfraConfig):
 
         self.register(resource, {"image_path": str(dest)})
 
-    def launch(self, resource: ResourceConfig) -> LocalResourceHandle:
+    def launch(self, resource: ResourceConfig) -> ResourceHandle:
+        """Instantiate a resource locally and return a live handle.
+
+        For VMResourceConfig: boots a QEMU VM with a copy-on-write overlay.
+        For DockerImageConfig: runs the container with dynamically-allocated host ports.
+
+        Reads resource_info from the ProvisionStore. Raises ResourceNotReadyError
+        if no entry is found (i.e. provision() or register() was never called).
+
+        run_id is generated internally; TTL resolves as
+        self.default_ttl_seconds ?? resource.default_ttl_seconds.
+        """
+        if isinstance(resource, DockerImageConfig):
+            return self._launch_docker(resource)
+        elif isinstance(resource, VMResourceConfig):
+            return self._launch_vm(resource)
+        else:
+            raise UnsupportedResourceType(resource, self)
+
+    def _launch_vm(self, resource: VMResourceConfig) -> LocalResourceHandle:
         """Boot a QEMU VM and return a handle with the guest agent endpoint.
 
         Reads image_path from the ProvisionStore. Raises ResourceNotReadyError
@@ -315,9 +407,6 @@ class LocalInfraConfig(InfraConfig):
         never modified. run_id is generated internally; TTL resolves as
         self.default_ttl_seconds ?? resource.default_ttl_seconds.
         """
-        if not isinstance(resource, VMResourceConfig):
-            raise UnsupportedResourceType(resource, self)
-
         from cube.provision_store import ProvisionStore
 
         resource_info = ProvisionStore().get(resource, self)
@@ -355,7 +444,7 @@ class LocalInfraConfig(InfraConfig):
         if self.enable_kvm and Path("/dev/kvm").exists():
             cmd += ["-enable-kvm", "-cpu", "host"]
 
-        logger.info("Starting QEMU VM for %r (run=%s, port=%d)", resource.name, run_id[:8], port)
+        logger.info(f"Starting QEMU VM for {resource.name!r} (run={run_id[:8]}, port={port})")
         proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
         endpoint = f"http://127.0.0.1:{port}"
@@ -365,10 +454,10 @@ class LocalInfraConfig(InfraConfig):
         created_at = datetime.utcnow()
         expires_at = created_at + timedelta(seconds=effective_ttl) if effective_ttl else None
 
-        # Persist to active.json for cross-process cleanup.
         _register_active(
             entry_id,
             {
+                "type": "vm",
                 "run_id": run_id,
                 "resource_name": resource.name,
                 "infra_fingerprint": self.fingerprint(),
@@ -401,15 +490,95 @@ class LocalInfraConfig(InfraConfig):
             _overlay_path=overlay,
         )
 
-    def list_active(self, run_id: str | None = None) -> list[LocalResourceHandle]:
-        """Return handles for all active local VMs, optionally filtered by run_id.
+    def _launch_docker(self, resource: DockerImageConfig) -> LocalDockerResourceHandle:
+        """Run a Docker container and return a handle with the primary endpoint.
 
-        Reconstructed from ~/.cube/active.json — processes that have died are
-        cleaned up and excluded from the result.
+        Allocates a free host port for each container port declared in resource.ports.
+        The endpoint is http://127.0.0.1:{first_host_port}. A health check is
+        performed on {endpoint}{resource.health_check_path} unless health_check_path
+        is empty. On failure the container is removed and the error is re-raised.
         """
+        from cube.provision_store import ProvisionStore
 
+        resource_info = ProvisionStore().get(resource, self)
+        if resource_info is None:
+            raise ResourceNotReadyError(resource, self)
+
+        run_id = str(uuid.uuid4())
+        container_name = f"cube-{resource.name}-{run_id[:8]}"
+        entry_id = f"cube-{run_id[:8]}-docker-{uuid.uuid4().hex[:6]}"
+
+        # Allocate one free host port per declared container port.
+        port_map: dict[int, int] = {}
+        if resource.ports:
+            for container_port in resource.ports:
+                port_map[container_port] = _free_port()
+
+        cmd = ["docker", "run", "-d", "--name", container_name]
+        for container_port, host_port in port_map.items():
+            cmd += ["-p", f"127.0.0.1:{host_port}:{container_port}"]
+        if resource.gpu:
+            cmd += ["--gpus", "all"]
+        cmd.append(resource_info["image"])
+
+        logger.info(f"Starting Docker container {container_name!r} (run={run_id[:8]})")
+        subprocess.run(cmd, check=True, capture_output=True)
+
+        endpoint: str | None = None
+        if port_map:
+            first_host_port = next(iter(port_map.values()))
+            endpoint = f"http://127.0.0.1:{first_host_port}"
+
+        effective_ttl = (
+            self.default_ttl_seconds if self.default_ttl_seconds is not None else resource.default_ttl_seconds
+        )
+        created_at = datetime.utcnow()
+        expires_at = created_at + timedelta(seconds=effective_ttl) if effective_ttl else None
+
+        _register_active(
+            entry_id,
+            {
+                "type": "docker",
+                "run_id": run_id,
+                "resource_name": resource.name,
+                "infra_fingerprint": self.fingerprint(),
+                "container_name": container_name,
+                "port_map": {str(k): v for k, v in port_map.items()},
+                "endpoint": endpoint,
+                "created_at": created_at.isoformat(),
+                "expires_at": expires_at.isoformat() if expires_at else None,
+            },
+        )
+
+        if endpoint and resource.health_check_path:
+            health_url = f"{endpoint}{resource.health_check_path}"
+            try:
+                _wait_for_docker_http(health_url, timeout=resource.health_check_timeout)
+            except TimeoutError:
+                _stop_docker_container(container_name)
+                _deregister_active(entry_id)
+                raise
+
+        return LocalDockerResourceHandle(
+            run_id=run_id,
+            resource=resource,
+            infra=self,
+            endpoint=endpoint,
+            created_at=created_at,
+            expires_at=expires_at,
+            _entry_id=entry_id,
+            _container_name=container_name,
+            port_map=port_map,
+        )
+
+    def list_active(self, run_id: str | None = None) -> list[ResourceHandle]:
+        """Return handles for all active local resources, optionally filtered by run_id.
+
+        Reconstructed from ~/.cube/active.json. Stale entries (dead process or
+        stopped container) are cleaned up and excluded from the result.
+        """
         data = _load_active()
-        handles = []
+        handles: list[ResourceHandle] = []
         stale_ids = []
 
         for entry_id, entry in data.items():
@@ -418,31 +587,19 @@ class LocalInfraConfig(InfraConfig):
             if run_id and entry.get("run_id") != run_id:
                 continue
 
-            pid = entry.get("pid")
-            if pid and not _pid_alive(pid):
+            entry_type = entry.get("type")
+            if entry_type == "docker":
+                handle = self._get_docker_handle(entry_id, entry)
+            elif entry_type == "vm":
+                handle = self._get_vm_handle(entry_id, entry)
+            else:
+                raise ValueError(f"Unknown active.json entry type: {entry_type!r}")
+
+            if handle is None:
                 stale_ids.append(entry_id)
-                continue
+            else:
+                handles.append(handle)
 
-            # Reconstruct a handle without the live Popen (pid-only tracking).
-            resource = VMResourceConfig(name=entry["resource_name"], scope="task")
-            created_at = datetime.fromisoformat(entry["created_at"])
-            expires_at = datetime.fromisoformat(entry["expires_at"]) if entry.get("expires_at") else None
-
-            handles.append(
-                LocalResourceHandle(
-                    run_id=entry["run_id"],
-                    resource=resource,
-                    infra=self,
-                    endpoint=entry["endpoint"],
-                    created_at=created_at,
-                    expires_at=expires_at,
-                    _entry_id=entry_id,
-                    _qemu_proc=None,  # can't reconstruct Popen; cleanup uses PID
-                    _overlay_path=Path(entry["overlay_path"]) if entry.get("overlay_path") else None,
-                )
-            )
-
-        # Clean up dead entries.
         if stale_ids:
             data = _load_active()
             for sid in stale_ids:
@@ -451,8 +608,64 @@ class LocalInfraConfig(InfraConfig):
 
         return handles
 
+    def _get_docker_handle(self, entry_id: str, entry: dict) -> LocalDockerResourceHandle | None:
+        """Reconstruct a LocalDockerResourceHandle from an active.json entry.
+
+        Returns None if the container is no longer running (stale entry).
+        """
+        container_name = entry.get("container_name", "")
+        result = subprocess.run(
+            ["docker", "inspect", "--format", "{{.State.Running}}", container_name],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0 or result.stdout.strip() != "true":
+            return None
+
+        created_at = datetime.fromisoformat(entry["created_at"])
+        expires_at = datetime.fromisoformat(entry["expires_at"]) if entry.get("expires_at") else None
+        port_map = {int(k): v for k, v in entry.get("port_map", {}).items()}
+        resource = DockerImageConfig(name=entry["resource_name"], image="")
+
+        return LocalDockerResourceHandle(
+            run_id=entry["run_id"],
+            resource=resource,
+            infra=self,
+            endpoint=entry.get("endpoint"),
+            created_at=created_at,
+            expires_at=expires_at,
+            _entry_id=entry_id,
+            _container_name=container_name,
+            port_map=port_map,
+        )
+
+    def _get_vm_handle(self, entry_id: str, entry: dict) -> LocalResourceHandle | None:
+        """Reconstruct a LocalResourceHandle from an active.json entry.
+
+        Returns None if the QEMU process is no longer alive (stale entry).
+        """
+        pid = entry.get("pid")
+        if pid and not _pid_alive(pid):
+            return None
+
+        resource = VMResourceConfig(name=entry["resource_name"])
+        created_at = datetime.fromisoformat(entry["created_at"])
+        expires_at = datetime.fromisoformat(entry["expires_at"]) if entry.get("expires_at") else None
+
+        return LocalResourceHandle(
+            run_id=entry["run_id"],
+            resource=resource,
+            infra=self,
+            endpoint=entry["endpoint"],
+            created_at=created_at,
+            expires_at=expires_at,
+            _entry_id=entry_id,
+            _qemu_proc=None,  # can't reconstruct Popen; cleanup uses PID
+            _overlay_path=Path(entry["overlay_path"]) if entry.get("overlay_path") else None,
+        )
+
     def cleanup(self, run_id: str) -> None:
-        """Kill all QEMU processes and remove overlays for run_id."""
+        """Tear down all local resources (VMs and Docker containers) for run_id."""
         data = _load_active()
         to_remove = []
         for entry_id, entry in list(data.items()):
@@ -520,21 +733,32 @@ def _pid_alive(pid: int) -> bool:
 
 
 def _kill_entry(entry: dict) -> None:
-    """Kill QEMU process and remove overlay for a single active.json entry."""
-    pid = entry.get("pid")
-    if pid and _pid_alive(pid):
-        try:
-            os.kill(pid, 15)  # SIGTERM
-            time.sleep(1)
-            if _pid_alive(pid):
-                os.kill(pid, 9)  # SIGKILL
-        except Exception:
-            pass
-        logger.debug("Killed PID %d", pid)
+    """Tear down a single active.json entry (VM or Docker container)."""
+    entry_type = entry.get("type")
 
-    overlay_path = entry.get("overlay_path")
-    if overlay_path:
-        p = Path(overlay_path)
-        if p.exists():
-            p.unlink()
-            logger.debug("Removed overlay %s", p)
+    if entry_type == "docker":
+        container_name = entry.get("container_name")
+        if container_name:
+            _stop_docker_container(container_name)
+
+    elif entry_type == "vm":
+        pid = entry.get("pid")
+        if pid and _pid_alive(pid):
+            try:
+                os.kill(pid, 15)  # SIGTERM
+                time.sleep(1)
+                if _pid_alive(pid):
+                    os.kill(pid, 9)  # SIGKILL
+            except Exception:
+                pass
+            logger.debug(f"Killed PID {pid}")
+
+        overlay_path = entry.get("overlay_path")
+        if overlay_path:
+            p = Path(overlay_path)
+            if p.exists():
+                p.unlink()
+                logger.debug(f"Removed overlay {p}")
+
+    else:
+        raise ValueError(f"Unknown active.json entry type: {entry_type!r}")

--- a/src/cube/resource.py
+++ b/src/cube/resource.py
@@ -171,7 +171,7 @@ class DockerImageConfig(ResourceConfig):
     """Single Docker image per task (SWE-bench, MLE-bench, CTF...).
 
     Resource requirements (ram_gb, cpu_cores, disk_gb, ports) are read by
-    DockerInfraConfig.launch() to configure the container. gpu=True maps to
+    LocalInfraConfig.launch() to configure the container. gpu=True maps to
     the "gpu:nvidia" capability requirement token via requirements().
     """
 
@@ -181,6 +181,11 @@ class DockerImageConfig(ResourceConfig):
     disk_gb: float = 10.0
     gpu: bool = False
     ports: list[int] | None = None
+    health_check_path: str = "/"
+    """HTTP path polled on the primary port after launch until status < 500.
+    Set to empty string to skip the health check entirely."""
+    health_check_timeout: int = 60
+    """Seconds to wait for the health check to pass before aborting launch."""
 
     def requirements(self) -> set[str]:
         reqs = {"docker"}

--- a/tests/test_infra_local_docker.py
+++ b/tests/test_infra_local_docker.py
@@ -1,0 +1,323 @@
+"""Unit tests for LocalInfraConfig Docker support.
+
+All tests mock subprocess calls — no Docker daemon required.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from cube.infra_local import (
+    LocalDockerResourceHandle,
+    LocalInfraConfig,
+    _kill_entry,
+    _stop_docker_container,
+    _wait_for_docker_http,
+)
+from cube.resource import (
+    DockerImageConfig,
+    ResourceNotReadyError,
+    UnsupportedResourceType,
+)
+
+
+@pytest.fixture()
+def infra(tmp_path):
+    """LocalInfraConfig with a temp active.json and provision store."""
+    active = tmp_path / "active.json"
+    store_dir = tmp_path / "provisions"
+    store_dir.mkdir()
+    with (
+        patch("cube.infra_local._ACTIVE_JSON", active),
+        patch("cube.provision_store._DEFAULT_STORE_DIR", store_dir),
+    ):
+        yield LocalInfraConfig()
+
+
+@pytest.fixture()
+def registered_image(infra):
+    """An infra with a DockerImageConfig already registered."""
+    resource = DockerImageConfig(
+        name="test-image",
+        image="myrepo/myimage:latest",
+        ports=[80, 8877],
+    )
+    infra.register(resource, {"image": "myrepo/myimage:latest"})
+    return infra, resource
+
+
+# ── provision() ───────────────────────────────────────────────────────────────
+
+
+def test_provision_docker_pulls_image_and_registers(infra):
+    resource = DockerImageConfig(name="test-image", image="myrepo/myimage:latest")
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0)
+        infra.provision(resource)
+
+    mock_run.assert_called_once_with(["docker", "pull", "myrepo/myimage:latest"], check=True)
+    assert infra.provision_status(resource) == "ready"
+
+
+def test_provision_docker_is_idempotent(infra):
+    resource = DockerImageConfig(name="test-image", image="myrepo/myimage:latest")
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0)
+        infra.provision(resource)
+        infra.provision(resource)
+
+    assert mock_run.call_count == 2  # docker pull called each time (docker handles idempotency)
+
+
+def test_provision_unsupported_type_raises(infra):
+    from cube.resource import ResourceConfig
+
+    class _AlienResource(ResourceConfig):
+        pass
+
+    with pytest.raises(UnsupportedResourceType):
+        infra.provision(_AlienResource(name="alien"))
+
+
+# ── launch() ──────────────────────────────────────────────────────────────────
+
+
+def test_launch_docker_without_provision_raises(infra):
+    resource = DockerImageConfig(name="test-image", image="myrepo/myimage:latest", ports=[80])
+    with pytest.raises(ResourceNotReadyError):
+        infra.launch(resource)
+
+
+def test_launch_docker_returns_handle_with_port_map(registered_image):
+    infra, resource = registered_image
+
+    with (
+        patch("subprocess.run") as mock_run,
+        patch("cube.infra_local._free_port", side_effect=[15001, 15002]),
+        patch("cube.infra_local._wait_for_docker_http"),
+    ):
+        mock_run.return_value = MagicMock(returncode=0)
+        handle = infra.launch(resource)
+
+    assert isinstance(handle, LocalDockerResourceHandle)
+    assert handle.port_map == {80: 15001, 8877: 15002}
+    assert handle.endpoint == "http://127.0.0.1:15001"
+    assert handle._container_name.startswith("cube-test-image-")
+
+
+def test_launch_docker_run_command_includes_port_flags(registered_image):
+    infra, resource = registered_image
+
+    with (
+        patch("subprocess.run") as mock_run,
+        patch("cube.infra_local._free_port", side_effect=[15001, 15002]),
+        patch("cube.infra_local._wait_for_docker_http"),
+    ):
+        mock_run.return_value = MagicMock(returncode=0)
+        infra.launch(resource)
+
+    docker_run_call = mock_run.call_args_list[0]
+    cmd = docker_run_call[0][0]
+    assert "docker" in cmd
+    assert "run" in cmd
+    assert "-p" in cmd
+    assert "127.0.0.1:15001:80" in cmd
+    assert "127.0.0.1:15002:8877" in cmd
+    assert "myrepo/myimage:latest" in cmd
+
+
+def test_launch_docker_gpu_flag(infra):
+    resource = DockerImageConfig(name="gpu-image", image="myrepo/gpu:latest", ports=[8080], gpu=True)
+    infra.register(resource, {"image": "myrepo/gpu:latest"})
+
+    with (
+        patch("subprocess.run") as mock_run,
+        patch("cube.infra_local._free_port", return_value=15001),
+        patch("cube.infra_local._wait_for_docker_http"),
+    ):
+        mock_run.return_value = MagicMock(returncode=0)
+        infra.launch(resource)
+
+    cmd = mock_run.call_args_list[0][0][0]
+    assert "--gpus" in cmd
+    assert "all" in cmd
+
+
+def test_launch_docker_no_ports_no_endpoint(infra):
+    resource = DockerImageConfig(name="no-port-image", image="myrepo/noop:latest")
+    infra.register(resource, {"image": "myrepo/noop:latest"})
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0)
+        handle = infra.launch(resource)
+
+    assert handle.endpoint is None
+    assert handle.port_map == {}
+
+
+def test_launch_docker_health_check_skipped_when_path_empty(infra):
+    resource = DockerImageConfig(name="test-image", image="myrepo/myimage:latest", ports=[80], health_check_path="")
+    infra.register(resource, {"image": "myrepo/myimage:latest"})
+
+    with (
+        patch("subprocess.run") as mock_run,
+        patch("cube.infra_local._free_port", return_value=15001),
+        patch("cube.infra_local._wait_for_docker_http") as mock_health,
+    ):
+        mock_run.return_value = MagicMock(returncode=0)
+        infra.launch(resource)
+
+    mock_health.assert_not_called()
+
+
+def test_launch_docker_health_check_timeout_removes_container(registered_image):
+    infra, resource = registered_image
+
+    with (
+        patch("subprocess.run") as mock_run,
+        patch("cube.infra_local._free_port", side_effect=[15001, 15002]),
+        patch("cube.infra_local._wait_for_docker_http", side_effect=TimeoutError("timed out")),
+        patch("cube.infra_local._stop_docker_container") as mock_stop,
+    ):
+        mock_run.return_value = MagicMock(returncode=0)
+        with pytest.raises(TimeoutError):
+            infra.launch(resource)
+
+    mock_stop.assert_called_once()
+
+
+# ── LocalDockerResourceHandle.close() ─────────────────────────────────────────
+
+
+def test_handle_close_stops_and_removes_container(registered_image, tmp_path):
+    infra, resource = registered_image
+
+    with (
+        patch("subprocess.run") as mock_run,
+        patch("cube.infra_local._free_port", side_effect=[15001, 15002]),
+        patch("cube.infra_local._wait_for_docker_http"),
+    ):
+        mock_run.return_value = MagicMock(returncode=0)
+        handle = infra.launch(resource)
+
+    container_name = handle._container_name
+    with patch("cube.infra_local._stop_docker_container") as mock_stop:
+        handle.close()
+
+    mock_stop.assert_called_once_with(container_name)
+
+
+# ── _stop_docker_container() ──────────────────────────────────────────────────
+
+
+def test_stop_docker_container_calls_stop_then_rm():
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0)
+        _stop_docker_container("my-container")
+
+    assert mock_run.call_count == 2
+    assert mock_run.call_args_list[0] == call(["docker", "stop", "my-container"], capture_output=True, text=True)
+    assert mock_run.call_args_list[1] == call(["docker", "rm", "my-container"], capture_output=True, text=True)
+
+
+def test_stop_docker_container_tolerates_not_found():
+    not_found = MagicMock(returncode=1, stderr="No such container: my-container")
+    with patch("subprocess.run", return_value=not_found):
+        _stop_docker_container("my-container")  # should not raise
+
+
+# ── _wait_for_docker_http() ───────────────────────────────────────────────────
+
+
+def test_wait_for_docker_http_succeeds_on_2xx():
+    mock_resp = MagicMock()
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    mock_resp.status = 200
+
+    with patch("urllib.request.urlopen", return_value=mock_resp):
+        _wait_for_docker_http("http://localhost:8080/", timeout=5)
+
+
+def test_wait_for_docker_http_succeeds_on_4xx():
+    import urllib.error
+
+    with patch("urllib.request.urlopen", side_effect=urllib.error.HTTPError(None, 401, "Unauthorized", {}, None)):
+        _wait_for_docker_http("http://localhost:8080/", timeout=5)
+
+
+def test_wait_for_docker_http_times_out():
+    with patch("urllib.request.urlopen", side_effect=ConnectionRefusedError):
+        with pytest.raises(TimeoutError):
+            _wait_for_docker_http("http://localhost:8080/", timeout=1)
+
+
+# ── _kill_entry() ─────────────────────────────────────────────────────────────
+
+
+def test_kill_entry_docker_calls_stop():
+    entry = {"type": "docker", "container_name": "cube-abc-docker-xyz"}
+    with patch("cube.infra_local._stop_docker_container") as mock_stop:
+        _kill_entry(entry)
+    mock_stop.assert_called_once_with("cube-abc-docker-xyz")
+
+
+def test_kill_entry_vm_kills_pid_and_removes_overlay(tmp_path):
+    overlay = tmp_path / "overlay.qcow2"
+    overlay.write_text("fake")
+    entry = {"type": "vm", "pid": 99999, "overlay_path": str(overlay)}
+    with patch("cube.infra_local._pid_alive", return_value=False):
+        _kill_entry(entry)
+    # PID not alive → no kill signal; overlay still present (only removed if alive path ran)
+
+
+def test_kill_entry_unknown_type_raises():
+    with pytest.raises(ValueError, match="Unknown active.json entry type"):
+        _kill_entry({"type": "kubernetes"})
+
+
+# ── list_active() ─────────────────────────────────────────────────────────────
+
+
+def test_list_active_returns_running_docker_handles(infra, tmp_path):
+    resource = DockerImageConfig(name="test-image", image="myrepo/myimage:latest", ports=[80])
+    infra.register(resource, {"image": "myrepo/myimage:latest"})
+
+    with (
+        patch("subprocess.run") as mock_run,
+        patch("cube.infra_local._free_port", return_value=15001),
+        patch("cube.infra_local._wait_for_docker_http"),
+    ):
+        mock_run.return_value = MagicMock(returncode=0)
+        handle = infra.launch(resource)
+
+    # Simulate container still running
+    inspect_result = MagicMock(returncode=0, stdout="true\n")
+    with patch("subprocess.run", return_value=inspect_result):
+        active = infra.list_active()
+
+    assert len(active) == 1
+    assert isinstance(active[0], LocalDockerResourceHandle)
+    assert active[0].run_id == handle.run_id
+
+
+def test_list_active_excludes_stopped_containers(infra):
+    resource = DockerImageConfig(name="test-image", image="myrepo/myimage:latest", ports=[80])
+    infra.register(resource, {"image": "myrepo/myimage:latest"})
+
+    with (
+        patch("subprocess.run") as mock_run,
+        patch("cube.infra_local._free_port", return_value=15001),
+        patch("cube.infra_local._wait_for_docker_http"),
+    ):
+        mock_run.return_value = MagicMock(returncode=0)
+        infra.launch(resource)
+
+    # Simulate container not running
+    inspect_result = MagicMock(returncode=1, stdout="")
+    with patch("subprocess.run", return_value=inspect_result):
+        active = infra.list_active()
+
+    assert active == []


### PR DESCRIPTION
## What

Implements Docker container support in `LocalInfraConfig`, closing #102.

## Changes

**`src/cube/resource.py`**
- `DockerImageConfig` gains two new fields:
  - `health_check_path: str = "/"` — HTTP path polled after launch until status < 500; set to `""` to skip
  - `health_check_timeout: int = 60` — seconds before giving up

**`src/cube/infra_local.py`**
- `provision(DockerImageConfig)` — `docker pull <image>` + `register(resource, {"image": ...})`
- `launch()` now dispatches to `_launch_vm()` (refactored from previous inline code) or `_launch_docker()`
- `_launch_docker(DockerImageConfig)` — `docker run -d` with dynamic host port allocation per declared container port, optional HTTP health check, active.json tracking under `"type": "docker"`
- `LocalDockerResourceHandle` — `close()` calls `docker stop` + `docker rm`; carries `port_map: dict[int, int]` (container port → host port)
- `list_active()` refactored: dispatches to `_get_docker_handle()` / `_get_vm_handle()` per entry type
- `_kill_entry()` dispatches on `"type": "docker" | "vm"`; raises `ValueError` for unknown types
- `active.json` entries now always carry `"type": "vm"` or `"type": "docker"`

**`tests/test_infra_local_docker.py`** — 21 new tests covering all new paths; all mocked, no Docker daemon required.

## Test plan

- [x] `uv run pytest tests/test_infra_local_docker.py` — 21 passed
- [x] `uv run pytest tests/` — 227 passed, 3 skipped (cloud credentials)

## Related

- Closes #102
- Unblocks https://github.com/The-AI-Alliance/cube-harness/issues/254 (webarena-verified container lifecycle)