### PR TITLE
docs: add Authoring a CUBE guide and cross-link from entry points

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing to CUBE Standard
 
+> **Building a new CUBE benchmark?** Start with the [Authoring a CUBE guide](https://the-ai-alliance.github.io/cube-standard/authoring-a-cube) — three starting paths, implementation order, validation, and submission. Come back here for framework invariants and the RFC process when you need them. This file covers contributing to the cube-standard **framework itself** (adding features, changing specs, modifying the template).
+
 ## Repo layout
 
 ```
@@ -45,20 +47,11 @@ Read the module docstrings — they are the authoritative spec:
 
 ## Writing a new cube package
 
-```sh
-cube init my-env       # scaffold from _template/new_cube_package
-cd my-env && uv sync
-cube test my_env       # must reach reward == 1.0 on every debug task
-```
+Full walkthrough lives in the [Authoring a CUBE guide](https://the-ai-alliance.github.io/cube-standard/authoring-a-cube) — three starting paths (`/new-cube` skill, copy counter-cube, `cube init`), implementation order, validation with `cube test` and `/review-cube`, and submission via `cube registry add --submit`.
 
-Work through the `TODO` comments in this order:
+Short form: `cube init my-env` → fill TODOs in `tool.py` → `task.py` → `benchmark.py` → `debug.py` (in that order) → `cube test my_env` must reach `reward == 1.0` on every debug task.
 
-1. [`tool.py`](src/cube/_template/new_cube_package/src/cube_package/tool.py) — define `CubeEnv`, add `@tool_action` methods
-2. [`task.py`](src/cube/_template/new_cube_package/src/cube_package/task.py) — implement `reset()` and `evaluate()`
-3. [`benchmark.py`](src/cube/_template/new_cube_package/src/cube_package/benchmark.py) — fill metadata (inline or via CSV/JSON)
-4. [`debug.py`](src/cube/_template/new_cube_package/src/cube_package/debug.py) — write deterministic action sequences for each task
-
-The counter-cube example covers all five layers concretely:
+The counter-cube example covers all layers concretely:
 - Tool with conditional `action_set` filtering → [`examples/counter-cube/src/counter_cube/tool.py`](examples/counter-cube/src/counter_cube/tool.py)
 - Partial-progress reward and early termination → [`examples/counter-cube/src/counter_cube/task.py`](examples/counter-cube/src/counter_cube/task.py)
 - Hardcoded debug sequences → [`examples/counter-cube/src/counter_cube/debug.py`](examples/counter-cube/src/counter_cube/debug.py)

--- a/README.md
+++ b/README.md
@@ -85,31 +85,18 @@ uv sync --extra dev
 
 ## For benchmark contributors
 
-**Fast path** — copy the reference implementation, rename, and iterate:
+Three ways to start:
 
-```sh
-cp -r examples/counter-cube my-bench
-cd my-bench && uv sync
-# Edit @tool_action decorated methods in src/*/tool.py
-# Edit reset() and evaluate() in src/*/task.py
-# Edit benchmark_metadata, task_metadata, task_config_class, _setup() and close() in src/*/benchmark.py
-# expose get_debug_benchmark and get_debug_agent in src/*/debug.py
-cube test my-bench
-```
+1. **Guided** — run `/new-cube` in [Claude Code](https://claude.ai/claude-code) with this repo checked out. The skill interviews you, scaffolds the package, fills TODOs, and validates end-to-end.
+2. **Copy** — `cp -r examples/counter-cube my-bench && cd my-bench && uv sync`, then edit the placeholders.
+3. **Scaffold** — `cube init my-bench && cd my-bench && uv sync`, then work through the `TODO` markers.
+
+Validate with `cube test my-bench` (every debug task must reach `reward == 1.0`), self-audit with `/review-cube ./my-bench`, and submit with `cube registry add --submit`.
+
+See the **[Authoring a CUBE guide](https://the-ai-alliance.github.io/cube-standard/authoring-a-cube)** for the full walkthrough. [CONTRIBUTING.md](CONTRIBUTING.md) covers framework invariants and the RFC process.
 
 > [!NOTE]
-> `cube test` discovers benchmarks via the `cube.benchmarks` entry point group. The benchmark package must be installed (e.g. `uv sync` or `pip install -e .`) before running `cube test`, otherwise the benchmark will not be found.
-
-Or scaffold from the template:
-
-```sh
-cube init my-bench    # scaffold a new benchmark package from the template
-cd my-bench
-uv sync
-cube test my-bench    # run the debug compliance suite
-```
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the five-layer architecture and implementation order.
+> `cube test` discovers benchmarks via the `cube.benchmarks` entry point group. Install the package (`uv sync` or `pip install -e .`) before running.
 
 ## Getting Involved
 

--- a/docs/about.markdown
+++ b/docs/about.markdown
@@ -67,6 +67,8 @@ When an evaluation platform supports CUBE:
 - Automatic discoverability through the registry
 - Control over your distribution and licensing
 
+**Start here:** [Authoring a CUBE]({{site.baseurl}}/authoring-a-cube) — walkthrough with three starting paths, implementation order, validation, and submission.
+
 ### Platform Developers
 
 **You want to**: Build the best evaluation/training platform without being bottlenecked by benchmark integration

--- a/docs/authoring-a-cube.markdown
+++ b/docs/authoring-a-cube.markdown
@@ -60,7 +60,7 @@ Work through the layers top-down. Each file has `TODO` comments pointing at what
 
 | # | File | What to fill in |
 |---|---|---|
-| 1 | `tool.py` | Subclass `Tool`; add `@tool_action` methods for each agent-callable action |
+| 1 | `tool.py` | **Check reusable tools first** — for web agents use [`cube-browser-tool`](https://github.com/The-AI-Alliance/cube-standard/tree/main/cube-tools/cube-browser-tool), for desktop/CUA use [`cube-computer-tool`](https://github.com/The-AI-Alliance/cube-standard/tree/main/cube-tools/cube-computer-tool). Import directly or subclass to add benchmark-specific actions. Only subclass `Tool` from scratch if neither fits; mark methods with `@tool_action`. |
 | 2 | `task.py` | Implement `reset()` (opening observation) and `evaluate()` (reward on termination) |
 | 3 | `benchmark.py` | Fill `BenchmarkMetadata` and `task_metadata` (inline or CSV/JSON); implement `_setup()` / `close()` |
 | 4 | `debug.py` | One deterministic action sequence per task — must reach `reward == 1.0` |
@@ -117,4 +117,5 @@ Ways to reach us:
 - [CONTRIBUTING.md](https://github.com/The-AI-Alliance/cube-standard/blob/main/CONTRIBUTING.md) — framework invariants, RFC process, template rules
 - [openspec/specs/](https://github.com/The-AI-Alliance/cube-standard/tree/main/openspec/specs) — formal per-layer contracts
 - [cube-registry](https://github.com/The-AI-Alliance/cube-registry) — submission YAML template and compliance tiers
+- [cube-tools/](https://github.com/The-AI-Alliance/cube-standard/tree/main/cube-tools) — reusable tool packages (browser, computer, chat)
 - [DeepWiki](https://deepwiki.com/The-AI-Alliance/cube-standard) — full API reference

--- a/docs/authoring-a-cube.markdown
+++ b/docs/authoring-a-cube.markdown
@@ -118,4 +118,6 @@ Ways to reach us:
 - [openspec/specs/](https://github.com/The-AI-Alliance/cube-standard/tree/main/openspec/specs) — formal per-layer contracts
 - [cube-registry](https://github.com/The-AI-Alliance/cube-registry) — submission YAML template and compliance tiers
 - [cube-tools/](https://github.com/The-AI-Alliance/cube-standard/tree/main/cube-tools) — reusable tool packages (browser, computer, chat)
+- [cube-resources/](https://github.com/The-AI-Alliance/cube-standard/tree/main/cube-resources) — reusable resource packages (playwright browser, chat sessions, AWS/Azure infra, VM backend)
+
 - [DeepWiki](https://deepwiki.com/The-AI-Alliance/cube-standard) — full API reference

--- a/docs/authoring-a-cube.markdown
+++ b/docs/authoring-a-cube.markdown
@@ -1,0 +1,120 @@
+---
+layout: default
+title: Authoring a CUBE
+nav_order: 20
+has_children: false
+---
+
+# Authoring a CUBE
+
+So you want to wrap a benchmark as a CUBE. This guide walks through what that involves, the easiest way to start, and who to ping if your benchmark isn't a clean fit.
+
+The short version: you implement four Python classes (tool, task, benchmark, debug agent), run `cube test` to prove it works, and submit one YAML file to the registry. Most benchmarks fit this shape naturally once it clicks.
+
+## What you're building
+
+A CUBE package exposes a benchmark through a uniform protocol so any CUBE-compatible harness can run it without custom integration. You implement four things:
+
+| Layer | What it answers |
+|---|---|
+| **Tool** | What actions can the agent take? (e.g. `click`, `type`, `run_shell`) |
+| **Task** | What's the initial observation, and how do I score a solution? |
+| **Benchmark** | What's the list of tasks, and what shared setup do they need? |
+| **Debug** | One deterministic solution per task — proves everything wires up correctly. |
+
+Each layer has a small, well-defined contract. Formal per-layer specs live in [openspec/specs/](https://github.com/The-AI-Alliance/cube-standard/tree/main/openspec/specs) when you want the contract-level detail.
+
+## Three ways to start
+
+### Option 1 — Use the `/new-cube` skill (recommended)
+
+If you have [Claude Code](https://claude.ai/claude-code) installed, open a workspace with `cube-standard` checked out and run:
+
+```
+/new-cube
+```
+
+The skill interviews you (what the agent does, what counts as a solved task, what resources you need), scaffolds the package, fills in the template TODOs, runs the debug suite, and produces a registry entry. You review and correct as it goes — it handles the boilerplate so you focus on the benchmark logic.
+
+### Option 2 — Copy the reference implementation
+
+```sh
+cp -r examples/counter-cube my-bench
+cd my-bench && uv sync
+```
+
+[counter-cube](https://github.com/The-AI-Alliance/cube-standard/tree/main/examples/counter-cube) is the minimal real cube — increment a counter to reach a target. Every layer has a comment explaining its role. Rename the placeholders, replace the logic with yours.
+
+### Option 3 — Scaffold from the template
+
+```sh
+cube init my-bench
+cd my-bench && uv sync
+```
+
+Blank slate with `TODO` markers at every decision point. Best if your benchmark's shape doesn't resemble counter-cube.
+
+## Implementation order
+
+Work through the layers top-down. Each file has `TODO` comments pointing at what needs to change.
+
+| # | File | What to fill in |
+|---|---|---|
+| 1 | `tool.py` | Subclass `Tool`; add `@tool_action` methods for each agent-callable action |
+| 2 | `task.py` | Implement `reset()` (opening observation) and `evaluate()` (reward on termination) |
+| 3 | `benchmark.py` | Fill `BenchmarkMetadata` and `task_metadata` (inline or CSV/JSON); implement `_setup()` / `close()` |
+| 4 | `debug.py` | One deterministic action sequence per task — must reach `reward == 1.0` |
+| 5 | `pyproject.toml` | Update `name`, `description`, and the `cube.benchmarks` entry-point |
+
+**A note on task metadata.** If you have more than a handful of tasks, you'll load them from `task_metadata.csv` or `.json` rather than inlining them in `benchmark.py`. If your task data starts life in a different shape — scraped from a website, exported from an existing benchmark repo, hand-curated in a spreadsheet — expect to write a small one-off conversion script as a pre-step. The `/new-cube` skill walks you through this; following options 2 or 3 you'll handle it manually.
+
+Framework invariants (return types, serialization rules, reward semantics) are in [CONTRIBUTING.md § Key invariants](https://github.com/The-AI-Alliance/cube-standard/blob/main/CONTRIBUTING.md#key-invariants). Read them once before you're deep in the code.
+
+## Validate
+
+```sh
+cube test my-bench
+```
+
+Every debug task must hit `reward == 1.0`. If one doesn't, either the debug action sequence is wrong or the task's `evaluate()` is wrong — catching this locally is the whole point of the debug suite.
+
+**Before you open a registry PR, self-audit with the `/review-cube` skill:**
+
+```
+/review-cube ./my-bench
+```
+
+`/review-cube` installs your package, runs pytest, runs `cube test`, audits against cube-standard invariants, and produces a Blocking / Suggestions report. Resolve everything in the Blocking section before submitting. Registry CI catches the same issues later, but locally is faster and less public.
+
+## Publish
+
+Once `cube test` and `/review-cube` both pass, submit to the registry with one command:
+
+```sh
+cube registry add --submit
+```
+
+This generates a `cube-registry-entry.yaml` from your `pyproject.toml`, forks [cube-registry](https://github.com/The-AI-Alliance/cube-registry), commits the entry, and opens a PR. Registry CI validates and auto-merges the happy path — no human review required.
+
+Run `cube registry add` without `--submit` first if you want to generate the YAML locally, edit it, and review the entry before opening the PR.
+
+Your package also needs to land on PyPI for the registry's compliance suite to install and run it — publish whenever you're ready; it doesn't have to come before the registry PR.
+
+## We'll help you
+
+Not every benchmark is a clean fit on first read. If you hit something awkward — the action space doesn't compress into a single `Tool`, scoring needs human judgment, the infra requirements are unusual, the episode structure doesn't match `reset → step → evaluate` — **tell us before wrangling it on your own**. Common awkwardness usually has an idiomatic solution we can point you at, and if yours is genuinely new we'd rather evolve the protocol than watch you paper over it.
+
+Ways to reach us:
+
+- **[Benchmark contributor form](https://docs.google.com/forms/d/e/1FAIpQLSddMFyRXZJPpD0I2K27OEmIPUpj57w--u2NuMscrjNlkqy8rQ/viewform)** — flag intent, no commitment; we follow up based on fit
+- **[GitHub Discussions](https://github.com/The-AI-Alliance/cube-standard/discussions)** — public Q&A and RFC gauging
+- **[Open an issue](https://github.com/The-AI-Alliance/cube-standard/issues/new)** and tag `@recursix` and `@nicolasag` for direct help
+
+## Deeper references
+
+- [counter-cube](https://github.com/The-AI-Alliance/cube-standard/tree/main/examples/counter-cube) — canonical reference implementation
+- [toy_benchmark](https://github.com/The-AI-Alliance/cube-standard/tree/main/examples/toy_benchmark) — single-file minimal variant
+- [CONTRIBUTING.md](https://github.com/The-AI-Alliance/cube-standard/blob/main/CONTRIBUTING.md) — framework invariants, RFC process, template rules
+- [openspec/specs/](https://github.com/The-AI-Alliance/cube-standard/tree/main/openspec/specs) — formal per-layer contracts
+- [cube-registry](https://github.com/The-AI-Alliance/cube-registry) — submission YAML template and compliance tiers
+- [DeepWiki](https://deepwiki.com/The-AI-Alliance/cube-standard) — full API reference

--- a/docs/index.markdown
+++ b/docs/index.markdown
@@ -13,5 +13,6 @@ has_children: false
 
 ## Get Started
 
+- **[Authoring a CUBE]({{site.baseurl}}/authoring-a-cube)** — How to wrap a benchmark as a CUBE: three starting paths, implementation order, validation, and submission
 - **[GitHub README](https://github.com/The-AI-Alliance/cube-standard#readme){:target="repo"}** — Installation, quick start, and contributing
 - **[DeepWiki](https://deepwiki.com/The-AI-Alliance/cube-standard){:target="deepwiki"}** — Full API reference and guides

--- a/examples/counter-cube/README.md
+++ b/examples/counter-cube/README.md
@@ -72,6 +72,7 @@ benchmark.close()
 
 ## Further reading
 
-- `../../design/main_specs.md` — full CUBE specification
-- `../../examples/toy_benchmark/counter.py` — flat single-file version of the same example
-- `../../cubes/osworld-cube/` — a real cube using VMs and desktop automation
+- **[Authoring a CUBE guide](https://the-ai-alliance.github.io/cube-standard/authoring-a-cube)** — if you're new to CUBE, start here; this directory is the reference implementation it points to
+- [`openspec/specs/`](../../openspec/specs/) — formal per-layer contracts
+- [`examples/toy_benchmark/`](../toy_benchmark/) — flat single-file variant of the same example
+- [`cube-harness/cubes/osworld-cube/`](https://github.com/The-AI-Alliance/cube-harness/tree/main/cubes/osworld-cube) — a real cube using VMs and desktop automation (lives in the cube-harness repo)

--- a/src/cube/_template/new_cube_package/README.md
+++ b/src/cube/_template/new_cube_package/README.md
@@ -3,6 +3,8 @@
 This directory is the canonical starting point for a new CUBE benchmark package.
 Copy it, rename things, and follow the TODOs in each file.
 
+> **New to CUBE?** Read the [Authoring a CUBE guide](https://the-ai-alliance.github.io/cube-standard/authoring-a-cube) for the end-to-end walkthrough — interviewer skill, implementation order, validation, and publishing.
+
 **If you copy-paste manually** (rather than using `cube init`), find every placeholder
 that needs renaming:
 
@@ -64,6 +66,8 @@ See `examples/counter-cube/` in the cube-standard repo for a complete reference 
 - [ ] `debug.py` — add one entry to `_TASK_ACTIONS` per task
 - [ ] `pyproject.toml` — update `name`, `description`, and the `cube.benchmarks` entry-point key
 - [ ] Run `cube test <your-benchmark-name>` — all tasks must pass
+- [ ] Run `/review-cube ./` in Claude Code for a pre-submission self-audit
+- [ ] Submit to the registry with `cube registry add --submit`
 
 ## Key invariants
 


### PR DESCRIPTION
## Summary

Adds a single pedagogical onboarding surface for new benchmark authors, published to the Jekyll site at https://the-ai-alliance.github.io/cube-standard/authoring-a-cube once merged.

Based on [feat/new-cube-skill](https://github.com/The-AI-Alliance/cube-standard/pull/114). Targets that branch so the guide ships alongside the `/new-cube` and `/review-cube` skills it references.

## What the guide covers

- **Three starting paths** — `/new-cube` skill (guided), copy `examples/counter-cube`, or `cube init`
- **Implementation order** — tool → task → benchmark → debug, with a note on task-metadata generation for JSON/CSV loading
- **Validation** — `cube test` plus `/review-cube` self-audit before submitting
- **Publishing** — primary flow is `cube registry add --submit` (auto-fork + PR via `gh`); PyPI is demoted to "whenever you're ready"
- **We'll help you** — structurally awkward fits are directed to open a GitHub issue tagging @recursix and @nicolasag (matching the escalation rule added to both skills in the parent branch)

## Cross-links added

| File | Change |
| --- | --- |
| [docs/index.markdown](docs/index.markdown) | Authoring guide is now the first Get Started link |
| [docs/about.markdown](docs/about.markdown) | CTA in the Benchmark Authors section |
| [README.md](README.md) | Contributors section trimmed to three paths + guide link |
| [CONTRIBUTING.md](CONTRIBUTING.md) | Repositioned as framework-contributor-only with banner; "Writing a new cube package" section redirects to the guide |
| [examples/counter-cube/README.md](examples/counter-cube/README.md) | Fixed stale paths (`design/main_specs.md`, relative `cubes/osworld-cube/`); added guide pointer as top "further reading" item |
| [src/cube/_template/new_cube_package/README.md](src/cube/_template/new_cube_package/README.md) | Top banner linking to the guide; `/review-cube` and `cube registry add --submit` added to the checklist |

## Why separate from PR #114

PR #114 adds the `/new-cube` and `/review-cube` skills. This PR adds the *human-discoverable* counterpart — the narrative guide plus the cross-links that surface it from every entry point a new author might land on. Keeping it in a separate PR makes the skill changes and the doc changes reviewable independently.

Companion PRs (separate, because separate repos):
- cube-registry — fixes `/create-cube` → `/new-cube`, adds `/review-cube`, promotes `cube registry add --submit`, links to the guide
- cube-harness — collapses `cubes/README.md` to point at the guide instead of duplicating the layer description

## Test plan

- [ ] Jekyll site builds cleanly (verify in GitHub Pages preview once merged)
- [ ] All relative and external links resolve
- [ ] Guide URL (`/authoring-a-cube`) renders with correct nav ordering (between index at 10 and contributing at 90)

🤖 Generated with [Claude Code](https://claude.com/claude-code)