### PR TITLE
docs(authoring): three-skill workflow (new-cube → review-cube → auto-cube)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ Cross-cutting:
 
 PRs are reviewed with `/code-review` ([plugin docs](https://github.com/anthropics/claude-code/blob/main/plugins/code-review/README.md)), which audits changes against these guidelines. Write PRs as if a reviewer will check each principle above against the diff.
 
-**Auto-fix provenance.** auto-cube-produced fixes carry `# auto-fix(N)↓ … # /auto-fix(N)`
+**Auto-fix provenance.** Auto-CUBE-produced fixes carry `# auto-fix(N)↓ … # /auto-fix(N)`
 markers + a one-line machine-readable footnote at module bottom (`N` = PR
 number for L0/L1, design-debt issue number for L2/L3). Reviewers: when a
 diff touches an `auto-fix` region/footnote, treat it as **possibly rotten**

--- a/cube-resources/cube-infra-toolkit/src/cube_infra_toolkit/toolkit.py
+++ b/cube-resources/cube-infra-toolkit/src/cube_infra_toolkit/toolkit.py
@@ -642,7 +642,7 @@ def _publish_cube_bundle(full_name: str, eai_path: str, profile: str | None) -> 
 
 # === auto-fix notes ===  (spec: openspec/specs/auto-fix/spec.md)
 # auto-fix-note(180) {class=L1 issue=180 hash=PENDING ctx=macos-arm64/no-eai-cli/cube-standard@2dad056}
-#   symptoms:  auto-cube infra-robustness session, Round 0 toolkit smoke on a box
+#   symptoms:  Auto-CUBE infra-robustness session, Round 0 toolkit smoke on a box
 #              without the EAI CLI: ToolkitInfraConfig launch raised a raw
 #              FileNotFoundError: 'eai' (8-line traceback). eai is NOT a pip
 #              dep (toolkit deps = cube-standard+tenacity) — external CLI.
@@ -657,7 +657,7 @@ def _publish_cube_bundle(full_name: str, eai_path: str, profile: str | None) -> 
 #              whose message names eai + remediation (invariant, not repro).
 #   hash=PENDING: stamped by scripts/auto_fix_lint.py (Tier-1) on first run.
 # auto-fix-note(182) {class=L1 issue=182 hash=PENDING ctx=eai-toolkit/yul101/darwin-arm64/cube@2dad0562}
-#   symptoms:  auto-cube infra-robustness session (terminalbench2, toolkit infra,
+#   symptoms:  Auto-CUBE infra-robustness session (terminalbench2, toolkit infra,
 #              yul101): every interrupted run leaked 1 EAI job + 1 local
 #              `eai job port-forward` proc; ~50 such procs found orphaned
 #              11-13 days on a dev box. Stress harness: N=8 -> +8 leaked

--- a/docs/authoring-a-cube.markdown
+++ b/docs/authoring-a-cube.markdown
@@ -106,7 +106,7 @@ Every debug task must hit `reward == 1.0`. If one doesn't, either the debug acti
 
 `/auto-cube` lives in [cube-harness](https://github.com/The-AI-Alliance/cube-harness/blob/dev/.claude/skills/auto-cube/README.md). It runs an iterative experiment loop: sweep models × tool configs across a task subset, dispatch the **Investigator** sub-agent on every trajectory, classify failures (infra / scaffold / model / **benchmark**), and ship fixes via the [auto-fix methodology](https://github.com/The-AI-Alliance/cube-harness/blob/dev/openspec/specs/auto-fix/spec.md). You get back a `REPORT.md` session rollup, one Fix Report PR per issue, and `design-debt` issues for systemic signals.
 
-Recommended once before registry submission, even if `cube test` and `/review-cube` are green — at least one real-LLM session against a fresh cube usually surfaces something. See the [auto-cube skill README](https://github.com/The-AI-Alliance/cube-harness/blob/dev/.claude/skills/auto-cube/README.md) for the prompt template and setup.
+Recommended once before registry submission, even if `cube test` and `/review-cube` are green — at least one real-LLM session against a fresh cube usually surfaces something. See the [Auto-CUBE skill README](https://github.com/The-AI-Alliance/cube-harness/blob/dev/.claude/skills/auto-cube/README.md) for the prompt template and setup.
 
 ## Publish
 
@@ -141,6 +141,6 @@ Ways to reach us:
 - [cube-registry](https://github.com/The-AI-Alliance/cube-registry) — submission YAML template and compliance tiers
 - [cube-tools/](https://github.com/The-AI-Alliance/cube-standard/tree/main/cube-tools) — reusable tool packages (browser, computer, chat)
 - [cube-resources/](https://github.com/The-AI-Alliance/cube-standard/tree/main/cube-resources) — reusable resource packages (playwright browser, chat sessions, AWS/Azure infra, VM backend)
-- [auto-cube skill (cube-harness)](https://github.com/The-AI-Alliance/cube-harness/blob/dev/.claude/skills/auto-cube/README.md) — iterate-and-fix loop for hardening a cube against real LLMs
+- [Auto-CUBE skill (cube-harness)](https://github.com/The-AI-Alliance/cube-harness/blob/dev/.claude/skills/auto-cube/README.md) — iterate-and-fix loop for hardening a cube against real LLMs
 - [auto-fix methodology (cube-harness)](https://github.com/The-AI-Alliance/cube-harness/blob/dev/openspec/specs/auto-fix/spec.md) — what a Fix Report PR looks like and why
 - [DeepWiki](https://deepwiki.com/The-AI-Alliance/cube-standard) — full API reference

--- a/docs/authoring-a-cube.markdown
+++ b/docs/authoring-a-cube.markdown
@@ -15,9 +15,9 @@ The short version: you implement four Python classes (tool, task, benchmark, deb
 
 | Skill | Phase | What it does |
 |---|---|---|
-| [`/new-cube`](https://github.com/The-AI-Alliance/cube-standard/tree/main/.claude/skills/new-cube) | Scaffold | Interviews you and writes the four classes + registry entry |
-| [`/review-cube`](https://github.com/The-AI-Alliance/cube-standard/tree/main/.claude/skills/review-cube) | Audit | Installs the package, runs `cube test`, audits against invariants, produces a Blocking/Suggestions report |
-| [`/auto-cube`](https://github.com/The-AI-Alliance/cube-harness/blob/dev/.claude/skills/auto-cube/README.md) | Iterate | Runs real LLMs against the cube, classifies failures (infra / scaffold / model / **benchmark**), ships fixes — the deep-debug pass `cube test` cannot do |
+| <a href="https://github.com/The-AI-Alliance/cube-standard/tree/main/.claude/skills/new-cube"><code>/new-cube</code></a> | Scaffold | Interviews you and writes the four classes + registry entry |
+| <a href="https://github.com/The-AI-Alliance/cube-standard/tree/main/.claude/skills/review-cube"><code>/review-cube</code></a> | Audit | Installs the package, runs `cube test`, audits against invariants, produces a Blocking/Suggestions report |
+| <a href="https://github.com/The-AI-Alliance/cube-harness/blob/dev/.claude/skills/auto-cube/README.md"><code>/auto-cube</code></a> | Iterate | Runs real LLMs against the cube, classifies failures (infra / scaffold / model / **benchmark**), ships fixes — the deep-debug pass `cube test` cannot do |
 
 `/auto-cube` lives in [cube-harness](https://github.com/The-AI-Alliance/cube-harness) (the runtime); the other two live here. Each phase has its own section below.
 

--- a/docs/authoring-a-cube.markdown
+++ b/docs/authoring-a-cube.markdown
@@ -106,6 +106,8 @@ Every debug task must hit `reward == 1.0`. If one doesn't, either the debug acti
 
 `/auto-cube` lives in [cube-harness](https://github.com/The-AI-Alliance/cube-harness/blob/dev/.claude/skills/auto-cube/README.md). It runs an iterative experiment loop: sweep models × tool configs across a task subset, dispatch the **Investigator** sub-agent on every trajectory, classify failures (infra / scaffold / model / **benchmark**), and ship fixes via the [auto-fix methodology](https://github.com/The-AI-Alliance/cube-harness/blob/dev/openspec/specs/auto-fix/spec.md). You get back a `REPORT.md` session rollup, one Fix Report PR per issue, and `design-debt` issues for systemic signals.
 
+![Auto-CUBE outer loop: dispatch → per-experiment Investigator on each trajectory → analysis → interventions](https://raw.githubusercontent.com/The-AI-Alliance/cube-harness/dev/.claude/skills/auto-cube/diagram.png)
+
 Recommended once before registry submission, even if `cube test` and `/review-cube` are green — at least one real-LLM session against a fresh cube usually surfaces something. See the [Auto-CUBE skill README](https://github.com/The-AI-Alliance/cube-harness/blob/dev/.claude/skills/auto-cube/README.md) for the prompt template and setup.
 
 ## Publish

--- a/docs/authoring-a-cube.markdown
+++ b/docs/authoring-a-cube.markdown
@@ -11,6 +11,16 @@ So you want to wrap a benchmark as a CUBE. This guide walks through what that in
 
 The short version: you implement four Python classes (tool, task, benchmark, debug agent), run `cube test` to prove it works, and submit one YAML file to the registry. Most benchmarks fit this shape naturally once it clicks.
 
+**Three Claude Code skills cover the workflow end to end:**
+
+| Skill | Phase | What it does |
+|---|---|---|
+| [`/new-cube`](https://github.com/The-AI-Alliance/cube-standard/tree/main/.claude/skills/new-cube) | Scaffold | Interviews you and writes the four classes + registry entry |
+| [`/review-cube`](https://github.com/The-AI-Alliance/cube-standard/tree/main/.claude/skills/review-cube) | Audit | Installs the package, runs `cube test`, audits against invariants, produces a Blocking/Suggestions report |
+| [`/auto-cube`](https://github.com/The-AI-Alliance/cube-harness/blob/dev/.claude/skills/auto-cube/README.md) | Iterate | Runs real LLMs against the cube, classifies failures (infra / scaffold / model / **benchmark**), ships fixes — the deep-debug pass `cube test` cannot do |
+
+`/auto-cube` lives in [cube-harness](https://github.com/The-AI-Alliance/cube-harness) (the runtime); the other two live here. Each phase has its own section below.
+
 ## What you're building
 
 A CUBE package exposes a benchmark through a uniform protocol so any CUBE-compatible harness can run it without custom integration. You implement four things:
@@ -86,6 +96,18 @@ Every debug task must hit `reward == 1.0`. If one doesn't, either the debug acti
 
 `/review-cube` installs your package, runs pytest, runs `cube test`, audits against cube-standard invariants, and produces a Blocking / Suggestions report. Resolve everything in the Blocking section before submitting. Registry CI catches the same issues later, but locally is faster and less public.
 
+## Iterate (real LLMs find what the debug suite can't)
+
+`cube test` validates with the **Debug** agent — deterministic action sequences, no LLM. Real LLMs find a different class of issue: infra flakes, scaffold bugs, tasks that are *technically* solvable but practically impossible, scoring that's too strict or too lenient, hidden environmental assumptions, and sometimes problems in the benchmark itself (ambiguous prompts, broken ground truth, contaminated training data leaking into the task description).
+
+```
+/auto-cube
+```
+
+`/auto-cube` lives in [cube-harness](https://github.com/The-AI-Alliance/cube-harness/blob/dev/.claude/skills/auto-cube/README.md). It runs an iterative experiment loop: sweep models × tool configs across a task subset, dispatch the **Investigator** sub-agent on every trajectory, classify failures (infra / scaffold / model / **benchmark**), and ship fixes via the [auto-fix methodology](https://github.com/The-AI-Alliance/cube-harness/blob/dev/openspec/specs/auto-fix/spec.md). You get back a `REPORT.md` session rollup, one Fix Report PR per issue, and `design-debt` issues for systemic signals.
+
+Recommended once before registry submission, even if `cube test` and `/review-cube` are green — at least one real-LLM session against a fresh cube usually surfaces something. See the [auto-cube skill README](https://github.com/The-AI-Alliance/cube-harness/blob/dev/.claude/skills/auto-cube/README.md) for the prompt template and setup.
+
 ## Publish
 
 Once `cube test` and `/review-cube` both pass, submit to the registry with one command:
@@ -119,4 +141,6 @@ Ways to reach us:
 - [cube-registry](https://github.com/The-AI-Alliance/cube-registry) — submission YAML template and compliance tiers
 - [cube-tools/](https://github.com/The-AI-Alliance/cube-standard/tree/main/cube-tools) — reusable tool packages (browser, computer, chat)
 - [cube-resources/](https://github.com/The-AI-Alliance/cube-standard/tree/main/cube-resources) — reusable resource packages (playwright browser, chat sessions, AWS/Azure infra, VM backend)
+- [auto-cube skill (cube-harness)](https://github.com/The-AI-Alliance/cube-harness/blob/dev/.claude/skills/auto-cube/README.md) — iterate-and-fix loop for hardening a cube against real LLMs
+- [auto-fix methodology (cube-harness)](https://github.com/The-AI-Alliance/cube-harness/blob/dev/openspec/specs/auto-fix/spec.md) — what a Fix Report PR looks like and why
 - [DeepWiki](https://deepwiki.com/The-AI-Alliance/cube-standard) — full API reference

--- a/docs/authoring-a-cube.markdown
+++ b/docs/authoring-a-cube.markdown
@@ -15,9 +15,9 @@ The short version: you implement four Python classes (tool, task, benchmark, deb
 
 | Skill | Phase | What it does |
 |---|---|---|
-| <a href="https://github.com/The-AI-Alliance/cube-standard/tree/main/.claude/skills/new-cube"><code>/new-cube</code></a> | Scaffold | Interviews you and writes the four classes + registry entry |
-| <a href="https://github.com/The-AI-Alliance/cube-standard/tree/main/.claude/skills/review-cube"><code>/review-cube</code></a> | Audit | Installs the package, runs `cube test`, audits against invariants, produces a Blocking/Suggestions report |
-| <a href="https://github.com/The-AI-Alliance/cube-harness/blob/dev/.claude/skills/auto-cube/README.md"><code>/auto-cube</code></a> | Iterate | Runs real LLMs against the cube, classifies failures (infra / scaffold / model / **benchmark**), ships fixes — the deep-debug pass `cube test` cannot do |
+| `/new-cube` | Scaffold | Interviews you and writes the four classes + registry entry. ([skill](https://github.com/The-AI-Alliance/cube-standard/tree/main/.claude/skills/new-cube)) |
+| `/review-cube` | Audit | Installs the package, runs `cube test`, audits against invariants, produces a Blocking/Suggestions report. ([skill](https://github.com/The-AI-Alliance/cube-standard/tree/main/.claude/skills/review-cube)) |
+| `/auto-cube` | Iterate | Runs real LLMs against the cube, classifies failures (infra / scaffold / model / **benchmark**), ships fixes — the deep-debug pass `cube test` cannot do. ([skill](https://github.com/The-AI-Alliance/cube-harness/blob/dev/.claude/skills/auto-cube/README.md)) |
 
 `/auto-cube` lives in [cube-harness](https://github.com/The-AI-Alliance/cube-harness) (the runtime); the other two live here. Each phase has its own section below.
 

--- a/docs/authoring-a-cube.markdown
+++ b/docs/authoring-a-cube.markdown
@@ -17,7 +17,7 @@ The short version: you implement four Python classes (tool, task, benchmark, deb
 |---|---|---|
 | `/new-cube` | Scaffold | Interviews you and writes the four classes + registry entry. ([skill](https://github.com/The-AI-Alliance/cube-standard/tree/main/.claude/skills/new-cube)) |
 | `/review-cube` | Audit | Installs the package, runs `cube test`, audits against invariants, produces a Blocking/Suggestions report. ([skill](https://github.com/The-AI-Alliance/cube-standard/tree/main/.claude/skills/review-cube)) |
-| `/auto-cube` | Iterate | Runs real LLMs against the cube, classifies failures (infra / scaffold / model / **benchmark**), ships fixes — the deep-debug pass `cube test` cannot do. ([skill](https://github.com/The-AI-Alliance/cube-harness/blob/dev/.claude/skills/auto-cube/README.md)) |
+| `/auto-cube` | Iterate | Runs real LLMs against the cube, classifies failures (infra / scaffold / model / **benchmark**), ships fixes — the deep-debug pass `cube test` cannot do. ([skill](https://github.com/The-AI-Alliance/cube-harness/tree/dev/.claude/skills/auto-cube), [README](https://github.com/The-AI-Alliance/cube-harness/blob/dev/.claude/skills/auto-cube/README.md)) |
 
 `/auto-cube` lives in [cube-harness](https://github.com/The-AI-Alliance/cube-harness) (the runtime); the other two live here. Each phase has its own section below.
 

--- a/openspec/specs/auto-fix/spec.md
+++ b/openspec/specs/auto-fix/spec.md
@@ -1,6 +1,6 @@
-# Auto-cube fix methodology & auto-fix provenance
+# Auto-CUBE fix methodology & auto-fix provenance
 
-> **Mirror of the cube-harness spec of the same path.** auto-cube runs
+> **Mirror of the cube-harness spec of the same path.** Auto-CUBE runs
 > from cube-harness, but its fixes land in cube-standard too (infra,
 > container, tool, debug-suite). This copy is the cube-standard-local
 > contract; keep it in sync with cube-harness's
@@ -8,7 +8,7 @@
 > differ). cube-standard is upstream — it must not point "up" into
 > cube-harness, hence a synced copy rather than a reference.
 
-Authoritative spec for fixes produced by the **auto-cube** autonomous
+Authoritative spec for fixes produced by the **Auto-CUBE** autonomous
 loop (the orchestrator that runs cube benchmarks, analyzes trajectories
 via the **Investigator**, and ships fixes as PRs). Goal: let a reviewer
 trust most patches *without* a deep contextual review, surface design
@@ -17,14 +17,14 @@ co-existing as the loop's output rate grows.
 
 Two distinct agent roles to keep straight:
 
-- **auto-cube** — outer loop: runs experiments, invokes Investigator per
+- **Auto-CUBE** — outer loop: runs experiments, invokes Investigator per
   trajectory, proposes fixes, opens PRs. This spec governs its outputs.
 - **Investigator** — inner sub-agent: takes one trajectory and produces
   a diagnostic report. Lives in cube-harness at
   `analyze/investigator/` (CLI: `ch-investigate`). Distinct from the
   fix-authoring step.
 
-auto-cube has no live feedback channel to other users. A fix it ships
+Auto-CUBE has no live feedback channel to other users. A fix it ships
 can't be validated by "does this help other cubes?" — so it must carry
 its own generalization proof, an adversarial audit of that proof, and a
 durable, context-stamped provenance record so a future agent (or
@@ -38,7 +38,7 @@ not generalize.
 | **L0** local-correct | restores an invariant/symmetry that already exists elsewhere; no contract change | trust-by-default |
 | **L1** layer fix | correct but touches a shared layer/call site | trust if fix-audit clears blast-radius |
 | **L2** symptom-of-design | the bug is a symptom; the patch is a band-aid | ship temp PR **and** open a kept-open `design-debt` issue + openspec stub |
-| **L3** auto-cube / Investigator defect | the defect is in the methodology or analysis layer itself, not the cube | ship + flag; do not patch the cube |
+| **L3** Auto-CUBE / Investigator defect | the defect is in the methodology or analysis layer itself, not the cube | ship + flag; do not patch the cube |
 
 **Nothing blocks the loop.** L2/L3 still ship a temporary PR. The human's
 queue is the `design-debt` backlog, not individual patches.
@@ -56,7 +56,7 @@ exists to prevent, turned on itself.
 
 Template lives in cube-harness at
 `.claude/skills/auto-cube/templates/fix_report.md` (cube-standard has
-no auto-cube authoring skill; auto-cube authors from cube-harness
+no Auto-CUBE authoring skill; Auto-CUBE authors from cube-harness
 regardless of which repo the fix lands in). It is the PR body.
 
 **Structure: named subsections + bullets within.** A skimmer reads
@@ -179,13 +179,13 @@ Degraded mode: if `gh` is unavailable when writing the marker, leave
    issues become the audit trail of what the refactor subsumed.
 
 **`Closes` keyword — per-issue line.** A bare `Closes #a #b #c` only
-auto-closes the *first* number — GitHub limitation, not auto-cube's.
+auto-closes the *first* number — GitHub limitation, not Auto-CUBE's.
 Use one closing line per issue: `Closes #174\nCloses #175\n…`. (L0/L1
 PR-only flow doesn't need closing keywords at all.)
 
 ## 6. Multi-PR working substrate (integration worktree)
 
-As the open-PR queue grows, auto-cube needs a place where **all
+As the open-PR queue grows, Auto-CUBE needs a place where **all
 in-flight changes co-exist** — so a new fix is developed against the
 realistic future state of `dev`, not against a stale snapshot. The
 methodology mandates the substrate; the agent maintains it.
@@ -200,7 +200,7 @@ small PR queues already; it does not scale.
 new public surface.** The integration worktree gives B's test
 environment A's code, but B's branch still won't compile against `dev`
 if it imports A's new symbols. In that case B branches from A and
-writes `Stacked-on: PR#A` in its body. On A's merge, auto-cube rebases
+writes `Stacked-on: PR#A` in its body. On A's merge, Auto-CUBE rebases
 B onto `dev`. On A's close-without-merge, B is orphaned: rebase onto
 `dev` (may break) or close with a note on A. The `Stacked-on:`
 declaration is friction-by-design — when in doubt, don't stack;
@@ -217,12 +217,12 @@ for pr in $(open_prs_by_auto_cube):
                                                 # flag the pair, continue
 ```
 
-- **New auto-cube work** happens on a fresh branch off `origin/dev`
+- **New Auto-CUBE work** happens on a fresh branch off `origin/dev`
   (clean PR-shaped diff). `make test`, `make lint`, and smokes run in
   **integration** to validate that the new change co-exists with the
   rest of the in-flight bag.
 - **Conflict in integration = early warning.** If PR-A and PR-B can't
-  both apply, auto-cube either (a) auto-rebases the offender for
+  both apply, Auto-CUBE either (a) auto-rebases the offender for
   mechanical conflicts (footnote merges, import-order diffs — same
   decision table the `pr-cleanup` skill uses today), or (b) surfaces
   the incompatibility to the human with concrete file ranges + an
@@ -235,10 +235,10 @@ for pr in $(open_prs_by_auto_cube):
   applies end-to-end via the existing `Depends-on:` declaration in PR
   bodies.
 
-### Parallel auto-cube sessions
+### Parallel Auto-CUBE sessions
 
 The integration worktree is **per session**, not machine-wide: multiple
-auto-cube sessions can run concurrently on one machine, each owning its
+Auto-CUBE sessions can run concurrently on one machine, each owning its
 worktree + `.venv` + journal subdir
 (`~/cube_auto_cube_journal/<session-slug>/`). Cross-session isolation is
 preserved by picking **orthogonal scopes** — different cubes by default
@@ -281,14 +281,14 @@ acknowledge.
 ## 8. Accretion → refactor
 
 Density is exact: `grep -c 'auto-fix(' <area>`. When an area
-crosses the band-aid threshold (≥3 distinct anchors), auto-cube
+crosses the band-aid threshold (≥3 distinct anchors), Auto-CUBE
 **must** emit an openspec refactor proposal instead of patch N+1.
 Patch accretion is a design signal, not a steady state.
 
 ## 9. Human-authorized merge
 
-auto-cube's responsibility ends at **green PR + Fix Report**. Merging
+Auto-CUBE's responsibility ends at **green PR + Fix Report**. Merging
 is a human action. The spec does not authorize auto-merge; a future
-auto-cube run must not infer authorization from a clean Fix Report
+Auto-CUBE run must not infer authorization from a clean Fix Report
 alone. The integration worktree (§6) gives the human a fully-resolved
 local substrate before approval; that's the substrate, not the trigger.

--- a/src/cube/infra_local.py
+++ b/src/cube/infra_local.py
@@ -975,7 +975,7 @@ def _kill_entry(entry: dict) -> None:
 
 # === auto-fix notes ===  (spec: openspec/specs/auto-fix/spec.md)
 # auto-fix-note(174) {class=L1 issue=174 hash=PENDING ctx=colima/macos-arm64/n-a/cube-standard@0e91ae1}
-#   symptoms:  tbench2 auto-cube shakeout on a macOS/arm64 Colima box; malformed
+#   symptoms:  tbench2 Auto-CUBE shakeout on a macOS/arm64 Colima box; malformed
 #              DOCKER_HOST=http+unix:// (no socket path) -> broken unix:// client,
 #              and from_env() missed Colima's non-default socket. Infra-specific:
 #              docker backend + OS + DOCKER_HOST are the load-bearing context.


### PR DESCRIPTION
## Summary

Frames the cube-authoring guide around the three Claude Code skills that cover the lifecycle end to end:

- `/new-cube` — scaffold (already documented)
- `/review-cube` — audit (already documented)
- `/auto-cube` — iterate (the new bit) — runs real LLMs against the cube, classifies failures, ships fixes via the [auto-fix methodology](https://github.com/The-AI-Alliance/cube-harness/blob/dev/openspec/specs/auto-fix/spec.md)

Changes:

- Adds a 3-row table near the top introducing all three skills with phase + role
- Adds an **Iterate** section between Validate and Publish pointing to `/auto-cube` in cube-harness for the real-LLM debug pass that `cube test` cannot do — and that can surface problems in the benchmark itself (ambiguous prompts, broken ground truth, contamination), not just scaffold/infra
- Adds two cross-links to the cube-harness auto-cube README and the auto-fix spec in the Deeper References list

Paired with cube-harness#419 which adds the README the table links to.

## Test plan
- [x] Doc-only (Jekyll markdown)
- [ ] CI green