### PR TITLE
fix(task): auto-include STOP_ACTION in action_set when accept_agent_stop=True

### DIFF
--- a/openspec/changes/stop-action-auto-include/deltas.md
+++ b/openspec/changes/stop-action-auto-include/deltas.md
@@ -1,0 +1,74 @@
+# Deltas — auto-include `STOP_ACTION` in `Task.action_set`
+
+**Targets:** `openspec/specs/task/spec.md`
+
+## MODIFIED — `STOP_ACTION` carries a valid empty-object schema
+
+**Spec:** task
+
+The `STOP_ACTION` module constant gains a non-empty `parameters` schema:
+
+```python
+STOP_ACTION = ActionSchema(
+    name="final_step",
+    description="Stop the task execution.",
+    parameters={"type": "object", "properties": {}},
+)
+```
+
+The schema is the minimal payload that satisfies Anthropic's
+`input_schema` requirement (`{"type": "object", ...}`). LiteLLM
+passes `parameters` through verbatim — an empty dict (the previous value)
+makes Anthropic-backed agents fail at the LLM call. Every cube currently
+hand-rolls this same schema in a `filter_actions` override; the constant
+now ships with it.
+
+## ADDED — `Task.action_set` auto-appends `STOP_ACTION`
+
+**Spec:** task
+
+```python
+@property
+def action_set(self) -> list[ActionSchema]:
+    actions = self.filter_actions(self.tool.action_set)
+    if self.accept_agent_stop and not any(a.name == STOP_ACTION.name for a in actions):
+        actions = [*actions, STOP_ACTION]
+    return actions
+```
+
+When `self.accept_agent_stop` is `True` (the default), the property
+appends `STOP_ACTION` to whatever `filter_actions()` returns, unless an
+action with the same name is already present. The dedup branch keeps
+existing `filter_actions` overrides that append `STOP_ACTION` working
+during the transition.
+
+Couples the `accept_agent_stop` flag — which already gates the
+termination branch in `Task.step()` — to action-set visibility:
+*if the agent is allowed to stop, the agent sees the stop action.*
+
+## MODIFIED — `filter_actions` no longer responsible for `STOP_ACTION`
+
+**Spec:** task
+
+```python
+def filter_actions(self, actions: list[ActionSchema]) -> list[ActionSchema]:
+    """(Optional) Whitelist subset of tool actions.
+    By default keeps all tool actions. STOP_ACTION is appended automatically
+    by action_set when accept_agent_stop=True — do not add it here.
+    """
+    return actions
+```
+
+## REMOVED — "STOP_ACTION is not automatically in the tool's action set" gotcha
+
+**Spec:** task
+
+The Gotchas bullet:
+
+> STOP_ACTION is not automatically in the tool's action set — the harness
+> / agent framework is responsible for including it in the action list
+> shown to the LLM.
+
+is removed. Replaced by the contract described above and a positive
+statement in the `STOP_ACTION` section that the base class auto-includes
+it when `accept_agent_stop=True`.

--- a/openspec/changes/stop-action-auto-include/proposal.md
+++ b/openspec/changes/stop-action-auto-include/proposal.md
@@ -1,0 +1,101 @@
+# Auto-include `STOP_ACTION` in `Task.action_set`
+
+**Status:** Proposed
+**Date:** 2026-05-13
+**Scope:** `cube.task`
+**Targets:** cube-standard PR #139
+
+## Problem
+
+Two coupled gaps in the current contract force every cube author to write
+the same workaround:
+
+1. `STOP_ACTION` is defined as
+   `ActionSchema(name="final_step", description="Stop the task execution.")`
+   with no `parameters`. LiteLLM passes the empty `parameters` dict through
+   verbatim. Anthropic's API rejects an `input_schema` that is not
+   `{"type": "object", ...}`, so any cube that surfaces `STOP_ACTION` to a
+   Claude-backed agent fails at the LLM call.
+
+2. The spec says (`openspec/specs/task/spec.md` Gotchas):
+   > STOP_ACTION is not automatically in the tool's action set — the harness
+   > / agent framework is responsible for including it in the action list
+   > shown to the LLM.
+
+   But `Task.step()` already treats `STOP_ACTION` specially when
+   `accept_agent_stop=True` (it terminates the task without dispatching to
+   the tool). So the action exists in the protocol — the agent just has to
+   guess that it is callable, since `action_set` doesn't declare it.
+
+Cube authors work around (1) and (2) together by overriding
+`filter_actions()` to append a hand-rolled `ActionSchema` with the
+Anthropic-compatible empty-object schema. `swebench-verified-cube` and
+`swebench-live-cube` carry identical overrides; every new cube that wants
+agent stop hits the same wall.
+
+## Solution
+
+Move both fixes into the base class:
+
+1. **`STOP_ACTION` carries a valid empty-object schema** —
+   `parameters={"type": "object", "properties": {}}`. Same payload every
+   cube was hand-rolling, now centralised.
+
+2. **`Task.action_set` auto-appends `STOP_ACTION`** when
+   `self.accept_agent_stop` is `True` and the action is not already
+   present. This closes the loop: the field that controls *whether* the
+   agent can stop also controls *whether* the agent sees the stop action.
+   The dedup branch keeps existing overrides working through the
+   transition.
+
+3. **`filter_actions` docstring** explicitly tells future cube authors not
+   to re-add `STOP_ACTION`.
+
+## Backwards compatibility
+
+- Cubes whose `filter_actions` still appends `STOP_ACTION` (the existing
+  workaround) keep working — the new code dedupes by name. The override
+  can be deleted in a follow-up cleanup PR but is not load-bearing.
+- Cubes that set `accept_agent_stop=False` see no change: `action_set`
+  does not include `STOP_ACTION` and `step()` does not handle it.
+- Default `Task` instances (`accept_agent_stop=True`, no `filter_actions`
+  override) now expose `STOP_ACTION` where they previously did not. This
+  is the intended behavior change: the agent can in fact stop these
+  tasks; `action_set` now reflects that.
+
+**Downstream coordination (cube-harness):** several agents in cube-harness
+(`legacy_generic_agent`, `react`, `genny2`) unconditionally append
+`STOP_ACTION` to whatever `action_set` they receive from the task. With
+this change, tasks that previously did not expose `STOP_ACTION` now do,
+so those agents will produce a duplicate `final_step` tool definition in
+the LLM tool list. A follow-up cube-harness PR should drop the manual
+appends (or dedupe on receipt). Today this duplicate already exists for
+the two SWE-bench cubes; this change widens it to every cube with
+`accept_agent_stop=True` until the cube-harness agents are updated.
+
+## Migration
+
+**This PR (cube-standard):**
+
+- `cube.task`: extend `STOP_ACTION` with the empty-object schema; auto-
+  append in `Task.action_set` when `accept_agent_stop=True` with dedup;
+  update the `filter_actions` and `action_set` docstrings.
+- Realign `openspec/specs/task/spec.md`: invert the "not automatically in
+  the action set" gotcha; document the new `Task.action_set` contract;
+  note the schema on the `STOP_ACTION` constant.
+- `tests/test_server.py::test_tools_list` updated — the task server now
+  surfaces `final_step` alongside the tool's own actions.
+- 5 new tests in `tests/test_task.py` (default includes, disabled
+  excludes, dedup, schema, regression on `test_task_action_set_comes_from_tool`).
+
+**Follow-up PRs (out of scope here):**
+
+- cube-harness: remove the manual `STOP_ACTION` append in
+  `legacy_generic_agent.py`, `react.py`, `genny2.py` so the LLM tool list
+  doesn't carry a duplicate `final_step` entry. Alternatively dedup on
+  receipt.
+- swebench-verified-cube, swebench-live-cube: delete the
+  `filter_actions` override entirely. The base class now does the right
+  thing.
+
+See [deltas.md](deltas.md) for the spec changes.

--- a/openspec/specs/task/spec.md
+++ b/openspec/specs/task/spec.md
@@ -126,11 +126,36 @@ Returns `EnvironmentOutput(obs, reward, done, info, error)`. `truncated` is alwa
 
 ### `STOP_ACTION` (module-level constant)
 ```python
-STOP_ACTION = ActionSchema(name="final_step", description="Stop the task execution.")
+STOP_ACTION = ActionSchema(
+    name="final_step",
+    description="Stop the task execution.",
+    parameters={"type": "object", "properties": {}},
+)
 ```
 Protocol for agent-initiated termination. Tasks that reject it must set
 `accept_agent_stop = False` (e.g., tasks that require the agent to reach a terminal
 state via environment interaction, not a self-declaration).
+
+`Task.action_set` auto-appends `STOP_ACTION` whenever `accept_agent_stop=True`
+(deduping by name), so cube authors do not re-add it in `filter_actions`. The
+non-empty `parameters` schema is the minimal payload Anthropic accepts for
+`input_schema`; LiteLLM passes it through verbatim.
+
+### `Task.action_set` (concrete property)
+
+```python
+@property
+def action_set(self) -> list[ActionSchema]:
+    actions = self.filter_actions(self.tool.action_set)
+    if self.accept_agent_stop and not any(a.name == STOP_ACTION.name for a in actions):
+        actions = [*actions, STOP_ACTION]
+    return actions
+```
+
+Returns the action schemas the agent should see. Runs `filter_actions()`
+first, then appends `STOP_ACTION` when `accept_agent_stop=True` unless an
+action with that name is already present. The dedup branch keeps legacy
+`filter_actions` overrides that still append `STOP_ACTION` working.
 
 ### `RuntimeContext`
 ```python
@@ -246,7 +271,9 @@ always retains the native un-prefixed id.
    `evaluate`, `filter_actions`, `obs_postprocess`, `finished`.
 3. Tool is built eagerly in `model_post_init` — once a Task is constructed, its tool is live.
 4. `accept_agent_stop=True` (default) means the agent can self-terminate via
-   `Action(name="final_step")`. Evaluate is called on termination.
+   `Action(name="final_step")`. `Task.action_set` auto-appends `STOP_ACTION`
+   in this case (dedup by name); `step()` recognises it and calls
+   `evaluate()` on termination.
 5. `info["profiling"]` is always populated after `step()` unless no actions ran (empty list).
 
 ## Contracts for implementers
@@ -282,8 +309,9 @@ always retains the native un-prefixed id.
   instantiation).
 - `validate_per_step=True` means `evaluate()` runs every step — expensive. Default is
   only on termination.
-- STOP_ACTION is not automatically in the tool's action set — the harness / agent
-  framework is responsible for including it in the action list shown to the LLM.
+- `filter_actions` overrides MUST NOT append `STOP_ACTION` — `Task.action_set`
+  does it automatically when `accept_agent_stop=True`. Manual appends still
+  work (dedup by name) but are redundant and should be removed.
 - `runtime_context` is a dict, not a Pydantic model — no type safety. Document keys
   in your `Benchmark._setup()` docstring.
 - `model_post_init` launches the container. If your ToolConfig `make()` fails and

--- a/src/cube/task.py
+++ b/src/cube/task.py
@@ -51,7 +51,11 @@ example:
 logger = logging.getLogger(__name__)
 
 
-STOP_ACTION = ActionSchema(name="final_step", description="Stop the task execution.")
+STOP_ACTION = ActionSchema(
+    name="final_step",
+    description="Stop the task execution.",
+    parameters={"type": "object", "properties": {}},
+)
 
 
 class TaskMetadata(TypedBaseModel):
@@ -250,12 +254,16 @@ class Task[TTMetadata: TaskMetadata](TypedBaseModel, ABC):
             }
         ]
         """
-        return self.filter_actions(self.tool.action_set)
+        actions = self.filter_actions(self.tool.action_set)
+        if self.accept_agent_stop and not any(a.name == STOP_ACTION.name for a in actions):
+            actions = [*actions, STOP_ACTION]
+        return actions
 
     def filter_actions(self, actions: list[ActionSchema]) -> list[ActionSchema]:
         """
-        (Optional) Allows the task to whitelist subset of all the actions provided by the tool.
-        By default filters nothing, keep all tool actions.
+        (Optional) Allows the task to whitelist a subset of the actions provided by the tool.
+        By default keeps all tool actions. STOP_ACTION is appended automatically by
+        action_set when accept_agent_stop=True — do not add it here.
         """
         return actions
 

--- a/src/cube/task.py
+++ b/src/cube/task.py
@@ -225,7 +225,10 @@ class Task[TTMetadata: TaskMetadata](TypedBaseModel, ABC):
     @property
     def action_set(self) -> List[ActionSchema]:
         """
-        Returns tool.action_set filtered if self.filter_actions() is implemented.
+        Returns tool.action_set filtered through self.filter_actions(), then with
+        STOP_ACTION appended when self.accept_agent_stop is True (dedup by name).
+        Cube authors should NOT add STOP_ACTION in filter_actions.
+
         Tool definitions in litellm-compatible format.
 
         Returns a JSON-serializable list of tool descriptors, each with:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -224,7 +224,9 @@ def test_tools_list(task_client):
     resp = _rpc(task_client, "tools/list")
     assert resp.status_code == 200
     names = {t["name"] for t in resp.json()["result"]}
-    assert names == {"increment", "get_value"}
+    # `final_step` is STOP_ACTION, auto-appended by Task.action_set when
+    # accept_agent_stop=True (the default).
+    assert names == {"increment", "get_value", "final_step"}
 
 
 def test_reset(task_client):

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -99,7 +99,37 @@ def test_task_validate_per_step_triggers_evaluate():
 
 def test_task_action_set_comes_from_tool():
     names = {a.name for a in make_task().action_set}
-    assert names == {"greet", "fail"}
+    assert names == {"greet", "fail", STOP_ACTION.name}
+
+
+def test_task_action_set_includes_stop_action_by_default() -> None:
+    task = make_task()
+    stop_schemas = [a for a in task.action_set if a.name == STOP_ACTION.name]
+    assert len(stop_schemas) == 1
+    assert stop_schemas[0].parameters == {"type": "object", "properties": {}}
+
+
+def test_task_action_set_excludes_stop_action_when_disabled() -> None:
+    task = make_task(accept_agent_stop=False)
+    names = {a.name for a in task.action_set}
+    assert STOP_ACTION.name not in names
+
+
+def test_task_action_set_stop_action_not_duplicated_if_filter_adds_it() -> None:
+    class TaskWithFilterStop(SimpleTask):
+        def filter_actions(self, actions):
+            return [*actions, STOP_ACTION]
+
+    task = TaskWithFilterStop(
+        metadata=TaskMetadata(id="t"),
+        tool_config=GreetToolConfig(),
+    )
+    stop_count = sum(1 for a in task.action_set if a.name == STOP_ACTION.name)
+    assert stop_count == 1
+
+
+def test_stop_action_parameters_valid_empty_schema() -> None:
+    assert STOP_ACTION.parameters == {"type": "object", "properties": {}}
 
 
 # --- TaskExecutionInfo ---


### PR DESCRIPTION
## Summary

- `STOP_ACTION` constant gains `parameters={"type":"object","properties":{}}` — Anthropic's API rejects an empty schema object, so every cube currently has to re-define `STOP_ACTION` with this schema in a `filter_actions` override.
- `Task.action_set` appends `STOP_ACTION` automatically when `accept_agent_stop=True` (the default), idempotent — deduplicates if `filter_actions` already included it.
- `filter_actions` docstring updated to note it should not add `STOP_ACTION`.
- `openspec/changes/stop-action-auto-include/` carries the proposal + deltas for the spec change. `openspec/specs/task/spec.md` is updated in this PR (new `Task.action_set` section, updated `STOP_ACTION` block, inverted Gotcha).

**Before:** every cube that wanted agents to be able to stop had to override `filter_actions` with a duplicate definition of STOP_ACTION. Two cubes (swebench-verified, swebench-live) carried identical workarounds.

**After:** the base class does the right thing. Both cube `filter_actions` overrides can be deleted once this lands.

## Downstream follow-up

cube-harness agents (`legacy_generic_agent`, `react`, `genny2`) currently append `STOP_ACTION` unconditionally to whatever `action_set` they receive. With this change, tasks that previously did not expose `STOP_ACTION` (everything with `accept_agent_stop=True` and no `filter_actions` override) now do — those agents will surface a duplicate `final_step` tool definition to the LLM until they are updated to dedup or drop the manual append. Today this duplicate already exists for the two SWE-bench cubes; this PR widens it. Follow-up PR in cube-harness is tracked in the change proposal.

## Test plan

- [x] All existing `test_task.py` tests pass
- [x] 5 new tests in `test_task.py`: default includes STOP_ACTION, disabled excludes it, dedup, schema assertion, tool-names regression
- [x] `test_server.py::test_tools_list` updated — task server now surfaces `final_step` alongside the tool's own actions

🤖 Generated with [Claude Code](https://claude.ai/claude-code)