### PR TITLE
fix(benchmark): walk MRO in _is_dynamic instead of any() (#127)

### DIFF
--- a/src/cube/benchmark.py
+++ b/src/cube/benchmark.py
@@ -329,11 +329,15 @@ class BenchmarkConfig[TTMetadata: TaskMetadata](TypedBaseModel, ABC):
         module_dir = Path(module_file).resolve().parent if module_file else None
 
         def _is_dynamic(name: str) -> bool:
-            """True iff *name* is declared as a ``@property`` somewhere in the MRO
-            below ``BenchmarkConfig`` — meaning the attribute is computed at access
-            time and should not be overwritten with a file-loaded ClassVar value.
+            """True iff the nearest definition of *name* in the MRO is a ``@property``
+            — meaning the attribute is computed at access time and should not be
+            overwritten with a file-loaded ClassVar value. A subclass ClassVar that
+            shadows a parent ``@property`` is treated as static.
             """
-            return any(isinstance(klass.__dict__.get(name), property) for klass in cls.__mro__)
+            for klass in cls.__mro__:
+                if name in klass.__dict__:
+                    return isinstance(klass.__dict__[name], property)
+            return False
 
         # ── benchmark_metadata ───────────────────────────────────────────────
         if not _is_dynamic("benchmark_metadata"):

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -119,6 +119,52 @@ def test_missing_task_config_class_raises():
             # missing: task_config_class
 
 
+def test_classvar_override_of_parent_property_is_validated():
+    """A subclass that shadows a parent ``@property`` with a ClassVar must be
+    *validated* — the parent's property must not bleed through and skip the
+    type-check branch in ``__init_subclass__``.
+
+    ``_is_dynamic`` has to look at the *nearest* definition in the MRO, not
+    ``any()`` over the whole chain; otherwise an invalid ClassVar on the
+    child slips past validation.
+    """
+
+    class _DynamicParent(BenchmarkConfig):
+        task_config_class = _TaskConfig
+        benchmark_class = MyBenchmark
+
+        @property
+        def benchmark_metadata(self) -> BenchmarkMetadata:  # type: ignore[override]
+            return BenchmarkMetadata(name="dynamic", version="0", description="computed")
+
+        @property
+        def task_metadata(self) -> dict[str, TaskMetadata]:  # type: ignore[override]
+            return {}
+
+    # An invalid ClassVar override on the child must be rejected — proves the
+    # validation branch ran instead of being skipped because of the parent's
+    # ``@property``.
+    with pytest.raises(TypeError, match="benchmark_metadata"):
+
+        class _BadStaticChild(_DynamicParent):  # noqa: F841
+            benchmark_metadata = "not a BenchmarkMetadata"  # type: ignore[assignment]
+            task_metadata = {"s1": TaskMetadata(id="s1")}
+
+    # A valid ClassVar override must be accepted, and the ClassVar value must
+    # surface on the class.
+    class _StaticChild(_DynamicParent):
+        benchmark_metadata = BenchmarkMetadata(name="static", version="1", description="x")
+        task_metadata = {"s1": TaskMetadata(id="s1")}
+
+    assert _StaticChild.benchmark_metadata.name == "static"
+    assert "s1" in _StaticChild.task_metadata
+
+    # Grandchild that adds nothing must inherit the child's ClassVars cleanly,
+    # i.e. validation walks the MRO and stops at ``_StaticChild``.
+    class _StaticGrandchild(_StaticChild):  # noqa: F841
+        pass
+
+
 # ── tasks() view (ClassVar filtered by task_ids) ──────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- `_is_dynamic` in `BenchmarkConfig.__init_subclass__` used `any(... for klass in cls.__mro__)`, so a parent's `@property` made the attribute look dynamic even when a child shadowed it with a `ClassVar` — silently skipping the file-load / type-check branch.
- Walk the MRO and return based on the *nearest* definition (parent property + child ClassVar → static, as it should be).
- Adds a regression test that an invalid ClassVar override on a child of a class with `@property benchmark_metadata` is rejected (test fails on the buggy code, passes on the fix).

Closes #127.

> Stacked on #124 (`nico_fix`). Re-target to `main` once #124 lands.

## Test plan
- [x] `uv run pytest tests/test_benchmark.py` — 34 passed
- [x] `make lint` — clean
- [x] Verified the new regression test fails without the fix and passes with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)