### PR TITLE
chore(auto-fix): backfill provenance for tbench2-shakeout fixes (#174-#177)

### DIFF
--- a/src/cube/container.py
+++ b/src/cube/container.py
@@ -150,12 +150,14 @@ def relocate_if_readonly(
     cmd = f"cp -a {working_dir} {new_wd}"
     if extra_setup:
         cmd += f" && {extra_setup}"
+    # auto-fix(176)↓
     result = container.exec(cmd, timeout=300)
     if result.exit_code != 0:
         raise ContainerExecError(
             f"relocate_if_readonly: '{cmd}' failed (exit {result.exit_code}); "
             f"working dir {new_wd!r} was not created. stderr: {result.stderr.strip()}"
         )
+    # /auto-fix(176)
     return new_wd
 
 
@@ -191,3 +193,17 @@ class ContainerConfig(TypedBaseModel):
     gpu: bool = False
     disk_gb: float = 10.0
     ports: list[int] | None = None
+
+
+# === auto-fix notes ===  (spec: openspec/specs/auto-fix/spec.md)
+# auto-fix-note(176) {class=L1 issue=176 hash=PENDING ctx=docker/tbench2:prove-plus-comm/cube-standard@0e91ae1}
+#   symptoms:  tbench2 task prove-plus-comm -- image has a read-only/absent
+#              /app; `cp -a` failed but the exit code was discarded and the
+#              never-created new_wd returned, so callers chdir'd into a
+#              phantom dir. Trigger = image shape; infra-agnostic.
+#   invariant: relocate_if_readonly returns a dir that exists, or raises
+#              ContainerExecError -- never a path that was never created.
+#   why:       check result.exit_code; raise the module's domain exception
+#              (ContainerExecError), consistent with its error hierarchy.
+#   tested:    tests/test_container.py relocate cases.
+#   hash=PENDING: stamped by scripts/auto_fix_lint.py (Tier-1) on first run.

--- a/src/cube/infra_local.py
+++ b/src/cube/infra_local.py
@@ -61,6 +61,7 @@ _PULL_BACKOFF_BASE = 30.0
 _PULL_BACKOFF_CAP = 300.0
 
 
+# auto-fix(174)↓
 def _active_docker_context_host() -> str | None:
     """Best-effort daemon endpoint of the active ``docker context``, or ``None``.
 
@@ -112,6 +113,9 @@ def _make_docker_client(docker: Any) -> Any:
             "non-default socket the Docker SDK does not auto-discover."
         ) from exc
     return client
+
+
+# /auto-fix(174)
 
 
 def _docker_pull(image: str) -> None:
@@ -967,3 +971,17 @@ def _kill_entry(entry: dict) -> None:
         if p.exists():
             p.unlink()
             logger.debug("Removed overlay %s", p)
+
+
+# === auto-fix notes ===  (spec: openspec/specs/auto-fix/spec.md)
+# auto-fix-note(174) {class=L1 issue=174 hash=PENDING ctx=colima/macos-arm64/n-a/cube-standard@0e91ae1}
+#   symptoms:  tbench2 PI shakeout on a macOS/arm64 Colima box; malformed
+#              DOCKER_HOST=http+unix:// (no socket path) -> broken unix:// client,
+#              and from_env() missed Colima's non-default socket. Infra-specific:
+#              docker backend + OS + DOCKER_HOST are the load-bearing context.
+#   invariant: a Docker SDK client is built that reaches the daemon across
+#              Podman/Colima/Docker-Desktop, or fails with an actionable error.
+#   why:       single construction site; normalize http+unix only with a real
+#              path -> docker context endpoint -> from_env -> actionable error.
+#   tested:    tests/test_infra_local.py docker-client cases.
+#   hash=PENDING: stamped by scripts/auto_fix_lint.py (Tier-1) on first run.

--- a/src/cube/testing.py
+++ b/src/cube/testing.py
@@ -484,6 +484,7 @@ def run_debug_suite(
             for tc in task_configs:
                 if on_episode_start is not None:
                     on_episode_start(tc.task_id)
+                # auto-fix(175)↓
                 try:
                     report = _episode_for_config(tc)
                 except Exception as exc:
@@ -494,6 +495,7 @@ def run_debug_suite(
                     )
                     report = _make_error_report(tc, exc)
                 results.append(report)
+                # /auto-fix(175)
                 if on_episode_done is not None:
                     on_episode_done(report)
         else:
@@ -675,3 +677,17 @@ def assert_debug_tasks_reward_one(
         assert not report["error"], f"[{task_id}] Episode error: {report['error']}"
         assert report["done"], f"[{task_id}] Episode did not complete: {report}"
         assert report["reward"] == 1.0, f"[{task_id}] Expected reward=1.0, got {report['reward']}: {report}"
+
+
+# === auto-fix notes ===  (spec: openspec/specs/auto-fix/spec.md)
+# auto-fix-note(175) {class=L0 issue=175 hash=PENDING ctx=logic/cube-standard@0e91ae1}
+#   symptoms:  tbench2 shakeout; a DockerException in task 1 of the SERIAL
+#              branch (effective_workers<=1, what `cube test` uses) escaped,
+#              tasks 2..N never ran, empty results -> success reported on a
+#              crash. Pure control-flow; benchmark-/OS-/infra-agnostic.
+#   invariant: a per-task crash becomes a structured error report so later
+#              tasks still run -- it never escapes run_debug_suite.
+#   why:       serial branch now mirrors the parallel branch's existing
+#              try/except -> _make_error_report (restores symmetry).
+#   tested:    tests/test_testing.py::test_suite_serial_collects_all_episode_results_when_first_task_raises
+#   hash=PENDING: stamped by scripts/auto_fix_lint.py (Tier-1) on first run.

--- a/src/cube/tools/terminal.py
+++ b/src/cube/tools/terminal.py
@@ -214,6 +214,7 @@ class ContainerTerminalTool(TerminalTool):
             ]
         return actions
 
+    # auto-fix(177)↓
     def _resolved_path(self, path: str) -> str:
         """Absolute in-container path a relative *path* actually lands at.
 
@@ -224,6 +225,8 @@ class ContainerTerminalTool(TerminalTool):
         (otherwise silent) mismatch immediately visible to the caller.
         """
         return str(PurePosixPath(self._config.working_dir) / path)
+
+    # /auto-fix(177)
 
     def bash_unlimited(self, command: str, timeout: int = 120) -> str:
         """Like ``bash()`` but without output truncation — for internal harness use only.
@@ -318,3 +321,18 @@ class ContainerTerminalTool(TerminalTool):
         if result.exit_code != 0:
             return f"Error writing {resolved}: {result.stderr or result.stdout}"
         return f"Wrote {len(content)} bytes to {resolved}"
+
+
+# === auto-fix notes ===  (spec: openspec/specs/auto-fix/spec.md)
+# auto-fix-note(177) {class=L1 issue=177 hash=PENDING ctx=any-infra/tbench2:fix-git/cube-standard@0e91ae1}
+#   symptoms:  tbench2 fix-git; Genny did a relative write_file after a bash
+#              `cd`. Every action execs at the static working_dir (shell
+#              state never persists), so the file landed elsewhere and a
+#              commit was corrupted -- silently. Tool-level; infra-agnostic.
+#   invariant: a relative path reported by read_file/write_file is the
+#              absolute path it actually resolved to (the static working_dir).
+#   why:       lean anti-footgun (visible resolved path). The real fix -- a
+#              stateful session working dir -- is a deferred contract change
+#              (needs a cube-standard openspec proposal).
+#   tested:    tests/ terminal resolved-path cases.
+#   hash=PENDING: stamped by scripts/auto_fix_lint.py (Tier-1) on first run.


### PR DESCRIPTION
## Summary

Retroactive auto-fix provenance for the PI fixes that merged **without** it. #170/#171 landed before their backfill because the "merge all 5 now" instruction overtook the post-#173 gating; this restores the registry now that the methodology (`openspec/specs/auto-fix/`) is on cube-standard dev via #173.

| Marker | File | Finding | Class |
|---|---|---|---|
| `auto-fix(174)` | `infra_local.py` | #1+#3 robust docker-client construction | L1 |
| `auto-fix(175)` | `testing.py` | #2 serial debug-suite false-green | L0 |
| `auto-fix(176)` | `container.py` | #4 `relocate_if_readonly` → `ContainerExecError` | L1 |
| `auto-fix(177)` | `tools/terminal.py` | #6 resolved-path anti-footgun | L1 |

Each: one-line `# auto-fix(N)↓ … # /auto-fix(N)` markers around the merged fix region + a module-bottom footnote (machine line + prose: symptoms **with judged triggering context**, invariant, why, test). Backing issues #174–#177 hold the full Dossiers.

**Comments only — +68/−0, zero code lines touched.** `ruff check` + `ruff format` clean (proves the modules still parse — the only failure mode for comment-only additions; same basis as the #407 dogfood). The underlying fixes' own tests passed when #170/#171 merged.

`hash=PENDING` until the Tier-1 lint (`scripts/auto_fix_lint.py`, next increment) stamps the canonical normalized hash.

Closes #174 #175 #176 #177 on merge (L0/L1 → archive).

## Test plan

- [x] ruff check + format clean (parse-verified)
- [x] markers balanced 1/1, one footnote stanza per module
- [x] no code lines modified (diff is purely `# auto-fix*` comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)