### PR TITLE
fix(benchmark): rename default_tool_config → tool_config

### DIFF
--- a/architecture-diagram.md
+++ b/architecture-diagram.md
@@ -166,7 +166,7 @@ classDiagram
         +ClassVar~type~ task_config_class
         -RuntimeContext _runtime_context
         +ContainerBackend container_backend
-        +ToolConfig default_tool_config
+        +ToolConfig tool_config
         +AbstractSeedGenerator seed_generator
         +setup() void
         +get_task_configs() Generator~TaskConfig~
@@ -272,7 +272,7 @@ classDiagram
 ## Lifecycle Flow
 
 1. **Benchmark Setup**:
-   - User creates Benchmark instance (passing `container_backend`, `default_tool_config`, `seed_generator` as constructor params)
+   - User creates Benchmark instance (passing `container_backend`, `tool_config`, `seed_generator` as constructor params)
    - User calls `benchmark.setup()`
    - Benchmark implementation (`_setup()`) sets:
      - `_runtime_context`: Shared infrastructure references (containers, VMs, etc.)
@@ -282,7 +282,7 @@ classDiagram
    - User calls `benchmark.get_task_configs()` to iterate over `TaskConfig` objects
    - Benchmark yields one `task_config_class` instance per task (and per seed if `seed_generator` is set):
      - `task_id`: unique identifier
-     - `tool_config`: from `default_tool_config`
+     - `tool_config`: from `benchmark.tool_config`
      - `seed`: from `seed_generator(task_metadata)` or `None`
 
 3. **Task Spawning**:

--- a/openspec/specs/benchmark/spec.md
+++ b/openspec/specs/benchmark/spec.md
@@ -55,7 +55,7 @@ If no `task_metadata` file and no declaration → `TypeError` at class definitio
 ```python
 resources: list[ResourceConfig] = []        # resource dependencies (L2/L3)
 container_backend: ContainerBackend | None  # passed to each Task
-default_tool_config: ToolConfig | None      # default for tasks without their own
+tool_config: ToolConfig | None              # applied to every task by the default get_task_configs(); override get_task_configs() for per-task variation
 seed_generator: AbstractSeedGenerator | None # yields seeds per TaskMetadata
 ```
 

--- a/src/cube/benchmark.py
+++ b/src/cube/benchmark.py
@@ -154,9 +154,9 @@ class Benchmark(TypedBaseModel, ABC):
     container_backend: ContainerBackend | None = Field(
         default=None
     )  # optional container backend to be used for all tasks in this benchmark
-    default_tool_config: ToolConfig | None = Field(
+    tool_config: ToolConfig | None = Field(
         default=None
-    )  # default tool config to be used for tasks that don't specify their own
+    )  # tool config applied uniformly to every task by the default get_task_configs(); override get_task_configs() for per-task variation
     seed_generator: AbstractSeedGenerator | None = Field(
         default=None
     )  # optional seed generator for tasks that require random seeds
@@ -420,8 +420,8 @@ class Benchmark(TypedBaseModel, ABC):
             missing_optional.append("_runtime_context")
         if self.container_backend is None:
             missing_optional.append("container_backend")
-        if self.default_tool_config is None:
-            missing_optional.append("default_tool_config")
+        if self.tool_config is None:
+            missing_optional.append("tool_config")
         if self.seed_generator is None:
             missing_optional.append("seed_generator")
         if missing_optional:
@@ -437,9 +437,9 @@ class Benchmark(TypedBaseModel, ABC):
         for tm in self.task_metadata.values():
             if self.seed_generator is not None:
                 for seed in self.seed_generator(tm):
-                    yield self.task_config_class(task_id=tm.id, tool_config=self.default_tool_config, seed=seed)
+                    yield self.task_config_class(task_id=tm.id, tool_config=self.tool_config, seed=seed)
             else:
-                yield self.task_config_class(task_id=tm.id, tool_config=self.default_tool_config, seed=None)
+                yield self.task_config_class(task_id=tm.id, tool_config=self.tool_config, seed=None)
 
     def subset_from_glob(self, glob_key: str, glob_pattern: str) -> "Benchmark":
         """


### PR DESCRIPTION
## Summary

- Renames `Benchmark.default_tool_config` → `tool_config` across `benchmark.py`, the benchmark spec, and the architecture diagram
- The `default_` prefix implied fallback semantics (used only when a task has no tool of its own), but the base `get_task_configs()` always applies it uniformly to every task — the name was misleading
- Updates the docstring and spec to say what it actually does: applied to every task by the default `get_task_configs()`; override `get_task_configs()` for per-task variation

Closes #119.

## Test plan

- [x] `make test` — 467 passed, 5 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)