### PR TITLE
fix(tool): return recoverable Observation for bad-argument tool calls

### DIFF
--- a/src/cube/tool.py
+++ b/src/cube/tool.py
@@ -336,13 +336,29 @@ class Tool(_ToolActionsMixin, AbstractTool):
     """
 
     def execute_action(self, action: Action) -> Observation | StepError:
-        """Execute an action by name."""
+        """Execute an action by name.
+
+        Argument-binding errors (wrong argument name, missing required argument)
+        are returned as error Observations so the agent can recover. Any exception
+        raised *inside* the method body is treated as a fatal infrastructure error
+        and returned as a StepError, terminating the episode.
+        """
         method = self.get_action_method(action)
         try:
-            action_result = method(**action.arguments) or "Success"
+            bound = inspect.signature(method).bind(**action.arguments)
+        except TypeError as e:
+            return Observation(
+                contents=[
+                    Content.from_data(
+                        f"Bad arguments for {action.name}: {e}",
+                        tool_call_id=action.id,
+                    )
+                ]
+            )
+        try:
+            action_result = method(*bound.args, **bound.kwargs) or "Success"
         except Exception as e:
-            action_result = f"Error executing action {action.name}: {e}"
-            logger.exception(action_result)
+            logger.exception("action %s raised an unexpected error", action.name)
             return StepError.from_exception(e)
         return Observation(contents=[Content.from_data(action_result, tool_call_id=action.id)])
 
@@ -386,13 +402,27 @@ class AsyncTool(_ToolActionsMixin, AbstractAsyncTool):
                 )
 
     async def execute_action(self, action: Action) -> Observation | StepError:
-        """Execute an async action by name."""
+        """Execute an async action by name.
+
+        Argument-binding errors are returned as error Observations (recoverable).
+        Exceptions from inside the method body are fatal StepErrors.
+        """
         method = self.get_action_method(action)
         try:
-            action_result = (await method(**action.arguments)) or "Success"
+            bound = inspect.signature(method).bind(**action.arguments)
+        except TypeError as e:
+            return Observation(
+                contents=[
+                    Content.from_data(
+                        f"Bad arguments for {action.name}: {e}",
+                        tool_call_id=action.id,
+                    )
+                ]
+            )
+        try:
+            action_result = (await method(*bound.args, **bound.kwargs)) or "Success"
         except Exception as e:
-            action_result = f"Error executing action {action.name}: {e}"
-            logger.exception(action_result)
+            logger.exception("action %s raised an unexpected error", action.name)
             return StepError.from_exception(e)
         return Observation(contents=[Content.from_data(action_result, tool_call_id=action.id)])
 

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -130,6 +130,21 @@ def test_tool_execute_action_exception_returns_step_error():
     assert result.exception_str == "intentional error"
 
 
+def test_tool_execute_action_missing_required_arg_returns_observation() -> None:
+    """Missing required argument → recoverable error Observation, not StepError."""
+    result = EchoTool().execute_action(Action(name="echo", arguments={}))
+    assert isinstance(result, Observation)
+    assert "Bad arguments" in result.contents[0].data
+    assert "echo" in result.contents[0].data
+
+
+def test_tool_execute_action_unknown_kwarg_returns_observation() -> None:
+    """Unknown keyword argument → recoverable error Observation, not StepError."""
+    result = EchoTool().execute_action(Action(name="echo", arguments={"text": "hi", "typo": "x"}))
+    assert isinstance(result, Observation)
+    assert "Bad arguments" in result.contents[0].data
+
+
 # ── AsyncTool ─────────────────────────────────────────────────────────────────
 
 
@@ -188,6 +203,23 @@ async def test_async_tool_execute_action_exception_returns_step_error():
     assert isinstance(result, StepError)
     assert result.error_type == "RuntimeError"
     assert result.exception_str == "intentional error"
+
+
+@pytest.mark.asyncio
+async def test_async_tool_missing_required_arg_returns_observation() -> None:
+    """Missing required argument → recoverable error Observation, not StepError."""
+    result = await AsyncEchoTool().execute_action(Action(name="echo", arguments={}))
+    assert isinstance(result, Observation)
+    assert "Bad arguments" in result.contents[0].data
+    assert "echo" in result.contents[0].data
+
+
+@pytest.mark.asyncio
+async def test_async_tool_unknown_kwarg_returns_observation() -> None:
+    """Unknown keyword argument → recoverable error Observation, not StepError."""
+    result = await AsyncEchoTool().execute_action(Action(name="echo", arguments={"text": "hi", "typo": "x"}))
+    assert isinstance(result, Observation)
+    assert "Bad arguments" in result.contents[0].data
 
 
 def test_async_tool_rejects_sync_action_at_class_definition():


### PR DESCRIPTION
## Summary

`Tool.execute_action` and `AsyncTool.execute_action` now distinguish two failure modes:

| Failure | Cause | Before | After |
|---|---|---|---|
| Bad arguments (wrong name, missing required) | LLM call shape error | `StepError` → episode terminates | `Observation` with error message → agent retries |
| Exception inside method body | Tool/infra failure | `StepError` → episode terminates | unchanged |

**How it works:** `inspect.signature(method).bind(**args)` is called before the method runs. A `TypeError` at bind-time is unambiguously a call-shape error — the method body never ran, so no side effects, nothing fatal. Method-body exceptions stay fatal (safe-by-default preserved).

**Why it matters:** An LLM emitting `bash({})` (missing the required `command` arg) previously crashed the episode with a `StepError`, wasting $0.60–$3.00 of compute. After this fix it gets back `"Bad arguments for bash: missing required argument 'command'"` and can retry.

Tool authors don't need to change anything. The only behavior change is that argument-shape errors become recoverable.

## Test plan

- [ ] 4 new tests (2 sync, 2 async): missing required arg → Observation, unknown kwarg → Observation
- [ ] Existing crash test still returns `StepError` for method-body exceptions

🤖 Generated with [Claude Code](https://claude.ai/claude-code)