### PR TITLE
fix: docker-client + debug-suite robustness (tbench2 shakeout)

### DIFF
--- a/src/cube/container.py
+++ b/src/cube/container.py
@@ -152,7 +152,7 @@ def relocate_if_readonly(
         cmd += f" && {extra_setup}"
     result = container.exec(cmd, timeout=300)
     if result.exit_code != 0:
-        raise RuntimeError(
+        raise ContainerExecError(
             f"relocate_if_readonly: '{cmd}' failed (exit {result.exit_code}); "
             f"working dir {new_wd!r} was not created. stderr: {result.stderr.strip()}"
         )

--- a/src/cube/container.py
+++ b/src/cube/container.py
@@ -150,7 +150,12 @@ def relocate_if_readonly(
     cmd = f"cp -a {working_dir} {new_wd}"
     if extra_setup:
         cmd += f" && {extra_setup}"
-    container.exec(cmd, timeout=300)
+    result = container.exec(cmd, timeout=300)
+    if result.exit_code != 0:
+        raise RuntimeError(
+            f"relocate_if_readonly: '{cmd}' failed (exit {result.exit_code}); "
+            f"working dir {new_wd!r} was not created. stderr: {result.stderr.strip()}"
+        )
     return new_wd
 
 

--- a/src/cube/infra_local.py
+++ b/src/cube/infra_local.py
@@ -33,6 +33,7 @@ import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from pathlib import Path
+from typing import Any
 
 from cube.infra_utils import build_volume_setup_script
 from cube.resource import (
@@ -58,6 +59,59 @@ _RATE_LIMIT_MARKERS = ("toomanyrequests", "rate limit", "429")
 _PULL_MAX_ATTEMPTS = 6
 _PULL_BACKOFF_BASE = 30.0
 _PULL_BACKOFF_CAP = 300.0
+
+
+def _active_docker_context_host() -> str | None:
+    """Best-effort daemon endpoint of the active ``docker context``, or ``None``.
+
+    The Docker SDK honours ``DOCKER_HOST`` but NOT ``docker context``; shelling
+    out to the CLI is the only reliable way to recover the endpoint on
+    Colima / Docker-Desktop, whose socket is not ``/var/run/docker.sock``.
+    """
+    try:
+        out = subprocess.run(
+            ["docker", "context", "inspect", "--format", "{{.Endpoints.docker.Host}}"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    host = out.stdout.strip()
+    return host or None
+
+
+def _make_docker_client(docker: Any) -> Any:
+    """Construct a Docker SDK client robustly across Podman / Colima / Docker Desktop.
+
+    Resolution order:
+
+    1. ``DOCKER_HOST`` if it names a real socket — normalising Podman's
+       ``http+unix://<path>`` to the ``unix://<path>`` the SDK accepts. A bare
+       ``http+unix://`` / ``unix://`` (no path) is malformed and treated as unset.
+    2. The active ``docker context`` endpoint (covers Colima / Docker-Desktop).
+    3. ``docker.from_env()``.
+
+    Raises an actionable ``RuntimeError`` if the client cannot reach the daemon,
+    instead of the SDK's opaque ``FileNotFoundError``.
+    """
+    host = os.environ.get("DOCKER_HOST", "").strip()
+    if host.startswith("http+unix://"):
+        host = host[len("http+") :]  # podman advertises http+unix://; SDK wants unix://
+    if host in ("", "unix://", "tcp://"):  # unset or malformed (scheme without a path)
+        host = _active_docker_context_host() or ""
+
+    try:
+        client = docker.DockerClient(base_url=host) if host else docker.from_env()
+        client.ping()
+    except Exception as exc:
+        raise RuntimeError(
+            f"Cannot reach the Docker daemon (tried base_url="
+            f"{host or '(docker.from_env)'!r}). Set DOCKER_HOST to a valid socket "
+            "or check `docker context ls` — Colima / Docker-Desktop use a "
+            "non-default socket the Docker SDK does not auto-discover."
+        ) from exc
+    return client
 
 
 def _docker_pull(image: str) -> None:
@@ -384,14 +438,7 @@ class LocalDockerServiceHandle(ResourceHandle):
 
         from cube.local_container import LocalContainer
 
-        # Podman advertises DOCKER_HOST with http+unix:// but the Docker SDK
-        # only accepts unix://. Normalize locally rather than mutating os.environ
-        # (which would be a process-global side effect visible to other workers).
-        _host = os.environ.get("DOCKER_HOST", "")
-        if _host.startswith("http+unix://"):
-            client = docker.DockerClient(base_url=_host[len("http+") :])
-        else:
-            client = docker.from_env()
+        client = _make_docker_client(docker)
         docker_container = client.containers.get(self._container_ids[0])
         # remove_on_close=False — this handle, not the wrapper, owns the lifecycle.
         self._container_cache = LocalContainer(docker_container, client, remove_on_close=False)

--- a/src/cube/testing.py
+++ b/src/cube/testing.py
@@ -484,9 +484,18 @@ def run_debug_suite(
             for tc in task_configs:
                 if on_episode_start is not None:
                     on_episode_start(tc.task_id)
-                results.append(_episode_for_config(tc))
+                try:
+                    report = _episode_for_config(tc)
+                except Exception as exc:
+                    logger.exception(
+                        "[run_debug_suite] benchmark=%r serial episode failed task_id=%r",
+                        benchmark_name,
+                        tc.task_id,
+                    )
+                    report = _make_error_report(tc, exc)
+                results.append(report)
                 if on_episode_done is not None:
-                    on_episode_done(results[-1])
+                    on_episode_done(report)
         else:
             # Snapshot _runtime_context key→value-identity before parallel run.
             # Any mutation (new key, deleted key, or reassigned value) during

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,0 +1,35 @@
+"""Tests for cube.container module-level helpers."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from cube.container import ExecResult, relocate_if_readonly
+
+
+def _container(probe: ExecResult, copy: ExecResult) -> MagicMock:
+    c = MagicMock()
+    c.exec.side_effect = [probe, copy]
+    return c
+
+
+def test_relocate_returns_original_when_writable() -> None:
+    c = MagicMock()
+    c.exec.return_value = ExecResult(stdout="W", exit_code=0)
+    assert relocate_if_readonly(c, "/app", "/tmp/app") == "/app"
+    c.exec.assert_called_once()  # only the probe; no copy
+
+
+def test_relocate_copies_and_returns_new_wd_on_success() -> None:
+    c = _container(ExecResult(stdout="R", exit_code=0), ExecResult(exit_code=0))
+    assert relocate_if_readonly(c, "/app", "/tmp/app") == "/tmp/app"
+
+
+def test_relocate_raises_when_copy_fails_instead_of_returning_phantom_dir() -> None:
+    """A failed `cp -a` must raise — never silently return a non-existent dir."""
+    c = _container(
+        ExecResult(stdout="R", exit_code=0),
+        ExecResult(exit_code=1, stderr="cp: cannot stat '/app': No such file or directory"),
+    )
+    with pytest.raises(RuntimeError, match=r"relocate_if_readonly.*failed.*was not created"):
+        relocate_if_readonly(c, "/app", "/tmp/app")

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from cube.container import ExecResult, relocate_if_readonly
+from cube.container import ContainerExecError, ExecResult, relocate_if_readonly
 
 
 def _container(probe: ExecResult, copy: ExecResult) -> MagicMock:
@@ -31,5 +31,5 @@ def test_relocate_raises_when_copy_fails_instead_of_returning_phantom_dir() -> N
         ExecResult(stdout="R", exit_code=0),
         ExecResult(exit_code=1, stderr="cp: cannot stat '/app': No such file or directory"),
     )
-    with pytest.raises(RuntimeError, match=r"relocate_if_readonly.*failed.*was not created"):
+    with pytest.raises(ContainerExecError, match=r"relocate_if_readonly.*failed.*was not created"):
         relocate_if_readonly(c, "/app", "/tmp/app")

--- a/tests/test_infra_local.py
+++ b/tests/test_infra_local.py
@@ -456,3 +456,44 @@ class TestDockerPull:
                 _mod._docker_pull("python:3.12-slim")
         assert run.call_count == _mod._PULL_MAX_ATTEMPTS
         assert sleep.call_count == _mod._PULL_MAX_ATTEMPTS - 1
+
+
+# ── _make_docker_client — robust client construction (#1/#3) ──────────────────
+
+
+class TestMakeDockerClient:
+    def test_malformed_bare_http_unix_falls_back_to_from_env(self, monkeypatch) -> None:
+        """A bare ``http+unix://`` (no socket path) is malformed — must be
+        treated as unset, not turned into a broken ``unix://`` client."""
+        monkeypatch.setenv("DOCKER_HOST", "http+unix://")
+        docker = MagicMock()
+        with patch.object(_mod, "_active_docker_context_host", return_value=None):
+            client = _mod._make_docker_client(docker)
+        docker.from_env.assert_called_once()
+        docker.DockerClient.assert_not_called()
+        assert client is docker.from_env.return_value
+
+    def test_podman_http_unix_with_path_is_normalised(self, monkeypatch) -> None:
+        monkeypatch.setenv("DOCKER_HOST", "http+unix:///run/user/1000/podman/podman.sock")
+        docker = MagicMock()
+        _mod._make_docker_client(docker)
+        docker.DockerClient.assert_called_once_with(base_url="unix:///run/user/1000/podman/podman.sock")
+
+    def test_unset_host_uses_docker_context_endpoint(self, monkeypatch) -> None:
+        monkeypatch.delenv("DOCKER_HOST", raising=False)
+        docker = MagicMock()
+        with patch.object(_mod, "_active_docker_context_host", return_value="unix:///x/colima.sock"):
+            _mod._make_docker_client(docker)
+        docker.DockerClient.assert_called_once_with(base_url="unix:///x/colima.sock")
+
+    def test_unreachable_daemon_raises_actionable_error(self, monkeypatch) -> None:
+        monkeypatch.delenv("DOCKER_HOST", raising=False)
+        docker = MagicMock()
+        docker.from_env.return_value.ping.side_effect = OSError("No such file or directory")
+        with patch.object(_mod, "_active_docker_context_host", return_value=None):
+            with pytest.raises(RuntimeError, match=r"Cannot reach the Docker daemon.*docker context ls"):
+                _mod._make_docker_client(docker)
+
+    def test_active_docker_context_host_swallows_missing_cli(self) -> None:
+        with patch.object(_mod.subprocess, "run", side_effect=FileNotFoundError("docker")):
+            assert _mod._active_docker_context_host() is None

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -257,6 +257,33 @@ def test_suite_parallel_workers_collects_all_episode_results_when_first_task_rai
     assert results[1].get("error") in (None, "")
 
 
+def test_suite_serial_collects_all_episode_results_when_first_task_raises():
+    """Serial path must mirror the parallel one: a crash in an earlier task
+    becomes a structured error report so later tasks still run (no false-green
+    from an exception escaping run_debug_suite with zero results)."""
+
+    class FirstFailsTaskConfig(TaskConfig):
+        def make(self, runtime_context=None):
+            if self.task_id == "t1":
+                raise RuntimeError("t1 make failed")
+            return DoneTask(metadata=self.metadata, tool_config=NoopToolConfig())
+
+    class FirstFailsBenchmarkConfig(DoneBenchmarkConfig):
+        task_config_class: ClassVar = FirstFailsTaskConfig
+
+    mod = ModuleType("fake_debug")
+    config = FirstFailsBenchmarkConfig().subset_from_list(["t1", "t2"])
+    mod.get_debug_benchmark = lambda: config  # type: ignore[attr-defined]
+    mod.make_debug_agent = lambda tid: stop_agent  # type: ignore[attr-defined]
+
+    results = run_debug_suite("bench", mod, print_json=False, workers=1)
+    assert len(results) == 2
+    assert results[0]["task_id"] == "t1"
+    assert results[0]["error"] is not None and "t1 make failed" in results[0]["error"]
+    assert results[1]["task_id"] == "t2"
+    assert results[1].get("error") in (None, "")
+
+
 # ── run_debug_suite — benchmark lifecycle ────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Four independent robustness bugs surfaced while running **terminalbench2** under local Docker (Colima) during a cube-harness investigator shakeout. All are upstream cube-standard issues; none are contract changes.

- **`run_debug_suite` serial path false-green** (`testing.py`) — the serial branch (`workers<=1`, what `cube test` uses) called `_episode_for_config(tc)` with no try/except. A `DockerException` (or any make/episode crash) propagated out of the loop → later tasks never ran → zero structured results → the cube's `failed = [...]` filter saw an empty list and **reported success**. Now mirrors the parallel path's `try/except → _make_error_report`.
- **`relocate_if_readonly` phantom working dir** (`container.py`) — ran `cp -a {wd} {new_wd}` and unconditionally returned `new_wd` without checking the exec exit code. On copy failure it returned a directory that was never created; callers `chdir`'d into it → opaque failure. Now raises a clear `RuntimeError` with stderr.
- **Brittle `http+unix://` shim + `docker context` blindness** (`infra_local.py`) — `DOCKER_HOST` handling assumed `http+unix://<realpath>`; a bare `http+unix://` became a broken `unix://` client. The Docker SDK honours `DOCKER_HOST` but **not** `docker context`, so Colima/Docker-Desktop sockets failed with an opaque `FileNotFoundError`. Consolidated into `_make_docker_client`: normalise only when a real path follows → fall back to the active `docker context` endpoint → `docker.from_env()`, and raise an **actionable** error on an unreachable daemon.

## Test plan

- [x] `tests/` full suite: **449 passed, 1 skipped**, 0 failed
- [x] New regression tests: serial debug-suite collects all results when first task raises; `relocate_if_readonly` raises on copy failure / returns correctly on success; `_make_docker_client` normalisation / context-fallback / actionable-error / `_active_docker_context_host` missing-CLI
- [x] Pre-existing `test_environ_not_mutated_for_podman_host` still passes (refactor preserves the no-`os.environ`-mutation contract)
- [x] `ruff check .` + `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)