### PR TITLE
feat(core): add ConfigRegistry — copy-on-access named-config catalog

### DIFF
--- a/openspec/specs/core/spec.md
+++ b/openspec/specs/core/spec.md
@@ -25,6 +25,12 @@ config ABCs (`ToolConfig`, `AsyncToolConfig`, `InfraConfig`, `BenchmarkConfig`);
 `TypedBaseModel` types keep construction-only validation. `model_copy(update=...)`
 bypasses it (so subsetting helpers are unaffected); `_type` round-trip preserved.
 
+### `ConfigRegistry[T: BaseModel]`
+Read-only `Mapping[str, T]` for named-config catalogs (canonical agent/benchmark/infra
+configs). Every `reg[name]` returns a fresh `model_copy(deep=True)` so callers can't
+mutate the shared instance; unknown name → `KeyError` listing available names. A
+`Mapping`, not a `dict` subclass, so no accessor bypasses the copy.
+
 ### `Action`
 ```python
 class Action(TypedBaseModel):

--- a/src/cube/core.py
+++ b/src/cube/core.py
@@ -20,6 +20,7 @@ import io
 import json
 import traceback
 from abc import ABC, abstractmethod
+from collections.abc import Iterator, Mapping
 from typing import Any, Callable, ClassVar, Self
 
 from PIL import Image as PILImage
@@ -92,6 +93,42 @@ class ValidatedConfig(TypedBaseModel):
     """
 
     model_config = ConfigDict(validate_assignment=True)
+
+
+class ConfigRegistry[T: BaseModel](Mapping[str, T]):
+    """Maps a name to a canonical config; every lookup returns a deep copy.
+
+    Used for the named-config catalogs that recipes pick from — canonical
+    agent configs, per-cube benchmark configs, infra profiles:
+
+        agent = GENNY_CONFIGS["swe"]
+        agent.budget.cost_limit = 2.0
+
+    Every lookup returns a fresh ``model_copy(deep=True)``, so a caller can
+    never mutate the shared canonical instance and corrupt other recipes in
+    the process. Trade-off: bind to a variable before mutating —
+    ``REG["x"].field = y`` mutates a throwaway and no-ops.
+
+    A ``Mapping`` (not a ``dict`` subclass) on purpose: ``dict.get`` /
+    ``.values`` / ``.items`` / ``**unpack`` would bypass ``__getitem__`` and
+    hand out the shared instance. ``Mapping`` routes every read through
+    ``__getitem__``, so copy-on-access actually holds.
+    """
+
+    def __init__(self, configs: dict[str, T]) -> None:
+        self._configs = configs
+
+    def __getitem__(self, name: str) -> T:
+        try:
+            return self._configs[name].model_copy(deep=True)
+        except KeyError:
+            raise KeyError(f"Unknown config {name!r}. Available: {sorted(self._configs)}") from None
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._configs)
+
+    def __len__(self) -> int:
+        return len(self._configs)
 
 
 class ActionSchema(TypedBaseModel):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ValidationError
 from cube.core import (
     Action,
     ActionSchema,
+    ConfigRegistry,
     Content,
     ImageContent,
     Observation,
@@ -256,3 +257,29 @@ def test_validated_config_preserves_typed_round_trip():
     assert data["_type"] == f"{__name__}._AgentCfg"
     restored = _AgentCfg.model_validate(data)
     assert restored == cfg
+
+
+# --- ConfigRegistry ---
+
+
+def test_config_registry_lookup_returns_independent_deep_copy():
+    reg = ConfigRegistry({"x": _AgentCfg(max_actions=10)})
+    a = reg["x"]
+    b = reg["x"]
+    assert a is not b
+    a.budget.cost_limit = 99.0
+    assert reg["x"].budget.cost_limit != 99.0  # shared instance untouched
+
+
+def test_config_registry_unknown_name_lists_available():
+    reg = ConfigRegistry({"x": _AgentCfg()})
+    with pytest.raises(KeyError, match=r"Unknown config 'y'. Available: \['x'\]"):
+        reg["y"]
+
+
+def test_config_registry_is_a_readonly_mapping():
+    reg = ConfigRegistry({"a": _AgentCfg(), "b": _AgentCfg()})
+    assert len(reg) == 2
+    assert sorted(reg) == ["a", "b"]
+    assert "a" in reg
+    assert not hasattr(reg, "__setitem__")


### PR DESCRIPTION
## Summary
Adds `ConfigRegistry[T: BaseModel]` to `cube.core` — a read-only `Mapping[str, T]` whose every lookup returns a fresh `model_copy(deep=True)`. Unknown name → `KeyError` listing available names. It's a `Mapping`, not a `dict` subclass, so no accessor bypasses the copy.

## Why here (not cube-harness)
It's the catalog type recipes pick canonical configs from — agent configs (cube-harness) **and** per-cube benchmark configs. Putting it in `cube.core` lets every cube expose a `<NAME>_CONFIGS` registry without depending on cube-harness (which would invert the layering). The cube-harness prototype is being removed in favour of this. Generic and dependency-free (`collections.abc` + pydantic).

## Test plan
- [x] `make lint`
- [x] `make test` — `tests/test_core.py` 29 passed (3 new: deep-copy isolation, KeyError lists names, read-only Mapping)

Unblocks: every cube ships a `ConfigRegistry` of canonical benchmark configs (cube-harness PR #395).

🤖 Generated with [Claude Code](https://claude.com/claude-code)