### PR TITLE
fix(infra_local): rate-limit retry + active.json locking + Podman DOCKER_HOST

### DIFF
--- a/src/cube/backends/local.py
+++ b/src/cube/backends/local.py
@@ -46,8 +46,10 @@ _retry_pull = retry(
     stop=stop_after_attempt(6),
     wait=wait_exponential(multiplier=30, min=30, max=300),
     retry=retry_if_exception(
-        lambda exc: isinstance(exc, docker.errors.APIError)
-        and any(kw in str(exc).lower() for kw in ("toomanyrequests", "rate limit", "429"))
+        lambda exc: (
+            isinstance(exc, docker.errors.APIError)
+            and any(kw in str(exc).lower() for kw in ("toomanyrequests", "rate limit", "429"))
+        )
     ),
     reraise=True,
     before_sleep=before_sleep_log(logger, logging.WARNING),

--- a/src/cube/backends/local.py
+++ b/src/cube/backends/local.py
@@ -194,16 +194,18 @@ class LocalContainerBackend(ContainerBackend):
         if self.pull_policy == "always" or (self.pull_policy == "missing" and not _image_exists(client, config.image)):
             logger.info("Pulling image %s …", config.image)
             try:
-                self._pull_image(client, config.image)
+                self._pull_image(config.image)
             except docker.errors.APIError as exc:
                 # Convert only after _retry_pull has exhausted all attempts.
                 raise ContainerLaunchError(f"Failed to pull image '{config.image}': {exc}") from exc
         return self._launch_with_retry(config)
 
     @_retry_pull
-    def _pull_image(self, client: docker.DockerClient, image: str) -> None:
-        # Raises docker.errors.APIError directly so _retry_pull can inspect it.
-        client.images.pull(image)
+    def _pull_image(self, image: str) -> None:
+        # Creates a fresh client per attempt so a long backoff can't leave a
+        # timed-out session that would fail with a connection error instead of
+        # the 429 APIError that _retry_pull is designed to catch.
+        docker.from_env().images.pull(image)
 
     @_retry_launch
     def _launch_with_retry(self, config: ContainerConfig) -> LocalContainer:

--- a/src/cube/backends/local.py
+++ b/src/cube/backends/local.py
@@ -10,6 +10,7 @@ import docker.errors
 from tenacity import (
     before_sleep_log,
     retry,
+    retry_if_exception,
     retry_if_not_exception_type,
     stop_after_attempt,
     wait_exponential,
@@ -34,6 +35,21 @@ _retry_launch = retry(
     wait=wait_exponential(multiplier=2, min=2, max=30),
     reraise=True,
     retry=retry_if_not_exception_type(HealthCheckError),
+    before_sleep=before_sleep_log(logger, logging.WARNING),
+)
+
+# Docker Hub rate-limits anonymous pulls to 100/6h per IP; authenticated to 200/6h.
+# Retry with long exponential backoff so workers that share an IP spread their pulls
+# over time instead of all failing immediately and dying.
+# 6 attempts × (30 s → 5 min) ≈ up to ~15 min total — enough to clear a burst.
+_retry_pull = retry(
+    stop=stop_after_attempt(6),
+    wait=wait_exponential(multiplier=30, min=30, max=300),
+    retry=retry_if_exception(
+        lambda exc: isinstance(exc, docker.errors.APIError)
+        and any(kw in str(exc).lower() for kw in ("toomanyrequests", "rate limit", "429"))
+    ),
+    reraise=True,
     before_sleep=before_sleep_log(logger, logging.WARNING),
 )
 
@@ -168,7 +184,24 @@ class LocalContainerBackend(ContainerBackend):
     remove_on_close: bool = True
 
     def launch(self, config: ContainerConfig) -> LocalContainer:
+        # Pull is handled separately from container creation so the two retry
+        # policies don't nest: _retry_pull handles Docker Hub rate limits
+        # (long waits, rate-limit errors only); _retry_launch handles transient
+        # Docker daemon errors during container creation (short waits, all errors).
+        client = docker.from_env()
+        if self.pull_policy == "always" or (self.pull_policy == "missing" and not _image_exists(client, config.image)):
+            logger.info("Pulling image %s …", config.image)
+            try:
+                self._pull_image(client, config.image)
+            except docker.errors.APIError as exc:
+                # Convert only after _retry_pull has exhausted all attempts.
+                raise ContainerLaunchError(f"Failed to pull image '{config.image}': {exc}") from exc
         return self._launch_with_retry(config)
+
+    @_retry_pull
+    def _pull_image(self, client: docker.DockerClient, image: str) -> None:
+        # Raises docker.errors.APIError directly so _retry_pull can inspect it.
+        client.images.pull(image)
 
     @_retry_launch
     def _launch_with_retry(self, config: ContainerConfig) -> LocalContainer:
@@ -179,13 +212,6 @@ class LocalContainerBackend(ContainerBackend):
                 "disk_gb=%.1f ignored — Docker does not enforce disk limits at container level",
                 config.disk_gb,
             )
-
-        if self.pull_policy == "always" or (self.pull_policy == "missing" and not _image_exists(client, config.image)):
-            logger.info("Pulling image %s …", config.image)
-            try:
-                client.images.pull(config.image)
-            except docker.errors.APIError as exc:
-                raise ContainerLaunchError(f"Failed to pull image '{config.image}': {exc}") from exc
 
         kwargs: dict[str, Any] = {}
         kwargs["mem_limit"] = f"{int(config.ram_gb * 1024)}m"

--- a/src/cube/infra_local.py
+++ b/src/cube/infra_local.py
@@ -21,6 +21,7 @@ System requirements (Docker):
 
 from __future__ import annotations
 
+import fcntl
 import json
 import logging
 import os
@@ -56,26 +57,37 @@ _ACTIVE_JSON = Path(os.environ.get("CUBE_CACHE_DIR", str(Path.home() / ".cube"))
 def _load_active() -> dict:
     if not _ACTIVE_JSON.exists():
         return {}
-    with open(_ACTIVE_JSON) as f:
-        return json.load(f)
+    try:
+        with open(_ACTIVE_JSON) as f:
+            return json.load(f)
+    except (json.JSONDecodeError, ValueError, OSError):
+        return {}
 
 
 def _save_active(data: dict) -> None:
-    _ACTIVE_JSON.parent.mkdir(parents=True, exist_ok=True)
-    with open(_ACTIVE_JSON, "w") as f:
-        json.dump(data, f, indent=2)
+    tmp = _ACTIVE_JSON.with_suffix(".tmp")
+    tmp.write_text(json.dumps(data, indent=2))
+    tmp.replace(_ACTIVE_JSON)
 
 
 def _register_active(entry_id: str, entry: dict) -> None:
-    data = _load_active()
-    data[entry_id] = entry
-    _save_active(data)
+    _ACTIVE_JSON.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = _ACTIVE_JSON.with_suffix(".lock")
+    with open(lock_path, "w") as lock_fd:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        data = _load_active()
+        data[entry_id] = entry
+        _save_active(data)
 
 
 def _deregister_active(entry_id: str) -> None:
-    data = _load_active()
-    data.pop(entry_id, None)
-    _save_active(data)
+    _ACTIVE_JSON.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = _ACTIVE_JSON.with_suffix(".lock")
+    with open(lock_path, "w") as lock_fd:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        data = _load_active()
+        data.pop(entry_id, None)
+        _save_active(data)
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -270,6 +282,11 @@ class LocalDockerServiceHandle(ResourceHandle):
 
         from cube.backends.local import LocalContainer
 
+        # Podman advertises DOCKER_HOST with http+unix:// but the Docker SDK
+        # only accepts unix://. Normalize once before creating the client.
+        _host = os.environ.get("DOCKER_HOST", "")
+        if _host.startswith("http+unix://"):
+            os.environ["DOCKER_HOST"] = _host[len("http+") :]
         client = docker.from_env()
         docker_container = client.containers.get(self._container_ids[0])
         # remove_on_close=False — this handle, not the wrapper, owns the lifecycle.

--- a/src/cube/infra_local.py
+++ b/src/cube/infra_local.py
@@ -283,11 +283,13 @@ class LocalDockerServiceHandle(ResourceHandle):
         from cube.backends.local import LocalContainer
 
         # Podman advertises DOCKER_HOST with http+unix:// but the Docker SDK
-        # only accepts unix://. Normalize once before creating the client.
+        # only accepts unix://. Normalize locally rather than mutating os.environ
+        # (which would be a process-global side effect visible to other workers).
         _host = os.environ.get("DOCKER_HOST", "")
         if _host.startswith("http+unix://"):
-            os.environ["DOCKER_HOST"] = _host[len("http+") :]
-        client = docker.from_env()
+            client = docker.DockerClient(base_url=_host[len("http+") :])
+        else:
+            client = docker.from_env()
         docker_container = client.containers.get(self._container_ids[0])
         # remove_on_close=False — this handle, not the wrapper, owns the lifecycle.
         self._container_cache = LocalContainer(docker_container, client, remove_on_close=False)
@@ -652,65 +654,77 @@ class LocalInfraConfig(InfraConfig):
 
         # Clean up dead VM entries.
         if stale_ids:
-            data = _load_active()
-            for sid in stale_ids:
-                data.pop(sid, None)
-            _save_active(data)
+            _ACTIVE_JSON.parent.mkdir(parents=True, exist_ok=True)
+            lock_path = _ACTIVE_JSON.with_suffix(".lock")
+            with open(lock_path, "w") as lock_fd:
+                fcntl.flock(lock_fd, fcntl.LOCK_EX)
+                data = _load_active()
+                for sid in stale_ids:
+                    data.pop(sid, None)
+                _save_active(data)
 
         return handles
 
     def cleanup(self, run_id: str) -> None:
         """Kill all QEMU processes and remove overlays for run_id."""
-        data = _load_active()
-        to_remove = []
-        for entry_id, entry in list(data.items()):
-            if entry.get("run_id") != run_id:
-                continue
-            if entry.get("infra_fingerprint") != self.fingerprint():
-                continue
-            _kill_entry(entry)
-            to_remove.append(entry_id)
+        _ACTIVE_JSON.parent.mkdir(parents=True, exist_ok=True)
+        lock_path = _ACTIVE_JSON.with_suffix(".lock")
+        with open(lock_path, "w") as lock_fd:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            data = _load_active()
+            to_remove = []
+            for entry_id, entry in list(data.items()):
+                if entry.get("run_id") != run_id:
+                    continue
+                if entry.get("infra_fingerprint") != self.fingerprint():
+                    continue
+                _kill_entry(entry)
+                to_remove.append(entry_id)
 
-        for entry_id in to_remove:
-            data.pop(entry_id, None)
-        if to_remove:
-            _save_active(data)
-            logger.info("Cleaned up %d resource(s) for run %s", len(to_remove), run_id[:8])
+            for entry_id in to_remove:
+                data.pop(entry_id, None)
+            if to_remove:
+                _save_active(data)
+                logger.info("Cleaned up %d resource(s) for run %s", len(to_remove), run_id[:8])
 
     def cleanup_stale(self, max_age_seconds: int | None = None) -> list[str]:
         """Kill expired resources and resources older than max_age_seconds.
 
         Returns list of deleted entry_ids.
         """
-        data = _load_active()
-        now = datetime.utcnow()
-        to_remove = []
+        _ACTIVE_JSON.parent.mkdir(parents=True, exist_ok=True)
+        lock_path = _ACTIVE_JSON.with_suffix(".lock")
+        with open(lock_path, "w") as lock_fd:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            data = _load_active()
+            now = datetime.utcnow()
+            to_remove = []
 
-        for entry_id, entry in list(data.items()):
-            if entry.get("infra_fingerprint") != self.fingerprint():
-                continue
+            for entry_id, entry in list(data.items()):
+                if entry.get("infra_fingerprint") != self.fingerprint():
+                    continue
 
-            expired = False
-            expires_at_str = entry.get("expires_at")
-            if expires_at_str:
-                expired = datetime.fromisoformat(expires_at_str) < now
+                expired = False
+                expires_at_str = entry.get("expires_at")
+                if expires_at_str:
+                    expired = datetime.fromisoformat(expires_at_str) < now
 
-            too_old = False
-            if not expired and max_age_seconds is not None:
-                created_at_str = entry.get("created_at")
-                if created_at_str:
-                    age = (now - datetime.fromisoformat(created_at_str)).total_seconds()
-                    too_old = age > max_age_seconds
+                too_old = False
+                if not expired and max_age_seconds is not None:
+                    created_at_str = entry.get("created_at")
+                    if created_at_str:
+                        age = (now - datetime.fromisoformat(created_at_str)).total_seconds()
+                        too_old = age > max_age_seconds
 
-            if expired or too_old:
-                _kill_entry(entry)
-                to_remove.append(entry_id)
+                if expired or too_old:
+                    _kill_entry(entry)
+                    to_remove.append(entry_id)
 
-        for entry_id in to_remove:
-            data.pop(entry_id, None)
-        if to_remove:
-            _save_active(data)
-            logger.info("cleanup_stale: removed %d stale resource(s)", len(to_remove))
+            for entry_id in to_remove:
+                data.pop(entry_id, None)
+            if to_remove:
+                _save_active(data)
+                logger.info("cleanup_stale: removed %d stale resource(s)", len(to_remove))
 
         return to_remove
 

--- a/tests/test_infra_local.py
+++ b/tests/test_infra_local.py
@@ -8,6 +8,7 @@ daemon — subprocess.run is mocked wherever Docker calls would be made.
 from __future__ import annotations
 
 import json
+import threading
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -20,6 +21,7 @@ from cube.infra_local import (
     LocalInfraConfig,
     LocalResourceHandle,
     _kill_entry,
+    _register_active,
 )
 from cube.infra_utils import build_volume_setup_script
 from cube.resource import DockerServiceConfig, VolumeSpec
@@ -285,3 +287,138 @@ class TestLocalDockerServiceHandleClose:
             handle.close()
 
         assert "entry-1" not in json.loads(active_path.read_text())
+
+
+# ── Regression: concurrent active.json writes ────────────────────────────────
+
+
+class TestActiveLocking:
+    """Verify all active.json write paths hold the fcntl lock.
+
+    Each test starts N threads that all call the same write path simultaneously.
+    Without locking, rapid concurrent read-modify-writes reliably lose entries
+    under load; with the lock the final file must contain every registration.
+    """
+
+    def test_register_concurrent_writes_are_serialised(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        active_path = tmp_path / "active.json"
+        monkeypatch.setattr(_mod, "_ACTIVE_JSON", active_path)
+
+        n = 20
+        threads = [threading.Thread(target=_register_active, args=(f"id-{i}", {"v": i})) for i in range(n)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        result = json.loads(active_path.read_text())
+        assert len(result) == n, f"Expected {n} entries, got {len(result)}: {list(result.keys())}"
+
+    def test_cleanup_concurrent_writes_are_serialised(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        active_path = tmp_path / "active.json"
+        monkeypatch.setattr(_mod, "_ACTIVE_JSON", active_path)
+
+        n = 10
+        # Pre-populate some entries to clean up alongside concurrent registers.
+        for i in range(n):
+            _register_active(f"id-{i}", {"run_id": "run-x", "infra_fingerprint": "local"})
+
+        infra = LocalInfraConfig()
+        threads = [threading.Thread(target=infra.cleanup, args=("run-x",)) for _ in range(3)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        result = json.loads(active_path.read_text())
+        # All run-x entries must be gone; the file must still be valid JSON.
+        assert all(e.get("run_id") != "run-x" for e in result.values())
+
+    def test_cleanup_stale_concurrent_with_register(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        active_path = tmp_path / "active.json"
+        monkeypatch.setattr(_mod, "_ACTIVE_JSON", active_path)
+
+        # Pre-populate stale entries (expired in the past).
+        for i in range(5):
+            _register_active(
+                f"stale-{i}",
+                {
+                    "run_id": "run-stale",
+                    "infra_fingerprint": "local",
+                    "created_at": "2000-01-01T00:00:00",
+                    "expires_at": "2000-01-01T01:00:00",
+                },
+            )
+
+        infra = LocalInfraConfig()
+
+        # Simultaneously register new entries while cleanup_stale runs.
+        def register_many() -> None:
+            for i in range(5):
+                _register_active(f"fresh-{i}", {"run_id": "run-fresh", "infra_fingerprint": "local"})
+
+        t_register = threading.Thread(target=register_many)
+        t_cleanup = threading.Thread(target=infra.cleanup_stale)
+        t_register.start()
+        t_cleanup.start()
+        t_register.join()
+        t_cleanup.join()
+
+        # File must be valid JSON — no corruption from the race.
+        result = json.loads(active_path.read_text())
+        assert isinstance(result, dict)
+
+
+# ── Regression: Podman DOCKER_HOST normalisation ──────────────────────────────
+
+
+class TestPodmanDockerHostNormalisation:
+    """Verify DOCKER_HOST is not mutated when Podman's http+unix:// prefix is stripped."""
+
+    def test_environ_not_mutated_for_podman_host(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        original = "http+unix:///run/user/1000/podman/podman.sock"
+        monkeypatch.setenv("DOCKER_HOST", original)
+
+        import docker as _docker
+
+        mock_client = MagicMock()
+        mock_container = MagicMock()
+        mock_container.id = "cid-podman"
+        mock_client.containers.get.return_value = mock_container
+
+        with patch.object(_docker, "DockerClient", return_value=mock_client):
+            handle = LocalDockerServiceHandle(
+                run_id="run-p",
+                resource=DockerServiceConfig(name="svc", scope="task"),
+                infra=LocalInfraConfig(),
+                endpoint="http://127.0.0.1:7780",
+                created_at=datetime.utcnow(),
+                _entry_id="e-p",
+                _container_ids=["cid-podman"],
+            )
+            _ = handle.container
+
+        # os.environ must be unchanged — the normalisation is local to DockerClient().
+        import os
+
+        assert os.environ.get("DOCKER_HOST") == original
+
+
+# ── Regression: _pull_image creates a fresh DockerClient per retry ────────────
+
+
+class TestPullImageFreshClient:
+    """Verify _pull_image does not accept an external client that could be stale."""
+
+    def test_pull_image_signature_takes_no_client(self) -> None:
+        import inspect
+
+        from cube.backends.local import LocalContainerBackend
+
+        sig = inspect.signature(LocalContainerBackend._pull_image)
+        param_names = list(sig.parameters.keys())
+        # Only 'self' and 'image' — no 'client' parameter.
+        assert "client" not in param_names, (
+            "_pull_image must not accept an external client; it should create one internally "
+            "so each retry attempt gets a fresh connection."
+        )


### PR DESCRIPTION
## Summary

Three related fixes to `LocalInfraConfig` / `infra_local.py`:

- **Rate-limit retry**: `LocalContainerBackend` retries Docker Hub 429 errors with exponential backoff — removes the need for pre-pull loops in benchmark setup code
- **`active.json` concurrency fix**: `_register_active` / `_deregister_active` now use `fcntl.flock` + atomic `tmp → replace` writes; concurrent Ray workers at ≥12 parallelism were corrupting the file with simultaneous writes
- **Podman `DOCKER_HOST` normalization**: Podman sets `DOCKER_HOST=http+unix://…` but the Docker Python SDK only accepts `unix://`; strip the `http+` prefix in `LocalDockerServiceHandle` before calling `docker.from_env()`, so every downstream user gets this transparently without recipe-level workarounds

## Follow-up

The `flock` approach is correct but still serializes all workers through one lock. #129 tracks a simpler design: one file per run in `~/.cube/active/<run_id>.json`, which eliminates the lock entirely.

## Test plan

- [x] `active.json` corruption no longer observed at 12+ parallel Ray workers
- [x] Docker Hub rate-limit errors retry automatically instead of crashing
- [x] Podman users can run recipes without normalizing `DOCKER_HOST` themselves

🤖 Generated with [Claude Code](https://claude.com/claude-code)