### PR TITLE
feat(cli): add -v/--verbose flag to cube test to surface INFO logs

### DIFF
--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -60,6 +60,7 @@ Options:
 - `--no-reset-check` — skip reset reproducibility check (useful in CI where the check is slow)
 - `--output PATH` — save report JSON
 - `--ci` — suppress Rich dashboard, plain-text output (also enabled by `CUBE_CI=1`)
+- `-v`, `--verbose` — surface INFO-level logs from cube internals (infra launch, provisioning, task lifecycle); default shows WARNING+ only
 
 ### `cube registry add [PATH]`
 Generates `cube-registry-entry.yaml` from `pyproject.toml` at `PATH` (default cwd).

--- a/src/cube/cli.py
+++ b/src/cube/cli.py
@@ -37,6 +37,7 @@ import base64
 import importlib
 import importlib.metadata
 import json
+import logging
 import os
 import re
 import shutil
@@ -483,6 +484,22 @@ def _resolve_debug_module(name: str) -> str:
     return f"{package_root}.debug"
 
 
+def _enable_verbose_logging() -> None:
+    """Surface INFO-level logs from cube internals during ``cube test``.
+
+    ``cube test`` does not configure logging, so only WARNING+ is shown and the
+    many ``logger.info(...)`` calls around infra launch / provisioning / task
+    lifecycle are swallowed. This installs a basic stderr handler at INFO and
+    raises the ``cube`` logger to INFO so those messages become visible even if
+    the root logger was already configured at a higher level elsewhere.
+    """
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    logging.getLogger("cube").setLevel(logging.INFO)
+
+
 def cmd_test(
     module_name: str,
     *,
@@ -492,6 +509,7 @@ def cmd_test(
     demo_reset_repro: bool = False,
     stress_test: bool = False,
     reset_check: bool = True,
+    verbose: bool = False,
 ) -> None:
     """Import *module_name* (or resolve an entry-point name) and run the debug compliance suite.
 
@@ -507,7 +525,12 @@ def cmd_test(
     When *demo_reset_repro* is True (or ``CUBE_DEMO_RESET_REPRO=1``), after a successful run the
     non-CI dashboard shows sample reset-reproducibility failure output (plain-text block + compliance)
     for UI review; the process still exits 0 if all tasks passed. Ignored when *ci_mode* is True.
+
+    When *verbose* is True (``-v`` / ``--verbose``), INFO-level logs from cube
+    internals are surfaced to stderr (otherwise only WARNING+ is shown).
     """
+    if verbose:
+        _enable_verbose_logging()
     ci_mode = ci_mode or bool(os.environ.get("CUBE_CI"))
     demo_reset_repro = demo_reset_repro or (os.environ.get("CUBE_DEMO_RESET_REPRO") == "1")
     from cube.testing import (
@@ -1385,6 +1408,7 @@ def _print_help() -> None:
         "[cmd]--no-reset-check[/cmd] (skip reset-reproducibility check — saves ~1 extra reset in CI), "
         "[cmd]--ci[/cmd] (plain-text CI output, also set via CUBE_CI=1), "
         "[cmd]--output=PATH[/cmd] (save JSON report), [cmd]--max-steps=N[/cmd], "
+        "[cmd]-v/--verbose[/cmd] (surface INFO logs from cube internals), "
         "[cmd]--demo-reset-repro[/cmd] (preview reset-repro output, non-CI; also [cmd]CUBE_DEMO_RESET_REPRO=1[/cmd])",
         "cube test counter-cube --stress",
     )
@@ -1457,6 +1481,7 @@ def main() -> None:
         demo_reset_repro = False
         stress_test = False
         reset_check = True
+        verbose = False
         remaining = args[2:]
         for opt in remaining:
             if opt.startswith("--max-steps="):
@@ -1473,6 +1498,8 @@ def main() -> None:
                 reset_check = False
             elif opt == "--demo-reset-repro":
                 demo_reset_repro = True
+            elif opt in ("-v", "--verbose"):
+                verbose = True
         cmd_test(
             args[1],
             max_steps=max_steps,
@@ -1481,6 +1508,7 @@ def main() -> None:
             demo_reset_repro=demo_reset_repro,
             stress_test=stress_test,
             reset_check=reset_check,
+            verbose=verbose,
         )
     elif command == "registry":
         subcmd = args[1] if len(args) > 1 else ""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 """Tests for cube.cli — covers cmd_init, cmd_list, cmd_test, _resolve_debug_module, main(), and registry helpers."""
 
+import logging
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -550,6 +551,7 @@ def test_main_test_dispatches_with_default_max_steps():
         demo_reset_repro=False,
         stress_test=False,
         reset_check=True,
+        verbose=False,
     )
 
 
@@ -565,6 +567,7 @@ def test_main_test_dispatches_with_custom_max_steps():
         demo_reset_repro=False,
         stress_test=False,
         reset_check=True,
+        verbose=False,
     )
 
 
@@ -580,7 +583,50 @@ def test_main_test_dispatches_demo_reset_repro():
         demo_reset_repro=True,
         stress_test=False,
         reset_check=True,
+        verbose=False,
     )
+
+
+def test_main_test_dispatches_verbose_short_flag():
+    with patch("cube.cli.cmd_test") as mock_test:
+        with patch.object(sys, "argv", ["cube", "test", "counter-cube", "-v"]):
+            main()
+    mock_test.assert_called_once_with(
+        "counter-cube",
+        max_steps=20,
+        output_path=None,
+        ci_mode=False,
+        demo_reset_repro=False,
+        stress_test=False,
+        reset_check=True,
+        verbose=True,
+    )
+
+
+def test_main_test_dispatches_verbose_long_flag():
+    with patch("cube.cli.cmd_test") as mock_test:
+        with patch.object(sys, "argv", ["cube", "test", "counter-cube", "--verbose"]):
+            main()
+    assert mock_test.call_args.kwargs["verbose"] is True
+
+
+def test_enable_verbose_logging_raises_cube_logger_to_info():
+    cube_logger = logging.getLogger("cube")
+    root = logging.getLogger()
+    saved_level = cube_logger.level
+    saved_root_level = root.level
+    saved_root_handlers = root.handlers[:]
+    try:
+        cube_logger.setLevel(logging.WARNING)
+        cli._enable_verbose_logging()
+        assert cube_logger.level == logging.INFO
+        # An INFO record from a cube-namespaced logger is now emittable
+        # (not filtered out by the logger's effective level).
+        assert cube_logger.isEnabledFor(logging.INFO)
+    finally:
+        cube_logger.setLevel(saved_level)
+        root.setLevel(saved_root_level)
+        root.handlers[:] = saved_root_handlers
 
 
 def test_cmd_test_demo_reset_repro_shows_reset_error_panel(fake_debug_in_sys_modules):


### PR DESCRIPTION
## What
Adds `-v` / `--verbose` to `cube test`. By default the CLI configures no logging, so only WARNING+ is shown and the many `logger.info(...)` calls around infra launch / provisioning / task lifecycle are swallowed. `-v` installs a stderr handler at INFO and raises the `cube` logger to INFO (robust even if the root logger was already configured elsewhere).

Closes #134.

## Changes
- `src/cube/cli.py` — `import logging`; `_enable_verbose_logging()` helper; `verbose` param on `cmd_test`; `-v`/`--verbose` parsing in `main()`'s `test` branch; help-text entry.
- `openspec/specs/cli/spec.md` — documents the new option (keeps the spec's option list aligned).
- `tests/test_cli.py` — 3 new tests (`-v` wiring, `--verbose` wiring, helper raises `cube` logger to INFO with state save/restore) + updated 3 existing dispatch assertions for the new kwarg.

## Verification
- `make lint` → all checks passed, formatting clean.
- `make test` → 586 passed, 1 pre-existing unrelated skip.
- Live E2E: `cube test counter-cube --ci --no-reset-check -v` surfaces INFO from `cube.testing`/`counter_cube.debug`, exit 0; without `-v` → 0 INFO lines (baseline preserved).

## Notes
No smoke script added — logic is deterministic and fully unit-tested + verified live; CLAUDE.md reserves smokes for plumbing unit tests cannot reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)