### PR TITLE
Refactor TypedBaseModel

### DIFF
--- a/src/cube/core.py
+++ b/src/cube/core.py
@@ -51,30 +51,33 @@ class TypedBaseModel(BaseModel):
 
     @model_serializer(mode="wrap")
     def _serialize_with_type(self, handler):
-        data = handler(self)
-        data["_type"] = f"{self.__class__.__module__}.{self.__class__.__name__}"
-        return data
+        value = handler(self)
+        value["_type"] = f"{self.__class__.__module__}.{self.__class__.__name__}"
+        return value
 
     @model_validator(mode="wrap")
     @classmethod
     def _deserialize_with_type(cls, value, handler):
-        if isinstance(value, dict) and "_type" in value:
-            type_path = value.pop("_type")
-            module_name, class_name = type_path.rsplit(".", 1)
-            module = importlib.import_module(module_name)  # nosemgrep: non-literal-import
-            actual_cls = getattr(module, class_name)
-            if not (isinstance(actual_cls, type) and issubclass(actual_cls, TypedBaseModel)):
-                raise ValueError(f"Refusing to deserialize '{type_path}': class must be a TypedBaseModel subclass.")
-            # If _type matches the current class, proceed normally via handler to avoid
-            # Pydantic v2's "returning non-self from __init__" warning and broken __init__ path.
-            if actual_cls is cls:
-                return handler(value)
-            return actual_cls.model_validate(value)
-        if isinstance(value, dict) and inspect.isabstract(cls):
-            raise ValueError(
-                f"Cannot deserialize abstract class '{cls.__name__}' directly. "
-                "Ensure the data was serialized from a concrete subclass (contains '_type' field)."
-            )
+        if isinstance(value, dict):
+            if "_type" in value:
+                value = value.copy()
+                type_path = value.pop("_type")
+                module_path, class_name = type_path.rsplit(".", 1)
+                module = importlib.import_module(
+                    module_path
+                )  # nosemgrep: non-literal-import
+                actual_cls = getattr(module, class_name)
+                if not isinstance(actual_cls, type) or not issubclass(actual_cls, cls):
+                    raise ValueError(
+                        f"Cannot deserialize '{type_path}': class must be a subclass of '{cls.__name__}'."
+                    )
+                if actual_cls is not cls:
+                    return actual_cls.model_validate(value)
+            elif inspect.isabstract(cls):
+                raise ValueError(
+                    f"Cannot deserialize abstract class '{cls.__name__}' directly. "
+                    "Ensure the input dict includes a '_type' field naming a concrete subclass."
+                )
         return handler(value)
 
 

--- a/src/cube/core.py
+++ b/src/cube/core.py
@@ -60,6 +60,9 @@ class TypedBaseModel(BaseModel):
     def _deserialize_with_type(cls, value, handler):
         if isinstance(value, dict):
             if "_type" in value:
+                # Copy before popping: the caller's dict may be reused (e.g. re-validated
+                # under validate_assignment=True), and losing _type silently downgrades
+                # polymorphism on the second pass.
                 value = value.copy()
                 type_path = value.pop("_type")
                 module_path, class_name = type_path.rsplit(".", 1)
@@ -67,6 +70,9 @@ class TypedBaseModel(BaseModel):
                 actual_cls = getattr(module, class_name)
                 if not isinstance(actual_cls, type) or not issubclass(actual_cls, cls):
                     raise ValueError(f"Cannot deserialize '{type_path}': class must be a subclass of '{cls.__name__}'.")
+                # When actual_cls is cls, fall through to handler(value) instead of
+                # recursing: Pydantic v2 warns about "returning non-self from __init__"
+                # if a wrap-validator returns the result of model_validate on the same class.
                 if actual_cls is not cls:
                     return actual_cls.model_validate(value)
             elif inspect.isabstract(cls):

--- a/src/cube/core.py
+++ b/src/cube/core.py
@@ -63,14 +63,10 @@ class TypedBaseModel(BaseModel):
                 value = value.copy()
                 type_path = value.pop("_type")
                 module_path, class_name = type_path.rsplit(".", 1)
-                module = importlib.import_module(
-                    module_path
-                )  # nosemgrep: non-literal-import
+                module = importlib.import_module(module_path)  # nosemgrep: non-literal-import
                 actual_cls = getattr(module, class_name)
                 if not isinstance(actual_cls, type) or not issubclass(actual_cls, cls):
-                    raise ValueError(
-                        f"Cannot deserialize '{type_path}': class must be a subclass of '{cls.__name__}'."
-                    )
+                    raise ValueError(f"Cannot deserialize '{type_path}': class must be a subclass of '{cls.__name__}'.")
                 if actual_cls is not cls:
                     return actual_cls.model_validate(value)
             elif inspect.isabstract(cls):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -31,6 +31,45 @@ def test_typed_base_model_round_trip():
     assert restored == original
 
 
+def test_typed_base_model_does_not_mutate_input_dict():
+    """The validator must not pop '_type' from the caller's dict; mutating it
+    silently downgrades polymorphism on the next round-trip."""
+    payload = {"_type": "cube.core.Action", "id": None, "name": "click", "arguments": {}}
+    snapshot = dict(payload)
+    Action.model_validate(payload)
+    assert payload == snapshot
+
+
+def test_typed_base_model_same_dict_validates_twice_preserving_subclass():
+    """Re-validating the same dict twice must keep returning the concrete
+    subclass — regression guard for the in-place `_type` pop."""
+    payload = {"_type": "cube.core.TextContent", "data": "hi", "tool_call_id": None, "name": None}
+    a = Content.model_validate(payload)
+    b = Content.model_validate(payload)
+    assert type(a) is TextContent
+    assert type(b) is TextContent
+
+
+def test_typed_base_model_list_field_round_trips_twice():
+    """Realistic scenario: an Observation with polymorphic contents, dumped
+    once and re-validated twice — both must yield TextContent instances."""
+    obs = Observation(contents=[TextContent(data="hi")])
+    data = obs.model_dump()
+    once = Observation.model_validate(data)
+    twice = Observation.model_validate(data)
+    assert [type(c) for c in once.contents] == [TextContent]
+    assert [type(c) for c in twice.contents] == [TextContent]
+
+
+def test_typed_base_model_rejects_type_outside_target_hierarchy():
+    """`_type` must name a subclass of the class being validated. The previous
+    check only required a TypedBaseModel subclass, so an Action payload would
+    silently coerce into any TypedBaseModel field."""
+    payload = {"_type": "cube.core.Action", "name": "click"}
+    with pytest.raises(ValidationError):
+        TextContent.model_validate(payload)
+
+
 # --- ActionSchema ---
 
 


### PR DESCRIPTION
1. `value.pop("_type")` stops `value` from being deserialized by other classes, so `value = value.copy()` is added before that.

2. `issubclass(actual_cls, TypedBaseModel)` is not enough, it should be `issubclass(actual_cls, cls)`

3. structure is simplified