### PR TITLE
fix(terminal): report absolute resolved path in read_file/write_file

### DIFF
--- a/src/cube/tools/terminal.py
+++ b/src/cube/tools/terminal.py
@@ -43,7 +43,7 @@ import logging
 import re
 import shlex
 from abc import abstractmethod
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Literal
 
 from cube.container import Container, ExecResult
@@ -214,6 +214,17 @@ class ContainerTerminalTool(TerminalTool):
             ]
         return actions
 
+    def _resolved_path(self, path: str) -> str:
+        """Absolute in-container path a relative *path* actually lands at.
+
+        Every action ``exec``s with ``workdir=self._config.working_dir`` and
+        shell state does not persist between calls, so a relative path always
+        resolves against the static working dir — never the directory a prior
+        ``bash`` ``cd``'d into. Reporting the resolved absolute path makes that
+        (otherwise silent) mismatch immediately visible to the caller.
+        """
+        return str(PurePosixPath(self._config.working_dir) / path)
+
     def bash_unlimited(self, command: str, timeout: int = 120) -> str:
         """Like ``bash()`` but without output truncation — for internal harness use only.
 
@@ -271,11 +282,11 @@ class ContainerTerminalTool(TerminalTool):
             cmd = f"sed -n '{start},{end}p' {shlex.quote(path)}"
             result = self._container.exec(cmd, workdir=self._config.working_dir)
             if result.exit_code != 0:
-                return f"Error reading {path}: {result.stderr or result.stdout}"
+                return f"Error reading {self._resolved_path(path)}: {result.stderr or result.stdout}"
             return result.stdout
         result = self._container.exec(f"cat {shlex.quote(path)}", workdir=self._config.working_dir)
         if result.exit_code != 0:
-            return f"Error reading {path}: {result.stderr or result.stdout}"
+            return f"Error reading {self._resolved_path(path)}: {result.stderr or result.stdout}"
         encoded = result.stdout.encode("utf-8")
         if len(encoded) > self._config.max_output_bytes:
             size_kb = len(encoded) // 1024
@@ -288,7 +299,9 @@ class ContainerTerminalTool(TerminalTool):
 
         Args:
             path: Destination path. Parent directories are created as needed.
-                Relative paths resolve against the working directory.
+                Relative paths resolve against the working directory (NOT any
+                directory a prior ``bash`` ``cd``'d into — shell state does not
+                persist). The result echoes the absolute path written.
             content: Full file contents to write. This is not a patch tool —
                 pass the entire new file body.
         """
@@ -301,6 +314,7 @@ class ContainerTerminalTool(TerminalTool):
             f"printf '%s' '{escaped}' > {shlex.quote(path)}",
             workdir=self._config.working_dir,
         )
+        resolved = self._resolved_path(path)
         if result.exit_code != 0:
-            return f"Error writing {path}: {result.stderr or result.stdout}"
-        return f"Wrote {len(content)} bytes to {path}"
+            return f"Error writing {resolved}: {result.stderr or result.stdout}"
+        return f"Wrote {len(content)} bytes to {resolved}"

--- a/tests/test_terminal_tool.py
+++ b/tests/test_terminal_tool.py
@@ -312,6 +312,42 @@ class TestTerminalToolWriteFile:
         assert "Error writing" in result
 
 
+class TestTerminalToolResolvedPath:
+    """A relative path resolves against the static working_dir, never a prior
+    `cd` (shell state does not persist). The reported path must be absolute so
+    that mismatch is visible instead of silently corrupting the wrong file."""
+
+    def test_relative_write_reports_absolute_resolved_path(self) -> None:
+        container = MagicMock()
+        container.exec.return_value = ExecResult(stdout="", stderr="", exit_code=0)
+        tool = ContainerTerminalTool(
+            config=TerminalToolConfig(enable_file_actions=True, working_dir="/repo"),
+            container=container,
+        )
+        result = tool.write_file("src/app.py", "x")
+        assert "/repo/src/app.py" in result
+
+    def test_absolute_write_path_passes_through(self) -> None:
+        container = MagicMock()
+        container.exec.return_value = ExecResult(stdout="", stderr="", exit_code=0)
+        tool = ContainerTerminalTool(
+            config=TerminalToolConfig(enable_file_actions=True, working_dir="/repo"),
+            container=container,
+        )
+        result = tool.write_file("/etc/hosts", "x")
+        assert "/etc/hosts" in result and "/repo/etc" not in result
+
+    def test_relative_read_error_reports_absolute_resolved_path(self) -> None:
+        container = MagicMock()
+        container.exec.return_value = ExecResult(stdout="", stderr="No such file", exit_code=1)
+        tool = ContainerTerminalTool(
+            config=TerminalToolConfig(enable_file_actions=True, working_dir="/repo"),
+            container=container,
+        )
+        result = tool.read_file("missing.txt")
+        assert "Error reading /repo/missing.txt" in result
+
+
 # ---------------------------------------------------------------------------
 # _parse_line_range
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`TerminalTool` (`cube/tools/terminal.py`) actions (`bash`, `read_file`, `write_file`) each `exec` with `workdir=self._config.working_dir`, and shell state does **not** persist between calls (`bash` documents this). So a **relative** path always resolves against the *static* working dir — never a directory a prior `bash` `cd`'d into.

`write_file`/`read_file` echoed the raw relative path, making that mismatch **silent**: an agent that `cd`'d elsewhere then wrote a relative path corrupted a file in the wrong location with no signal. Surfaced by a terminalbench2 `fix-git` trajectory during an investigator shakeout — the agent only recovered via a single-command `cd X && heredoc`.

This is the **lean anti-footgun**: no behaviour change (path resolution is identical), but the success/error messages now report the **absolute path the action actually hit**, so the mismatch is immediately visible. A proper stateful-session working directory is a larger contract change tracked separately (not in scope here).

## Test plan

- [x] `tests/` full suite: **443 passed**, 1 skipped, 0 failed
- [x] New `TestTerminalToolResolvedPath`: relative write/read-error report the absolute resolved path; absolute paths pass through unchanged
- [x] `ruff check` + `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)