### PR TITLE
chore: version the dev window (0.1.0rc8 → 0.1.0rc9)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,6 +124,28 @@ Large changes to the core protocol — new abstract methods, breaking type chang
 
 Active proposals live in [`openspec/changes/`](openspec/changes/).
 
+## Releases & dev versioning
+
+Releases are tag-driven and per-package: pushing a `cube-standard/v*`,
+`cube-tools/*/v*`, or `cube-resources/*/v*` tag triggers
+[`release.yml`](.github/workflows/release.yml), which builds and publishes
+that package to PyPI.
+
+**The `dev` branch always carries the *next* unreleased version**, never the
+last published one. Concretely: immediately after a release, bump the `dev`
+`version` to the next pre-release (e.g. publish `0.1.0rc8` → bump `dev` to
+`0.1.0rc9`).
+
+Why this matters: cube-harness and the cubes pin `cube-standard>=<rcN>`. If
+`dev` keeps the *published* version string while diverging (e.g. `dev` adds
+`ConfigRegistry` but stays `0.1.0rc8`), `uv` treats the dev build and the
+PyPI wheel as the same version and silently swaps the dev install for the
+PyPI one during cross-repo CI — producing confusing `ImportError`s for
+symbols that "exist on dev." A distinct dev version makes the two artifacts
+unambiguous and lets cross-repo installs resolve correctly without
+`--force-reinstall` workarounds. See cube-standard #167 for the full
+rationale and the companion ordered-release-pipeline work.
+
 ## Known gaps / TODOs
 
 Tracked inline in source:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cube-standard"
-version = "0.1.0rc8"
+version = "0.1.0rc9"
 description = "Common Unified Benchmark Environments"
 readme = "README.md"
 urls = { Repository = "https://github.com/The-AI-Alliance/cube-standard" }

--- a/uv.lock
+++ b/uv.lock
@@ -759,7 +759,7 @@ dev = [{ name = "pytest", specifier = ">=9.0" }]
 
 [[package]]
 name = "cube-standard"
-version = "0.1.0rc8"
+version = "0.1.0rc9"
 source = { editable = "." }
 dependencies = [
     { name = "docstring-parser" },


### PR DESCRIPTION
Recommendation **A** from #167, as a PR (not just tracked).

## Problem

`dev`'s `pyproject.toml` was `0.1.0rc8` — identical to the published `cube-standard/v0.1.0rc8` tag and the PyPI wheel — while `dev` had diverged substantially (`ConfigRegistry`, the TerminalTool split, `Task` generic, `BgymTool`, …).

Because the version strings matched, `uv` treated the dev build and the PyPI wheel as the same version. `uv pip install -e cubes/<x>` silently swapped the dev install for the PyPI wheel during cross-repo CI → `ImportError: cannot import name 'ConfigRegistry' from 'cube.core'` (observed on cube-harness #398), forcing `--force-reinstall --no-deps` + `uv run --no-sync` workarounds in every cross-repo workflow.

## Change

- `pyproject.toml`: `0.1.0rc8` → `0.1.0rc9` (+ `uv.lock` regenerated).
- `CONTRIBUTING.md`: new **"Releases & dev versioning"** section documenting the tag-driven per-package release model and the convention: *dev always carries the next unreleased pre-release; bump immediately after each release.*

A distinct dev version makes the dev artifact unambiguous — `uv` keeps the higher installed version instead of clobbering it with the PyPI wheel. Once this propagates, the cross-repo CI overrides added during the tools-architecture work can be simplified (tracked in #167).

## Scope

This is **A only**. Recommendation **B** (ordered release pipeline with post-publish verification gates) is a change to the live release path (`release.yml`) and stays in #167 for its own focused PR. **C** (`Depends-on:` CI automation) remains a separate optional investment.

## Test plan

- [x] `uv sync` → installed `cube-standard 0.1.0rc9`
- [x] `uv run pytest tests/ -m "not integration"` — **433 passed**, 1 skipped (unrelated)
- [x] Version bumped in both `pyproject.toml` and `uv.lock` (self-reference)

Refs: #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)