### PR TITLE
fix(toolkit): actionable error when eai CLI absent (auto-fix 180)

### DIFF
--- a/cube-resources/cube-infra-toolkit/src/cube_infra_toolkit/toolkit.py
+++ b/cube-resources/cube-infra-toolkit/src/cube_infra_toolkit/toolkit.py
@@ -344,6 +344,15 @@ def _resolve_eai_account(eai_path: str, profile: str | None) -> str:
     Reads ``eai user get --fields account --no-header``, which prints exactly
     the account name in table format.
     """
+    # auto-fix(180)↓
+    if shutil.which(eai_path) is None:
+        raise ContainerLaunchError(
+            f"EAI CLI {eai_path!r} not found on PATH. The toolkit infra backend "
+            f"requires the EAI Toolkit CLI installed separately — it is NOT a pip "
+            f"dependency of cube-infra-toolkit. Install it, or point "
+            f"ToolkitInfraConfig(eai_path=...) at the binary."
+        )
+    # /auto-fix(180)
     env = {**os.environ}
     if profile:
         env["EAI_PROFILE"] = profile
@@ -430,3 +439,21 @@ def _publish_cube_bundle(full_name: str, eai_path: str, profile: str | None) -> 
             else:
                 raise ContainerLaunchError(f"eai data new {full_name} failed: {err[:500]}")
     logger.info("Cube assets published to %s", full_name)
+
+
+# === auto-fix notes ===  (spec: openspec/specs/auto-fix/spec.md)
+# auto-fix-note(180) {class=L1 issue=180 hash=PENDING ctx=macos-arm64/no-eai-cli/cube-standard@2dad056}
+#   symptoms:  PI infra-robustness session, Round 0 toolkit smoke on a box
+#              without the EAI CLI: ToolkitInfraConfig launch raised a raw
+#              FileNotFoundError: 'eai' (8-line traceback). eai is NOT a pip
+#              dep (toolkit deps = cube-standard+tenacity) — external CLI.
+#   invariant: a missing required external CLI yields ONE actionable error
+#              naming the tool + remediation, never a raw FileNotFoundError.
+#   why:       preflight shutil.which at the first eai call
+#              (_resolve_eai_account); raise the file's domain
+#              ContainerLaunchError. Mirrors the #1/#3 actionable-error
+#              pattern already shipped in #170; right layer (the toolkit
+#              adapter owns its CLI-dependency contract).
+#   tested:    tests/ — shutil.which monkeypatched to None → ContainerLaunchError
+#              whose message names eai + remediation (invariant, not repro).
+#   hash=PENDING: stamped by scripts/auto_fix_lint.py (Tier-1) on first run.

--- a/cube-resources/cube-infra-toolkit/tests/test_eai_preflight.py
+++ b/cube-resources/cube-infra-toolkit/tests/test_eai_preflight.py
@@ -1,0 +1,30 @@
+"""auto-fix(180): missing eai CLI → actionable ContainerLaunchError, not raw FileNotFoundError."""
+
+import pytest
+from cube_infra_toolkit.toolkit import _resolve_eai_account
+
+from cube.container import ContainerLaunchError
+
+
+def test_missing_eai_raises_actionable_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("cube_infra_toolkit.toolkit.shutil.which", lambda _: None)
+    with pytest.raises(ContainerLaunchError) as ei:
+        _resolve_eai_account("eai", profile=None)
+    msg = str(ei.value)
+    assert "eai" in msg and "PATH" in msg and "not a pip dependency" in msg.lower() or "eai_path" in msg
+
+
+def test_present_eai_passes_preflight(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When eai resolves, preflight is transparent (we stop before the real call
+    by making the subprocess fail fast — proves the preflight didn't raise)."""
+    monkeypatch.setattr("cube_infra_toolkit.toolkit.shutil.which", lambda _: "/usr/bin/eai")
+
+    class _R:
+        returncode = 1
+        stdout = b""
+        stderr = b"boom"
+
+    monkeypatch.setattr("cube_infra_toolkit.toolkit.subprocess.run", lambda *a, **k: _R())
+    with pytest.raises(ContainerLaunchError) as ei:
+        _resolve_eai_account("eai", profile=None)
+    assert "user get" in str(ei.value)  # got past preflight to the real call


### PR DESCRIPTION
> Fix Dossier in issue #180. `auto-fix(180)`, Class L1.

**Invariant**: a missing required external CLI yields one actionable error naming the tool + remediation — never a raw `FileNotFoundError` traceback.

**Root cause**: `cube_infra_toolkit.toolkit._resolve_eai_account` (first `eai` call in the launch path) `subprocess.run`s the `eai` binary with no preflight. `eai` is **not** a pip dependency (toolkit deps = `cube-standard`+`tenacity`) — it's an external EAI CLI. Absent ⇒ bare `FileNotFoundError: 'eai'`. Found by the PI infra-robustness session, Round 0 toolkit smoke. Same opaque-error family as #1/#3 (fixed for the docker client in #170).

**Fix & layer**: preflight `shutil.which(eai_path)`; on miss raise the file's existing `ContainerLaunchError` with remediation. `shutil` already imported. Additive — zero behaviour change when `eai` is present. Right layer: the toolkit adapter owns its CLI-dependency contract.

**Blast radius**: `_resolve_eai_account` is the first `eai` invocation on every toolkit launch (single chokepoint). Custom `eai_path` still checked correctly.

**Test**: `tests/test_eai_preflight.py` — `shutil.which`→None ⇒ actionable `ContainerLaunchError`; present ⇒ preflight transparent (reaches the real call). 2 passed, ruff clean.

Note: a *separate, deeper* toolkit finding (F2) was observed by code-reading — `eai job new` with `retries=0` has an orphan-job path on submit timeout/failure ("we have no ID to kill it"). That's design-significant (job lifecycle/idempotency) and **not** addressed here; documented in the PI journal for when toolkit is runnable (the `eai` CLI is absent on this machine, so toolkit can't be exercised end-to-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)