### PR TITLE
docs: clarify ruff two-step lint rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,9 +110,17 @@ never live in cube-harness.** Full rule: [tool/spec.md § Packaging conventions]
 
 Active proposals: `openspec/changes/`. Archived: `openspec/changes/archive/`.
 
-## Testing
+## Testing and linting
 
-`make lint` and `make test`. For benchmark debug suite: `cube test <benchmark-name>`.
+```bash
+make lint               # uv run ruff check --fix && uv run ruff format  (auto-fixes in place)
+make lint-check         # uv run ruff check --diff && uv run ruff format --diff  (read-only, what CI runs)
+make test               # uv run pytest -n 10
+cube test <benchmark>   # benchmark debug suite
+```
+
+Always run `make lint` before finishing a task. `ruff check` and `ruff format` are
+**separate passes** — running only one is not enough for CI.
 
 ### Test categories
 


### PR DESCRIPTION
## Summary

- Documents that `make lint-check` (what CI runs) is distinct from `make lint` — both listed with inline descriptions in a new commands block
- Adds an explicit linting rule explaining that `ruff check` and `ruff format` are two separate passes; running only `ruff check` misses formatting failures
- Expands the former one-liner Testing section into a proper "Testing and linting" section

## Root cause this addresses

Nearly every PR hit a ruff CI failure because the dev workflow ran `uv run ruff check` (lint only) while CI runs `make lint-check` which also runs `ruff format --diff`. Long lines and other formatting issues pass `ruff check` silently and only blow up in CI.

cc @amanjaiswal73892

🤖 Generated with [Claude Code](https://claude.com/claude-code)