### PR TITLE
docs(tools): document packaging conventions for generalist tools

### DIFF
--- a/.claude/skills/new-cube/references/shared-packages.md
+++ b/.claude/skills/new-cube/references/shared-packages.md
@@ -57,8 +57,13 @@ class MyCubeVMBackend(LocalDockerVMBackend):
         ...
 ```
 
+## Where new tool code lives (cube-developer rule)
+
+If you build a **cube-specific** tool (one whose only consumer is your benchmark), it lives in your cube package — typically by subclassing a generalist tool from `cube-tools/`. If you build something **generalist** (reusable across cubes), it belongs in `cube-standard` — either in `src/cube/tools/` (no extra deps) or as a new `cube-tools/cube-<name>-tool/` sub-package (heavy deps). **Never put tool code in `cube-harness`.** See [`openspec/specs/tool/spec.md` § Packaging conventions](../../../../openspec/specs/tool/spec.md#packaging-conventions) for the authoritative rule. When in doubt, raise it during the Reflect phase.
+
 ## Anti-patterns
 
 - Don't fork these packages into the user's cube. Use them as dependencies.
 - Don't reimplement `AbstractBrowserTool` — inherit from `SyncPlaywrightTool` or compose.
 - Don't build your own VM backend unless you truly need a different hypervisor.
+- Don't put generalist tool code in `cube-harness`. It belongs in `cube-standard`.

--- a/.claude/skills/review-cube/references/checks.md
+++ b/.claude/skills/review-cube/references/checks.md
@@ -47,6 +47,7 @@ Detect which the cube uses by grepping the benchmark module for the ClassVar ass
 - Heavy per-task data (problem statements, patches, archives, evaluator scripts, …) appears as fields on a `TaskMetadata` subclass instead of on a typed `TaskExecutionInfo` subclass surfaced via `Task.execution_info`. Heavy data must live on `TaskExecutionInfo`, not `TaskMetadata`.
 
 **Suggestions:**
+- S-75: Tool code in `tool.py` reimplements a surface that an existing `cube-tools/*` package already provides (browser navigation, mouse/keyboard, web search, …) instead of importing/subclassing it. Per [`openspec/specs/tool/spec.md` § Packaging conventions](../../../../openspec/specs/tool/spec.md#packaging-conventions), generalist tools live in `cube-standard`; cubes consume or subclass them. If the cube needs a new generalist primitive, raise it for upstream rather than embedding it here.
 - S-75: `Task.reset()` has no visible call to `self.tool.reset()`.
 - S-75: `Task.evaluate()` appears to mutate state (writes to `self.tool._env.*`, calls tool action methods, writes to `self._runtime_context`). `evaluate()` must be pure.
 - S-75: `_setup()` / `install()` / `close()` appear non-idempotent (no early-return guard, no `if self._already_setup: return`, destructive ops unconditionally).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,16 +60,22 @@ src/cube/                       Core framework
 ├── resource.py                 L1/L2/L3 resource lifecycle
 ├── container.py                Single-container abstraction
 ├── backends/                   Docker, Modal, Daytona, Toolkit backends
-├── tools/                      Reference tool stubs (browser)
+├── tools/                      Generalist tool ABCs + dep-free concrete impls (browser ABC, terminal)
 ├── resources/                  BrowserSession, ChatSession protocols
 ├── integrations/nemogym.py     NemoGym interop
 └── _template/                  Scaffold used by `cube init`
 
 cube-resources/                 Optional resource packages (playwright, chat, infra-*)
-cube-tools/                     Optional tool packages (browser, computer, chat)
+cube-tools/                     Optional concrete tool packages — one per heavy dep (browser, computer, chat, web)
 examples/                       counter-cube (reference), toy_benchmark
 tests/                          Unit + integration + backends
 ```
+
+## Tools architecture
+
+ABCs live in `src/cube/tools/`. Concrete impls live in `cube-tools/cube-<name>-tool/`
+when they pull a non-trivial dep; otherwise alongside the ABC. **Tool implementations
+never live in cube-harness.** Full rule: [tool/spec.md § Packaging conventions](openspec/specs/tool/spec.md#packaging-conventions).
 
 ## Key conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,8 @@ Cross-cutting:
 
 ## Code review
 
+**Default branch is `dev`** — base all PRs off it, not `main`.
+
 **Sign your commits.** Every commit needs a `Signed-off-by` line (`git commit -s`). DCO is enforced by CI — unsigned commits will be blocked.
 
 PRs are reviewed with `/code-review` ([plugin docs](https://github.com/anthropics/claude-code/blob/main/plugins/code-review/README.md)), which audits changes against these guidelines. Write PRs as if a reviewer will check each principle above against the diff.

--- a/cube-tools/README.md
+++ b/cube-tools/README.md
@@ -6,6 +6,10 @@ Optional tool implementations for [cube-standard](../README.md).
 
 For instance, web browsing benchmarks (MiniWob, WorkArena, WebArena) can use the `cube-browser-tool` package, which provides `BrowsergymTool` and `PlaywrightTool` -- both satisfying the `AbstractBrowserTool` protocol defined in `cube-standard`.
 
+## When does a tool belong here?
+
+A concrete generalist tool gets its own `cube-tools/cube-<name>-tool/` sub-package **when it pulls a non-trivial runtime dependency** (Playwright, BrowserGym, PyAutoGUI, MCP SDK, …). If the implementation has no extra deps — like `TerminalTool` today — it stays in `cube-standard/src/cube/tools/` alongside the ABC. Tool implementations never live in `cube-harness`; cube-specific tools live in their own cube package, typically by subclassing a generalist tool from here. See [tool/spec.md § Packaging conventions](../openspec/specs/tool/spec.md#packaging-conventions) for the authoritative rule.
+
 ## Packages
 
 | Package | PyPI name | Description |

--- a/openspec/specs/tool/spec.md
+++ b/openspec/specs/tool/spec.md
@@ -107,6 +107,24 @@ the one owning that action name.
 - Action parameter names and types must be JSON-Schema-expressible (primitive types,
   `list`, `dict`, Optional). Pydantic types work via `function_to_dict`.
 
+## Packaging conventions
+
+Where generalist tool code lives:
+
+- **Abstract bases** (e.g. `AbstractBrowserTool`) live in `cube-standard/src/cube/tools/`
+  alongside this spec.
+- **Concrete implementations** live in `cube-standard/cube-tools/cube-<name>-tool/` as
+  optional sub-packages **when they pull a non-trivial runtime dependency** (Playwright,
+  BrowserGym, PyAutoGUI, MCP SDK, …). Otherwise — like `TerminalTool` today — the
+  implementation can sit directly in `cube-standard/src/cube/tools/`.
+- **Tool implementations never live in `cube-harness`.** The harness consumes
+  contracts and concrete implementations from this repo; it does not own tool code.
+  Harness-internal infrastructure that wraps tools (e.g. telemetry decorators) is not
+  itself a tool and is not in scope of this rule.
+- **Cube-specific tools** (a tool whose only consumer is a single benchmark) live in
+  that cube's own package, typically by subclassing a generalist tool from
+  `cube-tools/`. They are not generalist tools and do not move here.
+
 ## Gotchas
 
 - Forgetting `@tool_action` is the most common mistake. `execute_action` will raise


### PR DESCRIPTION
## Summary

Phase 0 of the tools-architecture cleanup: write the rule down in one authoritative place (`openspec/specs/tool/spec.md`) and point the developer touchpoints at it.

The rule (now in **[tool/spec.md § Packaging conventions](openspec/specs/tool/spec.md)**):

- **ABCs** live in `cube-standard/src/cube/tools/` alongside the spec.
- **Concrete impls** live in `cube-tools/cube-<name>-tool/` as optional sub-packages **when they pull a non-trivial runtime dependency** (Playwright, BrowserGym, PyAutoGUI, MCP SDK, …); otherwise alongside the ABC (e.g. `TerminalTool` today).
- **Tool implementations never live in `cube-harness`.** The harness consumes contracts and concrete impls from this repo; it does not own tool code.
- **Cube-specific tools** (single-cube consumer) live in that cube's package, typically by subclassing a generalist tool from `cube-tools/`.

## Touchpoints kept in sync

Each pointer is 1–2 sentences and links back to the spec for the authoritative rule:

- `CLAUDE.md` — new "Tools architecture" subsection.
- `cube-tools/README.md` — new "When does a tool belong here?" section.
- `.claude/skills/new-cube/references/shared-packages.md` — new "Where new tool code lives" section + anti-pattern bullet.
- `.claude/skills/review-cube/references/checks.md` — new S-75 suggestion flagging cubes that reimplement generalist tool surfaces instead of consuming/subclassing existing `cube-tools/*`.

## Companion PR

[The-AI-Alliance/cube-harness#390](https://github.com/The-AI-Alliance/cube-harness/pull/390) removes the corresponding dead `Computer` stub from `cube_harness/tools/`, which is the consumer-side proof of the "no tool implementations in cube-harness" rule.

## What this does not do (deferred to later phases)

This PR is documentation only. The migrations themselves land in subsequent phases:

- **Phase 1 (web):** move `BrowsergymTool` + `ExtraWebActionsTool` from `cube-harness` to a new `cube-tools/cube-browsergym-tool/`.
- **Phase 2 (SWE):** terminal/bash decisions.
- **Phase 3 (CUA):** promote `ComputerBase` ABC from `cube-computer-tool` into `cube-standard/src/cube/tools/computer.py`.
- **Cross-cutting:** `MCPTool` → new `cube-tools/cube-mcp-tool/`.

Each will land as an openspec change proposal under `openspec/changes/` since they involve moving symbols around the tool layer (ADDED/MODIFIED/REMOVED requirements). This PR establishes the rule those proposals will reference.

## Test plan

- [x] Spec subsection passes a self-read for clarity.
- [x] All four touchpoints link to the spec section anchor (`#packaging-conventions`).
- [ ] CI lint (markdown / link checks if any).

🤖 Generated with [Claude Code](https://claude.com/claude-code)