### PR TITLE
feat(tools/terminal): add normalize_ms_timeout config flag

### DIFF
--- a/src/cube/tools/terminal.py
+++ b/src/cube/tools/terminal.py
@@ -135,6 +135,10 @@ class TerminalToolConfig(ToolConfig):
         max_timeout: Optional ceiling (seconds) applied to every ``bash()``
             call. Prevents agents from requesting arbitrarily long timeouts.
             ``None`` means no cap.
+        normalize_ms_timeout: When ``True``, timeout values > 3600 are
+            divided by 1000 before use. Compensates for LLMs that pass
+            milliseconds instead of seconds (observed with some models on
+            TerminalBench-style tasks). Applied before ``max_timeout`` cap.
     """
 
     working_dir: str = "/app"
@@ -143,6 +147,7 @@ class TerminalToolConfig(ToolConfig):
     output_format: Literal["plain", "returncode_envelope"] = "plain"
     enable_file_actions: bool = False
     max_timeout: int | None = None
+    normalize_ms_timeout: bool = False
 
     def make(self, container: Container | None = None) -> "TerminalTool":
         if container is None:
@@ -201,6 +206,8 @@ class TerminalTool(Tool):
             timeout: Wall-clock seconds (not milliseconds). Default 120s. Use
                 larger values (600–1800) for test suites or builds.
         """
+        if self._config.normalize_ms_timeout and timeout > 3600:
+            timeout = timeout // 1000
         if self._config.max_timeout is not None:
             timeout = min(timeout, self._config.max_timeout)
         result = self._container.exec(

--- a/tests/test_terminal_tool.py
+++ b/tests/test_terminal_tool.py
@@ -396,3 +396,44 @@ class TestMaxTimeout:
         tool.bash("sleep 1", timeout=1800)
         _, kwargs = container.exec.call_args
         assert kwargs["timeout"] == 1800
+
+
+# ---------------------------------------------------------------------------
+# TerminalToolConfig.normalize_ms_timeout
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeMsTimeout:
+    def test_ms_timeout_converted(self) -> None:
+        """LLM passes 120000 (ms); normalize_ms_timeout=True divides by 1000."""
+        container = MagicMock()
+        container.exec.return_value = ExecResult(stdout="ok", stderr="", exit_code=0)
+        tool = TerminalTool(config=TerminalToolConfig(normalize_ms_timeout=True), container=container)
+        tool.bash("echo ok", timeout=120_000)
+        _, kwargs = container.exec.call_args
+        assert kwargs["timeout"] == 120
+
+    def test_ms_timeout_not_converted_when_disabled(self) -> None:
+        container = MagicMock()
+        container.exec.return_value = ExecResult(stdout="ok", stderr="", exit_code=0)
+        tool = TerminalTool(config=TerminalToolConfig(normalize_ms_timeout=False), container=container)
+        tool.bash("echo ok", timeout=120_000)
+        _, kwargs = container.exec.call_args
+        assert kwargs["timeout"] == 120_000
+
+    def test_reasonable_timeout_unchanged(self) -> None:
+        container = MagicMock()
+        container.exec.return_value = ExecResult(stdout="ok", stderr="", exit_code=0)
+        tool = TerminalTool(config=TerminalToolConfig(normalize_ms_timeout=True), container=container)
+        tool.bash("sleep 5", timeout=60)
+        _, kwargs = container.exec.call_args
+        assert kwargs["timeout"] == 60
+
+    def test_ms_normalize_applied_before_max_timeout_cap(self) -> None:
+        """normalize_ms_timeout runs before max_timeout: 1_800_000 ms → 1800s → capped at 900."""
+        container = MagicMock()
+        container.exec.return_value = ExecResult(stdout="ok", stderr="", exit_code=0)
+        tool = TerminalTool(config=TerminalToolConfig(normalize_ms_timeout=True, max_timeout=900), container=container)
+        tool.bash("sleep 1", timeout=1_800_000)
+        _, kwargs = container.exec.call_args
+        assert kwargs["timeout"] == 900


### PR DESCRIPTION
## Summary

Adds `normalize_ms_timeout: bool = False` to `TerminalToolConfig`. When enabled, `bash()` timeout values > 3600 are divided by 1000 before use — compensating for models that pass milliseconds instead of seconds.

- Applied before `max_timeout` cap (order: normalize → cap → exec)
- Default False — no change to existing behaviour
- Eliminates the need for cube-specific `TerminalTool` subclasses to override `bash()` for this normalization (TerminalBench was the driver)

## Test plan

- [x] 4 new tests in `TestNormalizeMsTimeout` covering: conversion, disabled, unchanged reasonable value, interaction with `max_timeout`
- [x] `make lint` clean
- [x] 51/51 `tests/test_terminal_tool.py` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)