### PR TITLE
feat(cube-browser-tool): add BgymTool (relocate BrowsergymTool from cube-harness)

### DIFF
--- a/cube-tools/README.md
+++ b/cube-tools/README.md
@@ -4,7 +4,7 @@ Optional tool implementations for [cube-standard](../README.md).
 
 `cube-standard` defines some `Protocol` for each benchmark domain but ships no concrete tool implementation. This folder contains packages that implement these protocols and can be installed independently.
 
-For instance, web browsing benchmarks (MiniWob, WorkArena, WebArena) can use the `cube-browser-tool` package, which provides `BrowsergymTool` and `PlaywrightTool` -- both satisfying the `AbstractBrowserTool` protocol defined in `cube-standard`.
+For instance, web browsing benchmarks (MiniWob, WorkArena, WebArena) can use the `cube-browser-tool` package, which provides `SyncPlaywrightTool` and (with the `[bgym]` extra) `BgymTool` — both satisfying the `BrowserTool` abstract base defined in `cube-standard`.
 
 ## When does a tool belong here?
 

--- a/cube-tools/cube-browser-tool/pyproject.toml
+++ b/cube-tools/cube-browser-tool/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cube-browser-tool"
-version = "0.2.0"
+version = "0.3.0"
 description = "Concrete browser tool implementations for cube-standard benchmarks"
 requires-python = ">=3.12"
 dependencies = [
@@ -12,7 +12,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-bgym = ["browsergym-core"]
+bgym = ["browsergym-core", "numpy"]
 dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.24.0",

--- a/cube-tools/cube-browser-tool/src/cube_browser_tool/bgym_tool.py
+++ b/cube-tools/cube-browser-tool/src/cube_browser_tool/bgym_tool.py
@@ -1,0 +1,462 @@
+"""BrowserGym-backed browser tool (optional dependency).
+
+``BgymTool`` exposes BrowserGym's native action set on a Playwright page and
+extracts BrowserGym observations (DOM / AXTree / screenshot). ``ExtraWebActionsTool``
+adds ``keyboard_type_into`` and ``js_eval`` on top of the same session.
+
+Requires the ``bgym`` extra::
+
+    pip install cube-browser-tool[bgym]
+
+Importing this module without ``browsergym-core`` installed raises a clear
+``ImportError`` with the install hint.
+
+Usage::
+
+    from cube_browser_tool.bgym_tool import BgymToolConfig
+
+    # axtree + screenshot (the canonical WorkArena observation):
+    config = BgymToolConfig(use_html=False, use_axtree=True, use_screenshot=True)
+
+    # bundled with keyboard_type_into / js_eval, flattened into one Toolbox:
+    from cube_browser_tool.bgym_tool import ExtendedBrowserConfig
+    config = ExtendedBrowserConfig(browser=BgymToolConfig(...))
+"""
+
+import json
+import logging
+import time
+from typing import Any
+
+import numpy as np
+from cube.core import Action, ActionSchema, Content, Observation, StepError
+from cube.tool import Tool, Toolbox, ToolConfig, tool_action
+from cube.tools.browser import BrowserTool
+from cube_browser_playwright.playwright_session import (
+    PlaywrightSession,
+    PlaywrightSessionConfig,
+)
+from PIL import Image
+from playwright.sync_api import Error, Page
+from pydantic import Field
+
+try:
+    from browsergym.core.action.base import execute_python_code
+    from browsergym.core.action.highlevel import HighLevelActionSet
+    from browsergym.core.action.utils import get_elem_by_bid
+    from browsergym.core.constants import BROWSERGYM_ID_ATTRIBUTE, EXTRACT_OBS_MAX_TRIES
+    from browsergym.core.observation import (
+        MarkingError,
+        _post_extract,
+        _pre_extract,
+        extract_dom_extra_properties,
+        extract_dom_snapshot,
+        extract_focused_element_bid,
+        extract_merged_axtree,
+        extract_screenshot,
+    )
+    from browsergym.utils.obs import flatten_axtree_to_str, flatten_dom_to_str, prune_html
+except ImportError as e:  # pragma: no cover - exercised via packaging, not unit tests
+    raise ImportError(
+        "cube_browser_tool.bgym_tool requires the 'bgym' extra. Install it with: pip install cube-browser-tool[bgym]"
+    ) from e
+
+logger = logging.getLogger(__name__)
+
+
+class BgymToolConfig(ToolConfig):
+    """Configuration for the BrowserGym-style Playwright tool."""
+
+    # Browser configuration (launch parameters)
+    browser: PlaywrightSessionConfig = Field(default_factory=PlaywrightSessionConfig)
+
+    # Action configuration
+    action_subsets: list[str] = Field(default=["bid", "nav", "tab"])
+
+    # Observation behavior
+    tags_to_mark: str = "standard_html"  # "all" or "standard_html"
+    pre_observation_delay: float = 0.5
+
+    # Observation configuration
+    use_html: bool = True
+    use_axtree: bool = True
+    use_screenshot: bool = True
+    prune_html: bool = True
+
+    # AXTree element attributes — requires extra_element_properties from the DOM snapshot
+    axtree_with_visible: bool = False  # label visible elements (vis >= 0.5) as "visible"
+    axtree_with_clickable: bool = False  # label clickable elements as "clickable"
+
+    def make(self, container: Any = None) -> "BgymTool":
+        return BgymTool(self)
+
+
+class BgymTool(BrowserTool):
+    """Browser tool using BrowserGym's action set on a Playwright Page.
+
+    Exposes bgym's native actions (click, fill, scroll, ...) as tool actions.
+    Pure browser — chat and infeasibility actions belong to ChatTool.
+    """
+
+    def __init__(self, config: BgymToolConfig) -> None:
+        super().__init__()
+        self.config = config
+        self._action_set = HighLevelActionSet(subsets=config.action_subsets, multiaction=False)
+        self._action_schemas: list[ActionSchema] | None = None
+        self._session: PlaywrightSession | None = None
+        self._last_obs: dict | None = None
+        self._last_info: dict | None = None
+        self._last_reward: float = 0.0
+        self._last_terminated: bool = False
+
+    # === Action set: built from bgym's HighLevelActionSet ===
+
+    @property
+    def action_set(self) -> list[ActionSchema]:
+        if self._action_schemas is None:
+            self._action_schemas = _build_action_schemas(self._action_set)
+        return self._action_schemas
+
+    # === Action execution: serialise Action -> bgym string -> execute ===
+
+    def execute_action(self, action: Action) -> Observation | StepError:
+        """Serialise an Action to a bgym action string, execute it, and return the observation."""
+        action_str = _action_to_bgym_string(action)
+        result = self._execute_bgym_step(action_str)
+        obs = self.page_obs()
+        return Observation(contents=[Content.from_data(result, tool_call_id=action.id)]) + obs
+
+    # === BrowserTool interface ===
+
+    @property
+    def session(self) -> PlaywrightSession:
+        if self._session is None:
+            raise RuntimeError("Browser is not initialized. Call reset() first.")
+        return self._session
+
+    @property
+    def page(self) -> Page:
+        return self.session.page
+
+    @property
+    def last_reward(self) -> float:
+        return self._last_reward
+
+    @property
+    def last_terminated(self) -> bool:
+        return self._last_terminated
+
+    def goto(self, url: str) -> None:
+        self._execute_bgym_step(f'goto(url="{url}")')
+
+    def noop(self) -> None:
+        self._execute_bgym_step("noop()")
+
+    def evaluate_js(self, js: str) -> Any:
+        return self.page.evaluate(js)
+
+    def page_obs(self) -> Observation:
+        self._last_obs = self._extract_bgym_obs()
+        self._last_info = {"source": "page_obs"}
+        self._last_reward = 0.0
+        self._last_terminated = False
+        return self._bgym_obs_to_cube_obs(self._last_obs)
+
+    # === Lifecycle ===
+
+    def reset(self) -> None:
+        self._close_runtime()
+        self._create_runtime()
+        self._wait_dom_loaded()
+        self._last_obs = self._extract_bgym_obs()
+        self._last_info = {"source": "reset"}
+        self._last_reward = 0.0
+        self._last_terminated = False
+
+    def close(self) -> None:
+        self._close_runtime()
+        self._last_obs = None
+        self._last_info = None
+        self._last_reward = 0.0
+        self._last_terminated = False
+
+    def _create_runtime(self) -> None:
+        self._session = self.config.browser.make()
+        self._session.playwright.selectors.set_test_id_attribute(BROWSERGYM_ID_ATTRIBUTE)
+
+    def _close_runtime(self) -> None:
+        if self._session is not None:
+            self.session.stop()
+            self._session = None
+
+    def _wait_dom_loaded(self) -> None:
+        if self._session is None:
+            return
+        for page in self.session.context.pages:
+            try:
+                page.wait_for_load_state("domcontentloaded", timeout=1500)
+            except Error:
+                pass
+            for frame in page.frames:
+                # un necessary to wait for detached frames, and waiting on them raises a timeout error, so skip them
+                if frame.is_detached():
+                    continue
+                try:
+                    frame.wait_for_load_state("domcontentloaded", timeout=1500)
+                except Error:
+                    pass
+
+    # === Core bgym step execution ===
+
+    def _execute_bgym_step(self, action_str: str) -> str:
+        """Execute a BrowserGym action string and return a result message.
+
+        Captures three error channels:
+        - Python exceptions (e.g. TimeoutError when element not found)
+        - report_infeasible_instructions callback (bgym soft failures)
+        - send_message_to_user callback (bgym task-completion signals)
+        """
+        logger.info(f"Execute bgym step: {action_str}")
+        result = "Success"
+
+        def send_message_to_user(_: str) -> None:
+            assert False, "send_message_to_user should not be called"
+
+        def report_infeasible_instructions(_: str) -> None:
+            assert False, "report_infeasible_instructions should not be called"
+
+        try:
+            code = self._action_set.to_python_code(action_str)
+            execute_python_code(
+                code=code,
+                page=self.page,
+                send_message_to_user=send_message_to_user,
+                report_infeasible_instructions=report_infeasible_instructions,
+            )
+            self._last_info = {
+                "source": "action",
+                "action": action_str,
+                "action_error": "",
+            }
+        except Exception as e:
+            error_msg = f"{type(e).__name__}: {e}"
+            self._last_info = {
+                "source": "action",
+                "action": action_str,
+                "action_error": error_msg,
+            }
+            result = f"Failed: {error_msg}"
+
+        self._last_obs = self._extract_bgym_obs()
+        self._last_reward = 0.0
+        self._last_terminated = False
+        return result
+
+    # === Observation extraction ===
+
+    def _extract_bgym_obs(self) -> dict[str, Any]:
+        page = self.page
+        if self.config.pre_observation_delay > 0:
+            time.sleep(self.config.pre_observation_delay)
+        self._wait_dom_loaded()
+
+        for retries_left in reversed(range(EXTRACT_OBS_MAX_TRIES)):
+            try:
+                _pre_extract(
+                    page,
+                    tags_to_mark=self.config.tags_to_mark,
+                    lenient=(retries_left == 0),
+                )
+                dom = extract_dom_snapshot(page)
+                axtree = extract_merged_axtree(page)
+                focused_element_bid = extract_focused_element_bid(page)
+                scale_factor = getattr(page, "_bgym_scale_factor", 1.0)
+                need_extra = self.config.axtree_with_visible or self.config.axtree_with_clickable
+                extra_properties = extract_dom_extra_properties(dom, scale_factor=scale_factor) if need_extra else {}
+            except (Error, MarkingError):
+                if retries_left > 0:
+                    logger.warning(
+                        f"Error extracting BrowserGym observation. Retrying ({retries_left}/{EXTRACT_OBS_MAX_TRIES})."
+                    )
+                    _post_extract(page)
+                    time.sleep(0.5)
+                    continue
+                raise
+            break
+
+        _post_extract(page)
+        obs: dict[str, Any] = {
+            "dom_object": dom,
+            "axtree_object": axtree,
+            "extra_element_properties": extra_properties,
+            "focused_element_bid": focused_element_bid,
+            "last_action_error": (self._last_info.get("action_error", "") if self._last_info else ""),
+        }
+        if self.config.use_screenshot:
+            obs["screenshot"] = extract_screenshot(page)
+        return obs
+
+    def _bgym_obs_to_cube_obs(self, bgym_obs: dict[str, Any]) -> Observation:
+        """Convert BrowserGym observation dict to a cube Observation."""
+        obs = Observation()
+
+        extra_properties = bgym_obs.get("extra_element_properties", {})
+
+        # HTML
+        if self.config.use_html and "dom_object" in bgym_obs:
+            dom_obj = bgym_obs["dom_object"]
+            html_str = flatten_dom_to_str(dom_obj, extra_properties=extra_properties)
+            if self.config.prune_html:
+                html_str = prune_html(html_str)
+            obs.contents.append(Content.from_data(html_str, name="pruned_html"))
+
+        # Focused element (placed before axtree so axtree+screenshot remain last)
+        if "focused_element_bid" in bgym_obs:
+            focused_bid = bgym_obs["focused_element_bid"]
+            if focused_bid:
+                obs.contents.append(Content.from_data(focused_bid, name="focused_element"))
+
+        # Accessibility tree
+        if self.config.use_axtree and "axtree_object" in bgym_obs:
+            axtree_obj = bgym_obs["axtree_object"]
+            if axtree_obj:
+                axtree_str = flatten_axtree_to_str(
+                    axtree_obj,
+                    extra_properties=extra_properties,
+                    with_visible=self.config.axtree_with_visible,
+                    with_clickable=self.config.axtree_with_clickable,
+                )
+                obs.contents.append(Content.from_data(axtree_str, name="axtree_txt"))
+
+        # Screenshot
+        if self.config.use_screenshot and "screenshot" in bgym_obs:
+            screenshot = bgym_obs["screenshot"]
+            if isinstance(screenshot, Image.Image):
+                obs.contents.append(Content.from_data(screenshot, name="screenshot"))
+            elif isinstance(screenshot, np.ndarray):
+                screenshot_img = Image.fromarray(screenshot)
+                obs.contents.append(Content.from_data(screenshot_img, name="screenshot"))
+
+        # Last action error
+        if "last_action_error" in bgym_obs:
+            error = bgym_obs["last_action_error"]
+            if error:
+                obs.contents.append(Content.from_data(str(error), name="last_action_error"))
+
+        # User messages from send_msg_to_user callback
+        if self._last_info and self._last_info.get("user_messages"):
+            for msg in self._last_info["user_messages"]:
+                obs.contents.append(Content.from_data(msg, name="user_message"))
+
+        return obs
+
+
+class ExtraWebActionsTool(Tool):
+    """Extra browser actions that complement BrowserGym's built-in set.
+
+    Holds a reference to a BgymTool to share its page and observation
+    extraction — both tools operate on the same browser session.
+
+    Intentionally uses composition rather than inheritance: this tool adds
+    actions on top of BgymTool but is not a BgymTool. It depends on BgymTool
+    specifically (not a generic BrowserTool) because it accesses .page and
+    .page_obs() which are BgymTool-specific.
+
+    Experimental: if BrowserGym adds native keyboard-event support in a future
+    release, keyboard_type_into can be removed and this class may become empty.
+    """
+
+    def __init__(self, browser: BgymTool) -> None:
+        self._browser = browser
+
+    def execute_action(self, action: Action) -> Observation | StepError:
+        method = self.get_action_method(action)
+        try:
+            result = str(method(**action.arguments) or "Success")
+        except Exception as e:
+            return StepError.from_exception(e)
+        action_obs = Observation(contents=[Content.from_data(result, tool_call_id=action.id)])
+        return action_obs + self._browser.page_obs()
+
+    @tool_action
+    def keyboard_type_into(self, bid: str, text: str) -> str:
+        """Type text into an element character-by-character, firing keyboard events per character.
+
+        Use this instead of fill() for fields that show autocomplete suggestions or dynamic
+        dropdowns as you type — fill() sets the value directly and bypasses keyboard events.
+        After typing, call noop() to wait for suggestions to appear, then click the suggestion.
+        """
+        logger.info(f"keyboard_type_into: bid={bid!r} text={text!r}")
+        try:
+            get_elem_by_bid(self._browser.page, bid).press_sequentially(text, delay=50)
+            return "Success"
+        except Error as e:
+            return f"Failed: {type(e).__name__}: {e}"
+
+    @tool_action
+    def js_eval(self, code: str, frame: str = "main") -> str:
+        """Evaluate JavaScript in the browser and return the JSON-serialized result.
+
+        Useful for inspecting DOM state, reading localStorage, checking field values,
+        or diagnosing why an action isn't working as expected.
+
+        Args:
+            code: JavaScript expression to evaluate. The result is JSON-serialized.
+                  Example: "document.title"
+                  Example: "JSON.stringify(localStorage)"
+                  Example: "g_form.getUniqueValue()"
+            frame: Frame to evaluate in. "main" = top-level page. Any other string
+                   is matched against iframe names (e.g. "gsft_main" for ServiceNow).
+        """
+        try:
+            if frame == "main":
+                target = self._browser.page
+            else:
+                target = next((f for f in self._browser.page.frames if f.name == frame), None)
+                if target is None:
+                    return f"Failed: frame {frame!r} not found"
+            raw = target.evaluate(
+                f"() => {{ try {{ return {code}; }} catch(e) {{ return 'JS error: ' + e.message; }} }}"
+            )
+            return json.dumps(raw, default=str)
+        except Error as e:
+            return f"Failed: {type(e).__name__}: {e}"
+
+
+class ExtendedBrowserConfig(ToolConfig):
+    """BrowserGym tool bundled with ExtraWebActionsTool, returned as a flat Toolbox.
+
+    Drop-in replacement for BgymToolConfig when extra web actions are needed.
+    When nested inside ToolboxConfig, the Toolbox is automatically flattened.
+    """
+
+    browser: BgymToolConfig = Field(default_factory=BgymToolConfig)
+
+    def make(self, container: Any = None) -> Toolbox:
+        bgym = self.browser.make(container)
+        extra = ExtraWebActionsTool(bgym)
+        return Toolbox([bgym, extra])
+
+
+# === Module-level helpers ===
+
+
+def _build_action_schemas(action_set: "HighLevelActionSet") -> list[ActionSchema]:
+    """Convert bgym's HighLevelActionSet to a list of ActionSchema objects."""
+    tool_descs = action_set.to_tool_description(api="openai")
+    schemas = []
+    for desc in tool_descs:
+        # "type": "function" is at the top-level desc dict, not inside parameters.
+        # parameters already has "type": "object" which Azure/OpenAI require — don't remove it.
+        params = desc.get("parameters", {})
+        name = desc["name"]
+        schemas.append(ActionSchema(name=name, description=desc.get("description", name), parameters=params))
+    return schemas
+
+
+def _action_to_bgym_string(action: Action) -> str:
+    """Serialise a cube Action into a BrowserGym action string like 'click(bid="a51")'."""
+    args_parts = []
+    for key, value in action.arguments.items():
+        args_parts.append(f"{key}={repr(value)}")
+    return f"{action.name}({', '.join(args_parts)})"

--- a/cube-tools/cube-browser-tool/tests/test_bgym_tool.py
+++ b/cube-tools/cube-browser-tool/tests/test_bgym_tool.py
@@ -1,0 +1,672 @@
+"""Tests for cube_browser_tool.bgym_tool module."""
+
+import tempfile
+from collections.abc import Generator
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+from browsergym.core.action.highlevel import HighLevelActionSet
+from browsergym.core.action.utils import get_elem_by_bid
+from browsergym.core.constants import BROWSERGYM_ID_ATTRIBUTE
+from cube.core import Action, Observation
+from cube_browser_playwright.playwright_session import PlaywrightSession, PlaywrightSessionConfig
+from PIL import Image
+from playwright.sync_api import Page, sync_playwright
+
+from cube_browser_tool.bgym_tool import (
+    BgymTool,
+    BgymToolConfig,
+    ExtraWebActionsTool,
+    _action_to_bgym_string,
+    _build_action_schemas,
+)
+
+
+@pytest.fixture
+def mock_playwright_session() -> Generator[PlaywrightSession, None, None]:
+    session = PlaywrightSession(
+        playwright=MagicMock(),
+        page=MagicMock(),
+        context=MagicMock(),
+        cdp_url="http://localhost:9222",
+        user_data_dir=tempfile.mkdtemp(prefix="cube_browser_tool_"),
+    )
+    yield session
+    session.stop()
+
+
+class TestBgymToolConfig:
+    """Tests for BgymToolConfig."""
+
+    def test_default_config_values(self) -> None:
+        config = BgymToolConfig()
+
+        assert config.browser.headless is True
+        assert config.use_html is True
+        assert config.use_axtree is True
+        assert config.use_screenshot is True
+        assert config.prune_html is True
+        assert config.action_subsets == ["bid", "nav", "tab"]
+
+    def test_custom_config_values(self) -> None:
+        config = BgymToolConfig(
+            browser=PlaywrightSessionConfig(headless=False, viewport={"width": 1920, "height": 1080}),
+            use_html=False,
+            use_axtree=False,
+            use_screenshot=False,
+            action_subsets=["workarena"],
+        )
+
+        assert config.browser.headless is False
+        assert config.use_html is False
+        assert config.use_axtree is False
+        assert config.use_screenshot is False
+        assert config.action_subsets == ["workarena"]
+        assert config.browser.viewport.width == 1920
+        assert config.browser.viewport.height == 1080
+
+    def test_make_creates_tool_instance(self) -> None:
+        config = BgymToolConfig()
+        tool = config.make()
+
+        assert isinstance(tool, BgymTool)
+        assert tool.config is config
+
+    def test_make_passes_config_to_tool(self) -> None:
+        config = BgymToolConfig(browser=PlaywrightSessionConfig(headless=False))
+        tool = config.make()
+
+        assert tool.config.browser.headless is False
+
+
+class TestBgymToolInitialization:
+    """Tests for BgymTool initialization and lifecycle."""
+
+    def test_tool_init_sets_config(self) -> None:
+        config = BgymToolConfig()
+        tool = BgymTool(config)
+
+        assert tool.config is config
+        assert tool._session is None
+        assert tool._last_obs is None
+        assert tool._last_info is None
+
+    def test_page_property_raises_when_not_initialized(self) -> None:
+        config = BgymToolConfig()
+        tool = BgymTool(config)
+
+        with pytest.raises(RuntimeError, match="Browser is not initialized"):
+            _ = tool.page
+
+    def test_page_obs_raises_when_not_initialized(self) -> None:
+        config = BgymToolConfig()
+        tool = BgymTool(config)
+
+        with pytest.raises(RuntimeError, match="Browser is not initialized"):
+            tool.page_obs()
+
+    def test_evaluate_js_raises_when_not_initialized(self) -> None:
+        config = BgymToolConfig()
+        tool = BgymTool(config)
+
+        with pytest.raises(RuntimeError, match="Browser is not initialized"):
+            tool.evaluate_js("return 1+1")
+
+
+class TestBgymToolObservationConversion:
+    """Tests for _bgym_obs_to_cube_obs conversion."""
+
+    def test_empty_observation(self) -> None:
+        config = BgymToolConfig(use_html=False, use_axtree=False, use_screenshot=False)
+        tool = BgymTool(config)
+
+        bgym_obs: dict = {}
+        obs = tool._bgym_obs_to_cube_obs(bgym_obs)
+
+        assert isinstance(obs, Observation)
+        assert len(obs.contents) == 0
+
+    @patch("cube_browser_tool.bgym_tool.flatten_dom_to_str")
+    def test_html_observation(self, mock_flatten_dom: MagicMock) -> None:
+        mock_flatten_dom.return_value = "<html><body>Test</body></html>"
+
+        config = BgymToolConfig(use_html=True, use_axtree=False, use_screenshot=False, prune_html=False)
+        tool = BgymTool(config)
+
+        dom_obj = {"documents": [], "strings": []}
+        bgym_obs = {"dom_object": dom_obj}
+        obs = tool._bgym_obs_to_cube_obs(bgym_obs)
+
+        assert len(obs.contents) == 1
+        assert obs.contents[0].name == "pruned_html"
+        assert obs.contents[0].data == "<html><body>Test</body></html>"
+
+    @patch("cube_browser_tool.bgym_tool.prune_html")
+    @patch("cube_browser_tool.bgym_tool.flatten_dom_to_str")
+    def test_html_observation_with_pruning(self, mock_flatten_dom: MagicMock, mock_prune_html: MagicMock) -> None:
+        mock_flatten_dom.return_value = "<html><body>Full HTML</body></html>"
+        mock_prune_html.return_value = "<body>Pruned</body>"
+
+        config = BgymToolConfig(use_html=True, use_axtree=False, use_screenshot=False, prune_html=True)
+        tool = BgymTool(config)
+
+        bgym_obs = {"dom_object": {"documents": [], "strings": []}}
+        obs = tool._bgym_obs_to_cube_obs(bgym_obs)
+
+        mock_prune_html.assert_called_once_with("<html><body>Full HTML</body></html>")
+        assert obs.contents[0].data == "<body>Pruned</body>"
+
+    @patch("cube_browser_tool.bgym_tool.flatten_axtree_to_str")
+    def test_axtree_observation(self, mock_flatten_axtree: MagicMock) -> None:
+        mock_flatten_axtree.return_value = "[a1] button 'Submit'"
+
+        config = BgymToolConfig(use_html=False, use_axtree=True, use_screenshot=False)
+        tool = BgymTool(config)
+
+        axtree_obj = {"nodes": []}
+        bgym_obs = {"axtree_object": axtree_obj}
+        obs = tool._bgym_obs_to_cube_obs(bgym_obs)
+
+        assert len(obs.contents) == 1
+        assert obs.contents[0].name == "axtree_txt"
+        assert obs.contents[0].data == "[a1] button 'Submit'"
+
+    def test_axtree_observation_empty_object(self) -> None:
+        config = BgymToolConfig(use_html=False, use_axtree=True, use_screenshot=False)
+        tool = BgymTool(config)
+
+        bgym_obs = {"axtree_object": None}
+        obs = tool._bgym_obs_to_cube_obs(bgym_obs)
+
+        assert len(obs.contents) == 0
+
+    def test_screenshot_observation_from_numpy(self) -> None:
+        config = BgymToolConfig(use_html=False, use_axtree=False, use_screenshot=True)
+        tool = BgymTool(config)
+
+        screenshot_array = np.zeros((100, 100, 3), dtype=np.uint8)
+        screenshot_array[:, :, 0] = 255
+
+        bgym_obs = {"screenshot": screenshot_array}
+        obs = tool._bgym_obs_to_cube_obs(bgym_obs)
+
+        assert len(obs.contents) == 1
+        assert obs.contents[0].name == "screenshot"
+        assert isinstance(obs.contents[0].data, Image.Image)
+        assert obs.contents[0].data.size == (100, 100)
+
+    def test_screenshot_observation_from_pil_image(self) -> None:
+        config = BgymToolConfig(use_html=False, use_axtree=False, use_screenshot=True)
+        tool = BgymTool(config)
+
+        screenshot_img = Image.new("RGB", (200, 150), color="blue")
+        bgym_obs = {"screenshot": screenshot_img}
+        obs = tool._bgym_obs_to_cube_obs(bgym_obs)
+
+        assert len(obs.contents) == 1
+        assert obs.contents[0].name == "screenshot"
+        assert obs.contents[0].data is screenshot_img
+
+    @patch("cube_browser_tool.bgym_tool.flatten_axtree_to_str")
+    @patch("cube_browser_tool.bgym_tool.flatten_dom_to_str")
+    def test_full_observation(self, mock_flatten_dom: MagicMock, mock_flatten_axtree: MagicMock) -> None:
+        mock_flatten_dom.return_value = "<html>...</html>"
+        mock_flatten_axtree.return_value = "[a1] button"
+
+        config = BgymToolConfig(use_html=True, use_axtree=True, use_screenshot=True, prune_html=False)
+        tool = BgymTool(config)
+
+        screenshot_img = Image.new("RGB", (100, 100), color="green")
+        bgym_obs = {
+            "dom_object": {"documents": []},
+            "axtree_object": {"nodes": []},
+            "screenshot": screenshot_img,
+        }
+        obs = tool._bgym_obs_to_cube_obs(bgym_obs)
+
+        assert len(obs.contents) == 3
+        content_names = {c.name for c in obs.contents}
+        assert content_names == {"pruned_html", "axtree_txt", "screenshot"}
+
+    def test_focused_element_observation(self) -> None:
+        config = BgymToolConfig(use_html=False, use_axtree=False, use_screenshot=False)
+        tool = BgymTool(config)
+
+        bgym_obs = {"focused_element_bid": "a123"}
+        obs = tool._bgym_obs_to_cube_obs(bgym_obs)
+
+        assert len(obs.contents) == 1
+        assert obs.contents[0].name == "focused_element"
+        assert obs.contents[0].data == "a123"
+
+    def test_focused_element_observation_empty(self) -> None:
+        config = BgymToolConfig(use_html=False, use_axtree=False, use_screenshot=False)
+        tool = BgymTool(config)
+
+        bgym_obs = {"focused_element_bid": None}
+        obs = tool._bgym_obs_to_cube_obs(bgym_obs)
+
+        assert len(obs.contents) == 0
+
+    def test_last_action_error_observation(self) -> None:
+        config = BgymToolConfig(use_html=False, use_axtree=False, use_screenshot=False)
+        tool = BgymTool(config)
+
+        bgym_obs = {"last_action_error": "Element not found: bid='xyz'"}
+        obs = tool._bgym_obs_to_cube_obs(bgym_obs)
+
+        assert len(obs.contents) == 1
+        assert obs.contents[0].name == "last_action_error"
+        assert obs.contents[0].data == "Element not found: bid='xyz'"
+
+    def test_last_action_error_observation_empty(self) -> None:
+        config = BgymToolConfig(use_html=False, use_axtree=False, use_screenshot=False)
+        tool = BgymTool(config)
+
+        bgym_obs = {"last_action_error": None}
+        obs = tool._bgym_obs_to_cube_obs(bgym_obs)
+
+        assert len(obs.contents) == 0
+
+    def test_last_action_error_observation_empty_string(self) -> None:
+        config = BgymToolConfig(use_html=False, use_axtree=False, use_screenshot=False)
+        tool = BgymTool(config)
+
+        bgym_obs = {"last_action_error": ""}
+        obs = tool._bgym_obs_to_cube_obs(bgym_obs)
+
+        assert len(obs.contents) == 0
+
+    def test_user_message_observation(self) -> None:
+        config = BgymToolConfig(use_html=False, use_axtree=False, use_screenshot=False)
+        tool = BgymTool(config)
+        tool._last_info = {"user_messages": ["Task completed successfully"]}
+
+        bgym_obs: dict = {}
+        obs = tool._bgym_obs_to_cube_obs(bgym_obs)
+
+        assert len(obs.contents) == 1
+        assert obs.contents[0].name == "user_message"
+        assert obs.contents[0].data == "Task completed successfully"
+
+
+class TestActionToBgymString:
+    """Tests for _action_to_bgym_string serialisation."""
+
+    def test_click_action(self) -> None:
+        action = Action(name="click", arguments={"bid": "a51"})
+        assert _action_to_bgym_string(action) == "click(bid='a51')"
+
+    def test_fill_action(self) -> None:
+        action = Action(name="fill", arguments={"bid": "b12", "value": "Hello World"})
+        assert _action_to_bgym_string(action) == "fill(bid='b12', value='Hello World')"
+
+    def test_fill_with_quotes(self) -> None:
+        action = Action(name="fill", arguments={"bid": "c1", "value": 'Say "Hello"'})
+        result = _action_to_bgym_string(action)
+        assert "fill(" in result
+        assert "bid='c1'" in result
+
+    def test_keyboard_press(self) -> None:
+        action = Action(name="keyboard_press", arguments={"key": "Enter"})
+        assert _action_to_bgym_string(action) == "keyboard_press(key='Enter')"
+
+    def test_drag_and_drop(self) -> None:
+        action = Action(name="drag_and_drop", arguments={"from_bid": "e1", "to_bid": "f2"})
+        assert _action_to_bgym_string(action) == "drag_and_drop(from_bid='e1', to_bid='f2')"
+
+    def test_hover(self) -> None:
+        action = Action(name="hover", arguments={"bid": "g3"})
+        assert _action_to_bgym_string(action) == "hover(bid='g3')"
+
+    def test_select_option(self) -> None:
+        action = Action(name="select_option", arguments={"bid": "h4", "options": "option1"})
+        assert _action_to_bgym_string(action) == "select_option(bid='h4', options='option1')"
+
+    def test_mouse_click(self) -> None:
+        action = Action(name="mouse_click", arguments={"x": 100, "y": 200})
+        assert _action_to_bgym_string(action) == "mouse_click(x=100, y=200)"
+
+    def test_noop(self) -> None:
+        action = Action(name="noop", arguments={})
+        assert _action_to_bgym_string(action) == "noop()"
+
+    def test_noop_with_wait(self) -> None:
+        action = Action(name="noop", arguments={"wait_ms": 5000})
+        assert _action_to_bgym_string(action) == "noop(wait_ms=5000)"
+
+    def test_goto(self) -> None:
+        action = Action(name="goto", arguments={"url": "http://example.com"})
+        assert _action_to_bgym_string(action) == "goto(url='http://example.com')"
+
+    def test_go_back(self) -> None:
+        action = Action(name="go_back", arguments={})
+        assert _action_to_bgym_string(action) == "go_back()"
+
+    def test_go_forward(self) -> None:
+        action = Action(name="go_forward", arguments={})
+        assert _action_to_bgym_string(action) == "go_forward()"
+
+    def test_scroll(self) -> None:
+        action = Action(name="scroll", arguments={"delta_x": 0, "delta_y": 200})
+        assert _action_to_bgym_string(action) == "scroll(delta_x=0, delta_y=200)"
+
+    def test_send_msg_to_user(self) -> None:
+        action = Action(name="send_msg_to_user", arguments={"text": "The answer is 42"})
+        assert _action_to_bgym_string(action) == "send_msg_to_user(text='The answer is 42')"
+
+
+class TestBuildActionSchemas:
+    """Tests for _build_action_schemas."""
+
+    def test_default_subsets_include_expected_actions(self) -> None:
+        action_set = HighLevelActionSet(subsets=["chat", "infeas", "bid", "nav", "tab"], multiaction=False)
+        schemas = _build_action_schemas(action_set)
+        names = {s.name for s in schemas}
+
+        # Core bgym actions should be present
+        assert "click" in names
+        assert "fill" in names
+        assert "hover" in names
+        assert "scroll" in names
+        assert "goto" in names
+        assert "go_back" in names
+        assert "noop" in names
+        assert "send_msg_to_user" in names
+        assert "report_infeasible" in names
+        assert "new_tab" in names
+
+    def test_workarena_subset(self) -> None:
+        action_set = HighLevelActionSet(subsets=["workarena"], multiaction=False)
+        schemas = _build_action_schemas(action_set)
+        names = {s.name for s in schemas}
+
+        assert "click" in names
+        assert "fill" in names
+        assert "noop" in names
+
+    def test_schemas_have_parameters(self) -> None:
+        action_set = HighLevelActionSet(subsets=["bid"], multiaction=False)
+        schemas = _build_action_schemas(action_set)
+
+        click_schema = next(s for s in schemas if s.name == "click")
+        assert "properties" in click_schema.parameters
+        assert "bid" in click_schema.parameters["properties"]
+
+
+class TestBgymToolStepResults:
+    """Tests for action step results and state updates."""
+
+    def _create_tool_with_mock_page(self, mock_playwright_session: PlaywrightSession) -> BgymTool:
+        config = BgymToolConfig()
+        tool = BgymTool(config)
+        tool._session = mock_playwright_session
+        tool._action_set = MagicMock()
+        return tool
+
+    def test_execute_bgym_step_returns_success(self, mock_playwright_session: PlaywrightSession) -> None:
+        tool = self._create_tool_with_mock_page(mock_playwright_session)
+
+        with (
+            patch("cube_browser_tool.bgym_tool.execute_python_code"),
+            patch.object(tool, "_extract_bgym_obs", return_value={}),
+        ):
+            result = tool._execute_bgym_step("noop()")
+
+        assert result == "Success"
+
+    def test_execute_bgym_step_returns_failure_on_exception(self, mock_playwright_session: PlaywrightSession) -> None:
+        tool = self._create_tool_with_mock_page(mock_playwright_session)
+
+        with (
+            patch("cube_browser_tool.bgym_tool.execute_python_code", side_effect=Exception("Some error")),
+            patch.object(tool, "_extract_bgym_obs", return_value={}),
+        ):
+            result = tool._execute_bgym_step("noop()")
+
+        assert "Failed" in result
+
+    def test_execute_bgym_step_updates_last_obs(self, mock_playwright_session: PlaywrightSession) -> None:
+        tool = self._create_tool_with_mock_page(mock_playwright_session)
+        new_obs = {"screenshot": np.zeros((10, 10, 3))}
+
+        with (
+            patch("cube_browser_tool.bgym_tool.execute_python_code"),
+            patch.object(tool, "_extract_bgym_obs", return_value=new_obs),
+        ):
+            tool._execute_bgym_step("noop()")
+
+        assert tool._last_obs is new_obs
+
+    def test_execute_bgym_step_updates_last_info(self, mock_playwright_session: PlaywrightSession) -> None:
+        tool = self._create_tool_with_mock_page(mock_playwright_session)
+
+        with (
+            patch("cube_browser_tool.bgym_tool.execute_python_code"),
+            patch.object(tool, "_extract_bgym_obs", return_value={}),
+        ):
+            tool._execute_bgym_step("noop()")
+
+        assert tool._last_info is not None
+        assert tool._last_info["source"] == "action"
+
+
+class TestBgymToolExecuteAction:
+    """Tests for execute_action integration."""
+
+    def test_execute_action_returns_observation(self, mock_playwright_session: PlaywrightSession) -> None:
+        config = BgymToolConfig(use_html=True, use_axtree=False, use_screenshot=False, prune_html=False)
+        tool = BgymTool(config)
+        tool._session = mock_playwright_session
+
+        action = Action(name="click", arguments={"bid": "a1"})
+
+        with (
+            patch.object(tool, "_execute_bgym_step", return_value="Success"),
+            patch.object(tool, "page_obs", return_value=Observation()),
+        ):
+            obs = tool.execute_action(action)
+
+        assert isinstance(obs, Observation)
+        assert len(obs.contents) >= 1
+
+
+class TestBgymToolActionSet:
+    """Tests for action_set property."""
+
+    def test_action_set_contains_bgym_native_actions(self) -> None:
+        """Test that default action_set contains pure browser actions only."""
+        config = BgymToolConfig()
+        tool = BgymTool(config)
+
+        action_names = {a.name for a in tool.action_set}
+
+        # Default subsets (bid, nav, tab) should include browser actions
+        assert "click" in action_names
+        assert "fill" in action_names
+        assert "hover" in action_names
+        assert "scroll" in action_names
+        assert "goto" in action_names
+        assert "noop" in action_names
+
+        # Chat/infeas actions should NOT be in default config — they belong to ChatTool
+        assert "send_msg_to_user" not in action_names
+        assert "report_infeasible" not in action_names
+
+        # Old names should NOT be present
+        assert "browser_click" not in action_names
+        assert "browser_type" not in action_names
+        assert "browser_hover" not in action_names
+
+    def test_action_set_configurable_subsets(self) -> None:
+        """Test that action_subsets config controls which actions are exposed."""
+        config_full = BgymToolConfig(action_subsets=["chat", "infeas", "bid", "nav", "tab"])
+        tool_full = BgymTool(config_full)
+
+        config_minimal = BgymToolConfig(action_subsets=["bid"])
+        tool_minimal = BgymTool(config_minimal)
+
+        full_names = {a.name for a in tool_full.action_set}
+        minimal_names = {a.name for a in tool_minimal.action_set}
+
+        # Full set should have tab/nav actions
+        assert "new_tab" in full_names
+        assert "goto" in full_names
+
+        # Minimal should not have tab/nav/chat
+        assert "new_tab" not in minimal_names
+        assert "send_msg_to_user" not in minimal_names
+
+
+class TestBgymToolLifecycle:
+    """Tests for tool lifecycle methods."""
+
+    def test_reset_initializes_browser(self) -> None:
+        config = BgymToolConfig()
+        tool = BgymTool(config)
+
+        with (
+            patch.object(tool, "_close_runtime") as mock_close,
+            patch.object(tool, "_create_runtime") as mock_create,
+            patch.object(tool, "_wait_dom_loaded") as mock_wait,
+            patch.object(tool, "_extract_bgym_obs", return_value={}) as mock_extract,
+        ):
+            tool.reset()
+
+        mock_close.assert_called_once()
+        mock_create.assert_called_once()
+        mock_wait.assert_called_once()
+        mock_extract.assert_called_once()
+
+    def test_reset_closes_existing_runtime(self, mock_playwright_session: PlaywrightSession) -> None:
+        config = BgymToolConfig()
+        tool = BgymTool(config)
+        tool._session = mock_playwright_session
+
+        with (
+            patch.object(tool, "_close_runtime") as mock_close,
+            patch.object(tool, "_create_runtime"),
+            patch.object(tool, "_wait_dom_loaded"),
+            patch.object(tool, "_extract_bgym_obs", return_value={}),
+        ):
+            tool.reset()
+
+        mock_close.assert_called_once()
+
+    def test_close_cleans_up_browser(self, mock_playwright_session: PlaywrightSession) -> None:
+        config = BgymToolConfig()
+        tool = BgymTool(config)
+
+        tool._session = mock_playwright_session
+        tool._last_obs = {"some": "data"}
+        tool._last_info = {"info": "data"}
+
+        tool.close()
+
+        assert tool._session is None
+        assert tool._last_obs is None
+        assert tool._last_info is None
+
+    def test_close_handles_exception(self, mock_playwright_session: PlaywrightSession) -> None:
+        config = BgymToolConfig()
+        tool = BgymTool(config)
+
+        mock_context = MagicMock()
+        mock_context.close.side_effect = Exception("Close failed")
+        tool._session = PlaywrightSession(
+            playwright=MagicMock(),
+            page=MagicMock(),
+            context=mock_context,
+            cdp_url="http://localhost:9222",
+            user_data_dir=tempfile.mkdtemp(prefix="cube_browser_tool_"),
+        )
+        tool._last_obs = {"some": "data"}
+
+        tool.close()
+
+        assert tool._session is None
+        assert tool._last_obs is None
+
+    def test_close_noop_when_no_browser(self) -> None:
+        config = BgymToolConfig()
+        tool = BgymTool(config)
+
+        tool.close()
+
+
+# HTML page with a keydown-based autocomplete simulation.
+# fill() sets the value directly without firing keydown/keypress — suggestions stay empty.
+# press_sequentially() fires a full keyboard event sequence per character — suggestions appear.
+# bgym BIDs for top-level elements are numeric strings ("1", "2", ...).
+# Leading lowercase letters are parsed as iframe-descent prefixes by get_elem_by_bid.
+_AUTOCOMPLETE_BID = "1"
+_AUTOCOMPLETE_PAGE = """<!DOCTYPE html>
+<html><body>
+  <input {bid_attr}="{bid}" id="search">
+  <ul id="suggestions"></ul>
+  <script>
+    window.keydownCount = 0;
+    document.getElementById('search').addEventListener('keydown', function(e) {{
+      if (e.key.length === 1) {{
+        window.keydownCount++;
+        const li = document.createElement('li');
+        li.textContent = e.key;
+        document.getElementById('suggestions').appendChild(li);
+      }}
+    }});
+  </script>
+</body></html>""".format(bid_attr=BROWSERGYM_ID_ATTRIBUTE, bid=_AUTOCOMPLETE_BID)
+
+
+@pytest.fixture(scope="module")
+def live_page() -> Generator[Page, None, None]:
+    """Real headless Chromium page configured with bgym's test-id attribute."""
+    with sync_playwright() as p:
+        p.selectors.set_test_id_attribute(BROWSERGYM_ID_ATTRIBUTE)
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+        yield page
+        browser.close()
+
+
+@pytest.mark.integration
+class TestKeyboardTypeIntoVsFill:
+    """Integration tests verifying keyboard_type_into fires keydown events that fill() skips."""
+
+    def test_fill_does_not_fire_keydown_events(self, live_page: Page) -> None:
+        live_page.set_content(_AUTOCOMPLETE_PAGE)
+
+        get_elem_by_bid(live_page, _AUTOCOMPLETE_BID).fill("hello")
+
+        keydown_count = live_page.evaluate("window.keydownCount")
+        assert keydown_count == 0, "fill() must not fire keydown events"
+        suggestions = live_page.locator("#suggestions li").count()
+        assert suggestions == 0
+
+    def test_press_sequentially_fires_keydown_per_character(self, live_page: Page) -> None:
+        live_page.set_content(_AUTOCOMPLETE_PAGE)
+
+        get_elem_by_bid(live_page, _AUTOCOMPLETE_BID).press_sequentially("hello", delay=0)
+
+        keydown_count = live_page.evaluate("window.keydownCount")
+        assert keydown_count == 5, "press_sequentially must fire one keydown per character"
+        suggestions = live_page.locator("#suggestions li").count()
+        assert suggestions == 5
+
+    def test_keyboard_type_into_action_fires_keydown_events(self, live_page: Page) -> None:
+        """End-to-end: ExtraWebActionsTool.keyboard_type_into reaches the element via get_elem_by_bid."""
+        live_page.set_content(_AUTOCOMPLETE_PAGE)
+
+        bgym = BgymTool(BgymToolConfig())
+        bgym._session = MagicMock()
+        bgym._session.page = live_page
+        extra = ExtraWebActionsTool(bgym)
+
+        result = extra.keyboard_type_into(_AUTOCOMPLETE_BID, "abc")
+
+        assert result == "Success"
+        keydown_count = live_page.evaluate("window.keydownCount")
+        assert keydown_count == 3
+        suggestions = live_page.locator("#suggestions li").count()
+        assert suggestions == 3

--- a/cube-tools/cube-browser-tool/uv.lock
+++ b/cube-tools/cube-browser-tool/uv.lock
@@ -313,7 +313,7 @@ wheels = [
 
 [[package]]
 name = "cube-browser-tool"
-version = "0.1.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -326,6 +326,7 @@ dependencies = [
 [package.optional-dependencies]
 bgym = [
     { name = "browsergym-core" },
+    { name = "numpy" },
 ]
 dev = [
     { name = "pytest" },
@@ -338,6 +339,7 @@ requires-dist = [
     { name = "browsergym-core", marker = "extra == 'bgym'" },
     { name = "cube-browser-playwright" },
     { name = "cube-standard" },
+    { name = "numpy", marker = "extra == 'bgym'" },
     { name = "pillow", specifier = ">=9.0" },
     { name = "playwright" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },


### PR DESCRIPTION
## Summary

Phase 1 of the tools-architecture migration (cube-standard #159) / Phase 3 of `cube-browser-tool/PLAN.md`. **Behaviour-preserving relocation** of the BrowserGym-backed browser tool out of `cube-harness` (where tool implementations must not live, per the packaging rule) into the slot the config-registry refactor already reserved in this package.

## What moved

| From (cube-harness) | To (this PR) |
|---|---|
| `src/cube_harness/tools/browsergym.py` :: `BrowsergymConfig` / `BrowsergymTool` | `src/cube_browser_tool/bgym_tool.py` :: `BgymToolConfig` / `BgymTool` |
| `src/cube_harness/tools/web_actions.py` :: `ExtraWebActionsTool` / `ExtendedBrowserConfig` | folded into `bgym_tool.py` |
| `tests/test_browsergym.py` | `tests/test_bgym_tool.py` |

Names match what the package `__init__.py` docstring and `PLAN.md` already reserved (`BgymTool` / `BgymToolConfig`).

## Behaviour preserved

Verbatim port — same BrowserGym-native action set (`HighLevelActionSet` → bgym code strings), same DOM/AXTree/screenshot observation extraction, same `BrowserTool`-ABC surface (`session`/`goto`/`evaluate_js`/`page_obs`/`noop`). **No action-vocabulary change**, so WorkArena / MiniWob / WebArena scores are unaffected. This is PLAN.md "Approach B" (lean, standalone BrowserGym functions on a Playwright `Page`, no `BrowserEnv`) — which is what the cube-harness implementation already did, so it's a straight port not a rewrite.

## Optional dependency handling

`bgym_tool.py` wraps its `browsergym.*` imports in `try/except ImportError` raising a clear `pip install cube-browser-tool[bgym]` hint. The module is **not** imported from the package `__init__.py` (per PLAN.md), so `import cube_browser_tool` still works without the extra.

- `pyproject.toml`: `0.2.0` → `0.3.0`; `bgym` extra gains `numpy`.

## Test plan

- [x] `uvx ruff check` + `ruff format --check` — pass
- [x] `pytest tests/test_bgym_tool.py -m "not integration"` — **52 passed**
- [x] `pytest tests/ -m "not integration"` (full package) — **78 passed, no regressions**
- [ ] Integration tests (`-m integration`, live Chromium) — run in CI / by reviewer

## Companion PR

cube-harness — deletes `tools/browsergym.py` + `tools/web_actions.py`, points the 3 web cubes (`workarena`, `miniwob`, `webarena-verified`) + meta-agent at `cube_browser_tool.bgym_tool`, swaps each cube's `cube-browser-tool` dep to the `[bgym]` extra. `Depends-on: cube-standard/feat/cube-browsergym-tool`.

Refs: #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)