### PR TITLE
feat(resource): task permission requirements + infra capability gate

### DIFF
--- a/cube-resources/cube-infra-aws/src/cube_infra_aws/aws.py
+++ b/cube-resources/cube-infra-aws/src/cube_infra_aws/aws.py
@@ -515,8 +515,8 @@ class AWSInfraConfig(InfraConfig):
         return f"aws:{self.region}"
 
     def capabilities(self) -> set[str]:
-        """EC2 HVM instances support KVM workloads and Docker-host provisioning."""
-        return {"kvm", "docker"}
+        """EC2 HVM instances support KVM workloads and Docker-host provisioning (root)."""
+        return {"kvm", "docker", "container:root"}
 
     def provision(self, resource: ResourceConfig) -> None:
         """Bootstrap a resource into an EC2 AMI.

--- a/cube-resources/cube-infra-azure/src/cube_infra_azure/azure.py
+++ b/cube-resources/cube-infra-azure/src/cube_infra_azure/azure.py
@@ -1045,8 +1045,8 @@ class AzureInfraConfig(InfraConfig):
         return f"azure:{self.location}"
 
     def capabilities(self) -> set[str]:
-        """Azure can satisfy VM and Docker resources (native hypervisor + Docker in VM)."""
-        return {"kvm", "docker"}
+        """Azure can satisfy VM and Docker resources (native hypervisor + Docker in VM, root)."""
+        return {"kvm", "docker", "container:root"}
 
     def provision(self, resource: ResourceConfig) -> None:
         """Bootstrap OSWorld (or any VM image) from source_url into the Compute Gallery.

--- a/cube-resources/cube-infra-daytona/src/cube_infra_daytona/daytona.py
+++ b/cube-resources/cube-infra-daytona/src/cube_infra_daytona/daytona.py
@@ -69,7 +69,7 @@ class DaytonaInfraConfig(InfraConfig):
         return f"daytona:{target}"
 
     def capabilities(self) -> set[str]:
-        return {"docker", "network:egress"}
+        return {"docker", "network:egress", "container:root"}
 
     def provision(self, resource: ResourceConfig) -> None:
         """Validate resource shape and record a ProvisionStore entry.

--- a/cube-resources/cube-infra-modal/src/cube_infra_modal/modal_infra.py
+++ b/cube-resources/cube-infra-modal/src/cube_infra_modal/modal_infra.py
@@ -52,7 +52,7 @@ class ModalInfraConfig(InfraConfig):
         return f"modal:{self.app_name}"
 
     def capabilities(self) -> set[str]:
-        return {"docker", "network:egress", "gpu:nvidia"}
+        return {"docker", "network:egress", "gpu:nvidia", "container:root"}
 
     def provision(self, resource: ResourceConfig) -> None:
         """Record a ProvisionStore entry.  Modal pulls images on-demand at Sandbox creation."""

--- a/cube-resources/cube-infra-toolkit/src/cube_infra_toolkit/toolkit.py
+++ b/cube-resources/cube-infra-toolkit/src/cube_infra_toolkit/toolkit.py
@@ -114,6 +114,8 @@ class ToolkitInfraConfig(InfraConfig):
         return f"toolkit:{prof}"
 
     def capabilities(self) -> set[str]:
+        # No "container:root": the EAI cluster pins a non-root uid (13011), so tasks that
+        # need root (apt-install, writes to /etc, /var) are correctly reported incompatible.
         return {"docker", "network:egress"}
 
     def provision(self, resource: ResourceConfig) -> None:

--- a/openspec/changes/task-permission-requirements/deltas.md
+++ b/openspec/changes/task-permission-requirements/deltas.md
@@ -1,30 +1,44 @@
-# Deltas — Benchmark/task permission requirements + infra capability handshake
+# Deltas — Task permission requirements + infra capability handshake
 
-## ADDED — `openspec/specs/resource/spec.md`: capability token vocabulary
+## ADDED — `resource/spec.md`: `container:root` capability token
 
-The `InfraConfig.capabilities()` docstring is extended with one
-permission-shaped token:
+Extend the `InfraConfig.capabilities()` vocabulary with one token:
 
 | Token | Meaning |
 |---|---|
 | `container:root` | Container processes run as uid 0 |
 
-A single token is intentional: `apt-get`, writes to `/etc` / `/var`,
-binding ports <1024, and `systemctl` are all root-gated and correlate
-near-perfectly with "is the container root?" on both the infra and image
-sides. The vocabulary stays open (`set[str]`), so a finer token (e.g.
-`container:cap-net-bind` for a future rootless-with-capabilities infra)
-can be added later without breaking existing declarations.
+Single token by design: `apt`, `/etc`+`/var` writes, ports <1024, and
+`systemctl` are all root-gated and correlate with "is the container root?".
+Vocabulary stays open (`set[str]`); a finer token can be added later for a
+partial-root infra. Pre-existing tokens (`kvm`, `docker`, `gpu:nvidia`,
+`network:egress`) unchanged. Adding a token is non-breaking.
 
-Adding a token is non-breaking. Infras default to **not** publishing one;
-benchmarks/tasks default to **not** requiring one. The pre-existing
-vocabulary (`kvm`, `docker`, `vm`, `gpu:nvidia`, `network:egress`) is
-unchanged.
+## MODIFIED — `container/spec.md`: `ContainerConfig` gains `requires`
 
-## ADDED — `openspec/specs/resource/spec.md`: `InfraConfig.can_serve_task()` (per-task bool) + `on_incompatible`
+```python
+class ContainerConfig(TypedBaseModel):
+    image: str
+    ram_gb: float = 4.0
+    cpu_cores: float = 2.0
+    gpu: bool = False
+    disk_gb: float = 10.0
+    ports: list[int] | None = None
+    requires: set[str] = Field(default_factory=set)   # NEW
 
-The compatibility primitive is a **per-task bool** the infra returns; the
-harness loops over tasks. No benchmark-level aggregate (awkward to build).
+    def requirements(self) -> set[str]:               # NEW
+        out = set(self.requires)
+        if self.gpu:
+            out.add("gpu:nvidia")
+        return out
+```
+
+`requires` is the source of truth. A blanket per-benchmark need is stamped
+on every task by the cube's metadata-generation script; heterogeneous
+benchmarks set it per task. Mirrors `VMResourceConfig.requires_kvm` →
+`requirements() -> {"kvm"}`.
+
+## ADDED — `resource/spec.md`: `InfraConfig.can_serve_task()` + `on_incompatible`
 
 ```python
 OnIncompatible = Literal["raise", "skip", "force"]
@@ -32,174 +46,86 @@ OnIncompatible = Literal["raise", "skip", "force"]
 class InfraConfig(TypedBaseModel, ABC):
     ...
     on_incompatible: OnIncompatible = "raise"
-    """Policy when a task needs a capability this infra lacks. 'raise':
-    abort setup if ANY task is incompatible. 'skip': run the compatible
-    subset, mark the rest INVALID_CONFIG. 'force': attempt every task
-    anyway (override for probing stale requirements)."""
+    """Policy when a task needs a capability this infra lacks. 'raise': abort
+    setup if ANY task is incompatible. 'skip': run the compatible subset,
+    mark the rest INVALID_CONFIG. 'force': attempt every task anyway."""
 
     def can_serve_task(self, container_config: ContainerConfig) -> bool:
-        """True iff this infra provides every capability the task's container
-        requires. Cheap, metadata-only — no resource built, no launch.
-        Mirrors the existing can_serve(resource) set-inclusion test."""
+        """Per-task compatibility bool — set-inclusion of the task's
+        requirements against this infra's capabilities. Mirrors the existing
+        can_serve(resource); cheap, metadata-only, no launch."""
         return container_config.requirements().issubset(self.capabilities())
 ```
 
-The **source of truth is the per-task `ContainerConfig.requires`** (below).
-"Is the whole benchmark incompatible?" is answered by the harness looping
-`can_serve_task` over the tasks — there is no aggregate method to maintain.
-The blanket "all of tbench2 needs root" case is realised by the
-metadata-generation script stamping `requires={"container:root"}` on every
-task's `ContainerConfig`.
+The harness loops `can_serve_task` over tasks. No benchmark-level aggregate.
 
-## MODIFIED — `openspec/specs/container/spec.md`: `ContainerConfig`
+## MODIFIED — `benchmark/spec.md`: `Benchmark.setup` reads `infra.on_incompatible`
 
-**Before**
-
-```python
-class ContainerConfig(TypedBaseModel):
-    image: str
-    ram_gb: float = 4.0
-    cpu_cores: float = 2.0
-    gpu: bool = False
-    disk_gb: float = 10.0
-    ports: list[int] | None = None
-```
-
-**After**
-
-```python
-class ContainerConfig(TypedBaseModel):
-    image: str
-    ram_gb: float = 4.0
-    cpu_cores: float = 2.0
-    gpu: bool = False
-    disk_gb: float = 10.0
-    ports: list[int] | None = None
-    requires: set[str] = Field(default_factory=set)
-    """Permission tokens this task's container needs from its infra. The
-    source of truth for requirements. A blanket-per-benchmark need (e.g.
-    'all of tbench2 needs root') is realised by the cube's metadata-
-    generation script stamping this on every task; heterogeneous benchmarks
-    set it per task. Empty (default) = runs on any infra."""
-
-    def requirements(self) -> set[str]:
-        out = set(self.requires)
-        if self.gpu:
-            out.add("gpu:nvidia")
-        return out
-```
-
-Mirrors the existing `VMResourceConfig.requires_kvm: bool` →
-`requirements() -> {"kvm"}` projection.
-
-## MODIFIED — `openspec/specs/benchmark/spec.md`: `Benchmark.setup` gate (per-task loop, infra-owned policy)
-
-`Benchmark.setup` reads `infra.on_incompatible` and loops the per-task bool
-`infra.can_serve_task(...)`. No new `setup` parameter, no benchmark-level
-aggregate:
+`setup` keeps its signature; it reads the infra's policy and loops the
+per-task bool **before any episode is created**:
 
 ```python
 def setup(self, infra: InfraConfig | None) -> None:
     if infra is not None and infra.on_incompatible != "force":
         incompatible = [
-            SkippedTask(task_id, sorted(meta.container_config.requirements() - infra.capabilities()))
-            for task_id, meta in self.tasks.items()
-            if meta.container_config is not None and not infra.can_serve_task(meta.container_config)
+            SkippedTask(tid, sorted(m.container_config.requirements() - infra.capabilities()))
+            for tid, m in self.tasks.items()
+            if m.container_config and not infra.can_serve_task(m.container_config)
         ]
         if incompatible and infra.on_incompatible == "raise":
             raise IncompatibleInfraError(
                 f"{type(infra).__name__} cannot run {len(incompatible)}/{len(self.tasks)} "
                 f"tasks of {self.config.metadata.name}: "
-                f"{[(s.task_id, s.missing_capabilities) for s in incompatible[:5]]}. "
-                f"Set infra.on_incompatible='skip' to run the compatible subset, "
-                f"or 'force' to attempt anyway."
+                f"{[(s.task_id, s.missing_capabilities) for s in incompatible[:5]]}"
             )
-        skipped_ids = {s.task_id for s in incompatible}    # skip mode
-        self._runnable_tasks = [t for t in self.tasks if t not in skipped_ids]
+        skip = {s.task_id for s in incompatible}          # skip mode
+        self._runnable_tasks = [t for t in self.tasks if t not in skip]
         self._skipped_tasks = incompatible
     else:
         self._runnable_tasks, self._skipped_tasks = list(self.tasks), []
     # ... existing resource-provisioning setup
 ```
 
-- **`"raise"`** (default): if the per-task loop finds **any** incompatible
-  task, abort setup with `IncompatibleInfraError`. No episodes created →
-  cube-harness surfaces a setup/system failure → nothing to retry.
-- **`"skip"`**: incompatible tasks are excluded from `_runnable_tasks` and
-  recorded in `_skipped_tasks`; the experiment runs the compatible subset.
-- **`"force"`**: loop skipped entirely; every task runs (per-task launch may
-  still fail naturally, but the harness no longer pre-empts it). A warning is
-  logged once.
+`infra is None` (debug runs) → no-op, whole list passes through.
 
-When `infra is None` (debug / non-container runs) the gate is a no-op and
-the whole task list passes through — matching today's behaviour.
-
-(Optional, not required by this RFC: `cube.task_infra.launch_task_container`
-may additionally thread `container_config.requirements()` into the
-`DockerServiceConfig` it builds, so the existing `can_serve(resource)` also
-enforces at launch time — defense in depth. The setup-time `can_serve_task`
-loop is the primary gate.)
-
-## ADDED — `openspec/specs/benchmark/spec.md`: `IncompatibleInfraError`, `SkippedTask`, `CompatibilityReport`
+## ADDED — `benchmark/spec.md`: `IncompatibleInfraError`, `SkippedTask`
 
 ```python
 class IncompatibleInfraError(Exception):
     """Raised by Benchmark.setup when infra.on_incompatible == 'raise' and the
-    per-task can_serve_task loop finds ≥1 task whose requirements the infra's
-    capabilities don't satisfy. A setup-time, pre-episode failure: the
-    experiment aborts before launching work, so no retry budget is consumed."""
+    per-task can_serve_task loop finds ≥1 incompatible task. Setup-time,
+    pre-episode: the experiment aborts before launching, so no retry budget
+    is consumed."""
 
 @dataclass
 class SkippedTask:
     task_id: str
-    missing_capabilities: list[str]   # sorted, deterministic
+    missing_capabilities: list[str]   # sorted
 ```
 
-```python
-@dataclass
-class CompatibilityReport:
-    benchmark: str
-    infra: str
-    compatible: bool                       # benchmark-level
-    benchmark_missing: list[str]
-    n_total: int
-    n_runnable: int                        # under skip mode
-    skipped_tasks: list[SkippedTask]
-```
+`BenchmarkSummary` gains `n_skipped: int` and `skipped_tasks: list[SkippedTask]`;
+accuracy is computed over completed (runnable) tasks, not over the skipped set.
 
-`compatibility_report(cls, infra)` reads `cls.tasks_metadata()` only (cheap;
-no archive load) for `cube list --infra=<name>` and CI gates.
+## CONSUMED (cube-harness follow-up, not modified here)
 
-## CONSUMED (not modified here) — cube-harness episode-status mapping
+- **skip mode** writes each skipped episode as the existing terminal,
+  non-retriable `INVALID_CONFIG` (`cube_harness.episode_status`); the
+  auto-retry loop excludes it by construction.
+- **raise mode**: `IncompatibleInfraError` propagates out of `setup` before
+  the episode loop — reported as a run-level setup failure.
+- An optional dedicated `INCOMPATIBLE` status is a future refinement; not
+  required for correct retry semantics.
 
-This is a cube-standard spec change; the cube-harness side consumes it.
-Documented here for reviewer context (cube-harness follow-up PR):
+## Migration
 
-- **skip mode**: each skipped task's episode is written with the existing
-  terminal, non-retriable status **`INVALID_CONFIG`**
-  (`cube_harness.episode_status`). This is correct by construction:
-  `RETRIABLE_STATUSES = {FAILED, CANCELLED, STALE}` excludes
-  `INVALID_CONFIG`, so the auto-retry loop never re-runs a skipped task —
-  matching the documented semantic "the identical request will fail
-  identically on retry, so replaying only burns the retry budget."
-- **raise mode**: `IncompatibleInfraError` propagates out of
-  `Benchmark.setup` before the episode loop starts; cube-harness reports it
-  as a run-level setup failure (no per-episode status).
-- An optional dedicated `INCOMPATIBLE` status (cleaner reporting) is left as
-  a future cube-harness refinement; not required for correct retry
-  semantics.
+| Audience | Change |
+|---|---|
+| Cubes with no `requires` | None — `can_serve_task` always True; loop is a no-op. |
+| Existing `InfraConfig` subclasses | None — inherit `on_incompatible="raise"` + default `can_serve_task`, both no-op until a task declares `requires`. |
+| `Benchmark.setup` callers | No signature change. |
+| tbench2 | Codegen stamps `requires={"container:root"}` on every task. |
+| Root-capable infras | Publish `container:root` in `capabilities()`. |
+| cube-harness runner | Read `infra.on_incompatible`; map skip-mode episodes to `INVALID_CONFIG`. |
 
-## Migration impact
-
-| Audience | Change | When |
-|---|---|---|
-| **Cubes that stamp no `requires`** | None. `ContainerConfig.requires` defaults `set()` → `can_serve_task` returns True for every task → loop is a no-op. | Immediate. |
-| **Existing `InfraConfig` subclasses** | None. They inherit `on_incompatible="raise"` + the default `can_serve_task`; both no-op until a task declares `requires`. | Immediate. |
-| **`Benchmark.setup` callers** | No signature change — `setup` reads `infra.on_incompatible` internally. Existing call sites unaffected. | This PR (spec). |
-| **Cubes adopting requirements (tbench2)** | Stamp `ContainerConfig.requires` (via the codegen script). Gated on infras lacking the token. | Per-cube follow-up. |
-| **Root-capable infras** | Publish `container:root` in `capabilities()`. | Paired with the first adopting cube. |
-| **Constrained infras (toolkit)** | Optionally set `on_incompatible` default (e.g. `"raise"`); otherwise inherit the base default. | Optional. |
-| **cube-harness runner** | Read `infra.on_incompatible` in `setup`/launch; map skip-mode episodes to `INVALID_CONFIG`. | cube-harness follow-up. |
-
-No silent behaviour change: the gate only fires for benchmarks whose tasks
-stamp `requires`.
+No silent behaviour change — the gate fires only for tasks that stamp
+`requires`.

--- a/openspec/changes/task-permission-requirements/deltas.md
+++ b/openspec/changes/task-permission-requirements/deltas.md
@@ -1,0 +1,185 @@
+# Deltas — Task permission requirements + infra capability handshake
+
+## MODIFIED — `openspec/specs/container/spec.md`: `ContainerConfig`
+
+**Before**
+
+```python
+class ContainerConfig(TypedBaseModel):
+    image: str
+    ram_gb: float = 4.0
+    cpu_cores: float = 2.0
+    gpu: bool = False
+    disk_gb: float = 10.0
+    ports: list[int] | None = None
+```
+
+**After**
+
+```python
+class ContainerConfig(TypedBaseModel):
+    image: str
+    ram_gb: float = 4.0
+    cpu_cores: float = 2.0
+    gpu: bool = False
+    disk_gb: float = 10.0
+    ports: list[int] | None = None
+    requires: set[str] = Field(default_factory=set)
+    """Permission tokens this container needs from its host infra. See
+    `cube.resource.InfraConfig.capabilities` for the authoritative
+    vocabulary. Common tokens: `container:root`, `container:apt`,
+    `container:privileged-ports`, `container:systemd`. Empty (default)
+    = no special requirements; container runs on every infra."""
+
+    def requirements(self) -> set[str]:
+        """Projection used by `InfraConfig.can_serve` and `Benchmark._setup`.
+        Composes typed booleans (`gpu`) with free-form `requires` tokens."""
+        out = set(self.requires)
+        if self.gpu:
+            out.add("gpu:nvidia")
+        return out
+```
+
+The `requirements()` projection mirrors the existing pattern on
+`VMResourceConfig.requires_kvm: bool` → `requirements() -> {"kvm"}`.
+`ContainerConfig.requirements()` is the canonical task-level answer to
+"what does this container need from its infra".
+
+## ADDED — `openspec/specs/resource/spec.md`: capability token vocabulary
+
+The `InfraConfig.capabilities()` docstring is extended with the standard
+permission-shaped token vocabulary:
+
+| Token | Meaning |
+|---|---|
+| `container:root` | Container processes run as uid 0 |
+| `container:apt` | `apt-get install` (and equivalent) work — implies root + reachable Debian/Ubuntu mirrors |
+| `container:privileged-ports` | A process inside the container may `bind()` ports <1024 |
+| `container:systemd` | `systemctl` / `service` work (PID 1 is systemd or a systemd-compatible init) |
+
+Adding a token to the vocabulary is non-breaking. Infras default to
+**not** publishing a token; tasks default to **not** requiring it. A
+task is gated only when the task explicitly requires a token AND the
+target infra does not publish it.
+
+The pre-existing vocabulary (`kvm`, `docker`, `vm`, `gpu:nvidia`,
+`network:egress`) is unchanged.
+
+## MODIFIED — `openspec/specs/benchmark/spec.md`: `Benchmark._setup`
+
+`Benchmark._setup(infra)` (called by `Benchmark.setup`) gains an explicit
+task-compatibility filter:
+
+```python
+def _setup(self, infra: InfraConfig | None) -> None:
+    if infra is None:
+        self._runnable_tasks = list(self.tasks)
+        self._skipped_tasks = []
+        return
+    runnable, skipped = [], []
+    for task_id, task_meta in self.tasks.items():
+        cc = task_meta.container_config
+        if cc is None:
+            runnable.append(task_id)
+            continue
+        missing = cc.requirements() - infra.capabilities()
+        if missing:
+            skipped.append(SkippedTask(task_id=task_id, missing_capabilities=sorted(missing)))
+        else:
+            runnable.append(task_id)
+    if skipped and self.config.on_incompatible_task == "raise":
+        raise IncompatibleTaskError(
+            f"{len(skipped)} task(s) require capabilities not provided by "
+            f"{type(infra).__name__}: {[(s.task_id, s.missing_capabilities) for s in skipped]}"
+        )
+    self._runnable_tasks = runnable
+    self._skipped_tasks = skipped
+```
+
+When `infra is None` (debug / non-container runs), no filtering is
+applied — the whole task list passes through, matching today's behaviour.
+
+`Experiment` and `run_with_ray` / `run_sequentially` consume
+`benchmark._runnable_tasks` instead of `benchmark.tasks` after setup,
+and surface `benchmark._skipped_tasks` in the summary.
+
+## ADDED — `openspec/specs/benchmark/spec.md`: `BenchmarkConfig.on_incompatible_task`
+
+New optional field on `BenchmarkConfig`:
+
+```python
+class BenchmarkConfig(TypedBaseModel, ABC):
+    ...
+    on_incompatible_task: Literal["skip", "raise"] = "skip"
+```
+
+Default `"skip"` preserves "run what you can" semantics. `"raise"`
+short-circuits the experiment for strict same-task comparison runs.
+
+## ADDED — `openspec/specs/benchmark/spec.md`: `SkippedTask` and `IncompatibleTaskError`
+
+```python
+@dataclass
+class SkippedTask:
+    task_id: str
+    missing_capabilities: list[str]   # sorted, deterministic
+
+class IncompatibleTaskError(Exception):
+    """Raised when `on_incompatible_task='raise'` and one or more tasks'
+    requirements are not satisfied by the target infra's capabilities."""
+```
+
+`BenchmarkSummary` (in the storage / summary layer) gains:
+
+```python
+class BenchmarkSummary:
+    ...
+    n_skipped: int = 0
+    skipped_tasks: list[SkippedTask] = field(default_factory=list)
+```
+
+Accuracy and other aggregates are computed over `n_completed`
+(runnable tasks that finished), not over `n_skipped + n_completed`.
+This makes cross-infra comparisons of the *attempted* overlap fair by
+construction.
+
+## ADDED — `openspec/specs/benchmark/spec.md`: `BenchmarkConfig.compatibility_report`
+
+```python
+@classmethod
+def compatibility_report(cls, infra: InfraConfig) -> CompatibilityReport:
+    """Static preview of which tasks would be skipped on `infra`, without
+    launching anything. Used by `cube list --infra=<name>` and CI gates."""
+```
+
+```python
+@dataclass
+class CompatibilityReport:
+    benchmark: str
+    infra: str
+    n_total: int
+    n_runnable: int
+    n_skipped: int
+    skipped_tasks: list[SkippedTask]
+    missing_capability_counts: dict[str, int]   # which tokens block the most tasks
+```
+
+Reads `cls.tasks_metadata()` only (cheap; no archive load). Surfaces:
+
+> `terminalbench2-cube on toolkit:`
+> `  runnable: 84/89`
+> `  skipped: 5 (container:root × 5; container:apt × 5)`
+> `  Use a root-capable infra (daytona, aws, azure, local) to run these.`
+
+## Migration impact
+
+| Audience | Change | When |
+|---|---|---|
+| **Cubes that don't set `container_config.requires`** | No change. Default `set()` means tasks pass the filter on every infra. | Immediate. |
+| **Existing `InfraConfig` subclasses** | No code change required. New tokens are not requested by any task until a cube opts in. | Immediate. |
+| **Cubes adopting requirements** | Set `container_config.requires` in `TaskMetadata`. Tasks become opt-in gated on infras that don't publish the matching tokens. | Per-cube follow-up PRs. |
+| **Root-capable infras** | Publish `container:root` / `container:apt` / `container:privileged-ports` in `capabilities()` so newly-annotated tasks still run there. | Paired with the first cube that opts in. |
+| **`Experiment` / runners** | Switch from `benchmark.tasks` to `benchmark.runnable_tasks` for episode iteration. Read `benchmark.skipped_tasks` for summary reporting. Two-line change. | This PR. |
+
+No silent behaviour change. The compatibility filter only fires for
+tasks that explicitly request tokens.

--- a/openspec/changes/task-permission-requirements/deltas.md
+++ b/openspec/changes/task-permission-requirements/deltas.md
@@ -2,15 +2,19 @@
 
 ## ADDED — `openspec/specs/resource/spec.md`: capability token vocabulary
 
-The `InfraConfig.capabilities()` docstring is extended with the standard
-permission-shaped token vocabulary:
+The `InfraConfig.capabilities()` docstring is extended with one
+permission-shaped token:
 
 | Token | Meaning |
 |---|---|
 | `container:root` | Container processes run as uid 0 |
-| `container:apt` | `apt-get install` (and equivalent) work — implies root + reachable Debian/Ubuntu mirrors |
-| `container:privileged-ports` | A process inside the container may `bind()` ports <1024 |
-| `container:systemd` | `systemctl` / `service` work (PID 1 is systemd-compatible) |
+
+A single token is intentional: `apt-get`, writes to `/etc` / `/var`,
+binding ports <1024, and `systemctl` are all root-gated and correlate
+near-perfectly with "is the container root?" on both the infra and image
+sides. The vocabulary stays open (`set[str]`), so a finer token (e.g.
+`container:cap-net-bind` for a future rootless-with-capabilities infra)
+can be added later without breaking existing declarations.
 
 Adding a token is non-breaking. Infras default to **not** publishing one;
 benchmarks/tasks default to **not** requiring one. The pre-existing
@@ -175,7 +179,7 @@ Documented here for reviewer context (cube-harness follow-up PR):
 | **Existing `InfraConfig` subclasses** | None. New tokens unrequested until a cube opts in. | Immediate. |
 | **`Benchmark.setup` callers** | New keyword-only `on_incompatible="raise"` with a no-op default when `requirements()` is empty. Existing call sites unaffected. | This PR (spec); cube-harness wires the knob. |
 | **Cubes adopting requirements (tbench2)** | Implement `BenchmarkConfig.requirements()`. Gated on infras lacking the tokens. | Per-cube follow-up. |
-| **Root-capable infras** | Publish `container:root` / `container:apt` / `container:privileged-ports` in `capabilities()`. | Paired with the first adopting cube. |
+| **Root-capable infras** | Publish `container:root` in `capabilities()`. | Paired with the first adopting cube. |
 | **cube-harness runner** | Forward `on_incompatible` from `Experiment`/`run_*`; map skip-mode episodes to `INVALID_CONFIG`. | cube-harness follow-up. |
 
 No silent behaviour change: the gate only fires for benchmarks that

--- a/openspec/changes/task-permission-requirements/deltas.md
+++ b/openspec/changes/task-permission-requirements/deltas.md
@@ -1,4 +1,39 @@
-# Deltas — Task permission requirements + infra capability handshake
+# Deltas — Benchmark/task permission requirements + infra capability handshake
+
+## ADDED — `openspec/specs/resource/spec.md`: capability token vocabulary
+
+The `InfraConfig.capabilities()` docstring is extended with the standard
+permission-shaped token vocabulary:
+
+| Token | Meaning |
+|---|---|
+| `container:root` | Container processes run as uid 0 |
+| `container:apt` | `apt-get install` (and equivalent) work — implies root + reachable Debian/Ubuntu mirrors |
+| `container:privileged-ports` | A process inside the container may `bind()` ports <1024 |
+| `container:systemd` | `systemctl` / `service` work (PID 1 is systemd-compatible) |
+
+Adding a token is non-breaking. Infras default to **not** publishing one;
+benchmarks/tasks default to **not** requiring one. The pre-existing
+vocabulary (`kvm`, `docker`, `vm`, `gpu:nvidia`, `network:egress`) is
+unchanged.
+
+## ADDED — `openspec/specs/benchmark/spec.md`: `BenchmarkConfig.requirements()`
+
+```python
+class BenchmarkConfig(TypedBaseModel, ABC):
+    ...
+    def requirements(self) -> set[str]:
+        """Permission tokens EVERY task in this benchmark needs from its
+        infra. Default empty = runs on any infra. The primary, blanket
+        mechanism: a benchmark whose tasks broadly need root declares it
+        once here rather than annotating each task. Composes (union) with
+        any per-task ContainerConfig.requires."""
+        return set()
+```
+
+This is the **primary** requirement-declaration surface. The effective
+requirement for a single task is
+`benchmark.requirements() | task.metadata.container_config.requirements()`.
 
 ## MODIFIED — `openspec/specs/container/spec.md`: `ContainerConfig`
 
@@ -25,131 +60,77 @@ class ContainerConfig(TypedBaseModel):
     disk_gb: float = 10.0
     ports: list[int] | None = None
     requires: set[str] = Field(default_factory=set)
-    """Permission tokens this container needs from its host infra. See
-    `cube.resource.InfraConfig.capabilities` for the authoritative
-    vocabulary. Common tokens: `container:root`, `container:apt`,
-    `container:privileged-ports`, `container:systemd`. Empty (default)
-    = no special requirements; container runs on every infra."""
+    """Optional per-task permission tokens, for heterogeneous benchmarks
+    where requirements differ across tasks. Most cubes leave this empty
+    and declare blanket needs via BenchmarkConfig.requirements()."""
 
     def requirements(self) -> set[str]:
-        """Projection used by `InfraConfig.can_serve` and `Benchmark._setup`.
-        Composes typed booleans (`gpu`) with free-form `requires` tokens."""
         out = set(self.requires)
         if self.gpu:
             out.add("gpu:nvidia")
         return out
 ```
 
-The `requirements()` projection mirrors the existing pattern on
-`VMResourceConfig.requires_kvm: bool` → `requirements() -> {"kvm"}`.
-`ContainerConfig.requirements()` is the canonical task-level answer to
-"what does this container need from its infra".
+Mirrors the existing `VMResourceConfig.requires_kvm: bool` →
+`requirements() -> {"kvm"}` projection.
 
-## ADDED — `openspec/specs/resource/spec.md`: capability token vocabulary
+## MODIFIED — `openspec/specs/benchmark/spec.md`: `Benchmark.setup` gate
 
-The `InfraConfig.capabilities()` docstring is extended with the standard
-permission-shaped token vocabulary:
-
-| Token | Meaning |
-|---|---|
-| `container:root` | Container processes run as uid 0 |
-| `container:apt` | `apt-get install` (and equivalent) work — implies root + reachable Debian/Ubuntu mirrors |
-| `container:privileged-ports` | A process inside the container may `bind()` ports <1024 |
-| `container:systemd` | `systemctl` / `service` work (PID 1 is systemd or a systemd-compatible init) |
-
-Adding a token to the vocabulary is non-breaking. Infras default to
-**not** publishing a token; tasks default to **not** requiring it. A
-task is gated only when the task explicitly requires a token AND the
-target infra does not publish it.
-
-The pre-existing vocabulary (`kvm`, `docker`, `vm`, `gpu:nvidia`,
-`network:egress`) is unchanged.
-
-## MODIFIED — `openspec/specs/benchmark/spec.md`: `Benchmark._setup`
-
-`Benchmark._setup(infra)` (called by `Benchmark.setup`) gains an explicit
-task-compatibility filter:
+`Benchmark.setup` gains an `on_incompatible` parameter and an explicit
+capability gate that fires **before any episode is created**:
 
 ```python
-def _setup(self, infra: InfraConfig | None) -> None:
-    if infra is None:
-        self._runnable_tasks = list(self.tasks)
-        self._skipped_tasks = []
-        return
-    runnable, skipped = [], []
-    for task_id, task_meta in self.tasks.items():
-        cc = task_meta.container_config
-        if cc is None:
-            runnable.append(task_id)
-            continue
-        missing = cc.requirements() - infra.capabilities()
-        if missing:
-            skipped.append(SkippedTask(task_id=task_id, missing_capabilities=sorted(missing)))
-        else:
-            runnable.append(task_id)
-    if skipped and self.config.on_incompatible_task == "raise":
-        raise IncompatibleTaskError(
-            f"{len(skipped)} task(s) require capabilities not provided by "
-            f"{type(infra).__name__}: {[(s.task_id, s.missing_capabilities) for s in skipped]}"
-        )
-    self._runnable_tasks = runnable
-    self._skipped_tasks = skipped
+OnIncompatible = Literal["raise", "skip", "force"]
+
+def setup(self, infra: InfraConfig | None, *, on_incompatible: OnIncompatible = "raise") -> None:
+    if infra is not None and on_incompatible != "force":
+        bench_missing = self.config.requirements() - infra.capabilities()
+        if bench_missing and on_incompatible == "raise":
+            raise IncompatibleInfraError(
+                f"{type(infra).__name__} cannot run {self.config.metadata.name}: "
+                f"missing required capabilities {sorted(bench_missing)}. "
+                f"Use on_incompatible='skip' to run the compatible subset, or "
+                f"'force' to attempt anyway."
+            )
+        # skip mode: partition tasks; benchmark-level miss skips ALL tasks
+        runnable, skipped = [], []
+        for task_id, meta in self.tasks.items():
+            cc = meta.container_config
+            task_req = self.config.requirements() | (cc.requirements() if cc else set())
+            missing = task_req - infra.capabilities()
+            (skipped if missing else runnable).append(
+                SkippedTask(task_id, sorted(missing)) if missing else task_id
+            )
+        self._runnable_tasks, self._skipped_tasks = runnable, skipped
+    else:
+        self._runnable_tasks, self._skipped_tasks = list(self.tasks), []
+    # ... existing resource-provisioning setup
 ```
 
-When `infra is None` (debug / non-container runs), no filtering is
-applied — the whole task list passes through, matching today's behaviour.
+- **`"raise"`** (default): benchmark-level incompatibility aborts setup
+  with `IncompatibleInfraError`. No episodes created → cube-harness
+  surfaces a setup/system failure → nothing to retry.
+- **`"skip"`**: incompatible tasks are excluded from `_runnable_tasks` and
+  recorded in `_skipped_tasks`; the experiment runs the compatible subset.
+- **`"force"`**: gate skipped entirely; every task runs (per-task launch may
+  still fail, but the harness no longer pre-empts it). A warning is logged.
 
-`Experiment` and `run_with_ray` / `run_sequentially` consume
-`benchmark._runnable_tasks` instead of `benchmark.tasks` after setup,
-and surface `benchmark._skipped_tasks` in the summary.
+When `infra is None` (debug / non-container runs) the gate is a no-op and
+the whole task list passes through — matching today's behaviour.
 
-## ADDED — `openspec/specs/benchmark/spec.md`: `BenchmarkConfig.on_incompatible_task`
-
-New optional field on `BenchmarkConfig`:
-
-```python
-class BenchmarkConfig(TypedBaseModel, ABC):
-    ...
-    on_incompatible_task: Literal["skip", "raise"] = "skip"
-```
-
-Default `"skip"` preserves "run what you can" semantics. `"raise"`
-short-circuits the experiment for strict same-task comparison runs.
-
-## ADDED — `openspec/specs/benchmark/spec.md`: `SkippedTask` and `IncompatibleTaskError`
+## ADDED — `openspec/specs/benchmark/spec.md`: `IncompatibleInfraError`, `SkippedTask`, `CompatibilityReport`
 
 ```python
+class IncompatibleInfraError(Exception):
+    """Raised by Benchmark.setup(on_incompatible='raise') when the benchmark's
+    requirements() are not satisfied by the target infra's capabilities().
+    A setup-time, pre-episode failure: the experiment aborts before launching
+    work, so no retry budget is consumed."""
+
 @dataclass
 class SkippedTask:
     task_id: str
     missing_capabilities: list[str]   # sorted, deterministic
-
-class IncompatibleTaskError(Exception):
-    """Raised when `on_incompatible_task='raise'` and one or more tasks'
-    requirements are not satisfied by the target infra's capabilities."""
-```
-
-`BenchmarkSummary` (in the storage / summary layer) gains:
-
-```python
-class BenchmarkSummary:
-    ...
-    n_skipped: int = 0
-    skipped_tasks: list[SkippedTask] = field(default_factory=list)
-```
-
-Accuracy and other aggregates are computed over `n_completed`
-(runnable tasks that finished), not over `n_skipped + n_completed`.
-This makes cross-infra comparisons of the *attempted* overlap fair by
-construction.
-
-## ADDED — `openspec/specs/benchmark/spec.md`: `BenchmarkConfig.compatibility_report`
-
-```python
-@classmethod
-def compatibility_report(cls, infra: InfraConfig) -> CompatibilityReport:
-    """Static preview of which tasks would be skipped on `infra`, without
-    launching anything. Used by `cube list --infra=<name>` and CI gates."""
 ```
 
 ```python
@@ -157,29 +138,45 @@ def compatibility_report(cls, infra: InfraConfig) -> CompatibilityReport:
 class CompatibilityReport:
     benchmark: str
     infra: str
+    compatible: bool                       # benchmark-level
+    benchmark_missing: list[str]
     n_total: int
-    n_runnable: int
-    n_skipped: int
+    n_runnable: int                        # under skip mode
     skipped_tasks: list[SkippedTask]
-    missing_capability_counts: dict[str, int]   # which tokens block the most tasks
 ```
 
-Reads `cls.tasks_metadata()` only (cheap; no archive load). Surfaces:
+`compatibility_report(cls, infra)` reads `cls.tasks_metadata()` only (cheap;
+no archive load) for `cube list --infra=<name>` and CI gates.
 
-> `terminalbench2-cube on toolkit:`
-> `  runnable: 84/89`
-> `  skipped: 5 (container:root × 5; container:apt × 5)`
-> `  Use a root-capable infra (daytona, aws, azure, local) to run these.`
+## CONSUMED (not modified here) — cube-harness episode-status mapping
+
+This is a cube-standard spec change; the cube-harness side consumes it.
+Documented here for reviewer context (cube-harness follow-up PR):
+
+- **skip mode**: each skipped task's episode is written with the existing
+  terminal, non-retriable status **`INVALID_CONFIG`**
+  (`cube_harness.episode_status`). This is correct by construction:
+  `RETRIABLE_STATUSES = {FAILED, CANCELLED, STALE}` excludes
+  `INVALID_CONFIG`, so the auto-retry loop never re-runs a skipped task —
+  matching the documented semantic "the identical request will fail
+  identically on retry, so replaying only burns the retry budget."
+- **raise mode**: `IncompatibleInfraError` propagates out of
+  `Benchmark.setup` before the episode loop starts; cube-harness reports it
+  as a run-level setup failure (no per-episode status).
+- An optional dedicated `INCOMPATIBLE` status (cleaner reporting) is left as
+  a future cube-harness refinement; not required for correct retry
+  semantics.
 
 ## Migration impact
 
 | Audience | Change | When |
 |---|---|---|
-| **Cubes that don't set `container_config.requires`** | No change. Default `set()` means tasks pass the filter on every infra. | Immediate. |
-| **Existing `InfraConfig` subclasses** | No code change required. New tokens are not requested by any task until a cube opts in. | Immediate. |
-| **Cubes adopting requirements** | Set `container_config.requires` in `TaskMetadata`. Tasks become opt-in gated on infras that don't publish the matching tokens. | Per-cube follow-up PRs. |
-| **Root-capable infras** | Publish `container:root` / `container:apt` / `container:privileged-ports` in `capabilities()` so newly-annotated tasks still run there. | Paired with the first cube that opts in. |
-| **`Experiment` / runners** | Switch from `benchmark.tasks` to `benchmark.runnable_tasks` for episode iteration. Read `benchmark.skipped_tasks` for summary reporting. Two-line change. | This PR. |
+| **Cubes that declare no requirements** | None. `requirements()` defaults `set()`; gate is a no-op. | Immediate. |
+| **Existing `InfraConfig` subclasses** | None. New tokens unrequested until a cube opts in. | Immediate. |
+| **`Benchmark.setup` callers** | New keyword-only `on_incompatible="raise"` with a no-op default when `requirements()` is empty. Existing call sites unaffected. | This PR (spec); cube-harness wires the knob. |
+| **Cubes adopting requirements (tbench2)** | Implement `BenchmarkConfig.requirements()`. Gated on infras lacking the tokens. | Per-cube follow-up. |
+| **Root-capable infras** | Publish `container:root` / `container:apt` / `container:privileged-ports` in `capabilities()`. | Paired with the first adopting cube. |
+| **cube-harness runner** | Forward `on_incompatible` from `Experiment`/`run_*`; map skip-mode episodes to `INVALID_CONFIG`. | cube-harness follow-up. |
 
-No silent behaviour change. The compatibility filter only fires for
-tasks that explicitly request tokens.
+No silent behaviour change: the gate only fires for benchmarks that
+explicitly declare requirements.

--- a/openspec/changes/task-permission-requirements/deltas.md
+++ b/openspec/changes/task-permission-requirements/deltas.md
@@ -1,126 +1,64 @@
 # Deltas — Task permission requirements + infra capability handshake
 
+Applied to `openspec/specs/resource/spec.md` and `openspec/specs/benchmark/spec.md`.
+
 ## ADDED — `resource/spec.md`: `container:root` capability token
 
-Extend the `InfraConfig.capabilities()` vocabulary with one token:
+One token added to the `capabilities()` / `requirements()` vocabulary: `container:root`
+(container processes run as uid 0). Single token by design — `apt`, `/etc`+`/var` writes,
+ports <1024, and `systemctl` all correlate with "is the container root?". Vocabulary stays
+open (`set[str]`); finer tokens can be added later.
 
-| Token | Meaning |
-|---|---|
-| `container:root` | Container processes run as uid 0 |
-
-Single token by design: `apt`, `/etc`+`/var` writes, ports <1024, and
-`systemctl` are all root-gated and correlate with "is the container root?".
-Vocabulary stays open (`set[str]`); a finer token can be added later for a
-partial-root infra. Pre-existing tokens (`kvm`, `docker`, `gpu:nvidia`,
-`network:egress`) unchanged. Adding a token is non-breaking.
-
-## MODIFIED — `container/spec.md`: `ContainerConfig` gains `requires`
+## MODIFIED — `resource/spec.md`: `ResourceConfig.requires`
 
 ```python
-class ContainerConfig(TypedBaseModel):
-    image: str
-    ram_gb: float = 4.0
-    cpu_cores: float = 2.0
-    gpu: bool = False
-    disk_gb: float = 10.0
-    ports: list[int] | None = None
-    requires: set[str] = Field(default_factory=set)   # NEW
-    """Capability tokens this task's container needs, e.g. {"container:root"}.
-    Empty (default) = runs on any infra."""
-```
-
-`requires` is the source of truth. A blanket per-benchmark need is stamped
-on every task by the cube's metadata-generation script; heterogeneous
-benchmarks set it per task.
-
-## ADDED — `resource/spec.md`: `InfraConfig.can_serve_task()` + `on_incompatible`
-
-```python
-OnIncompatible = Literal["raise", "skip", "force"]
-
-class InfraConfig(TypedBaseModel, ABC):
+class ResourceConfig(TypedBaseModel):
     ...
-    on_incompatible: OnIncompatible = "raise"
-    """Policy when a task needs a capability this infra lacks. 'raise': abort
-    setup if ANY task is incompatible. 'skip': run the compatible subset,
-    mark the rest INVALID_CONFIG. 'force': attempt every task anyway."""
-
-    def can_serve_task(self, container_config: ContainerConfig) -> bool:
-        """Per-task compatibility bool — set-inclusion of the task's requires
-        against this infra's capabilities. Mirrors the existing
-        can_serve(resource); cheap, metadata-only, no launch."""
-        return container_config.requires.issubset(self.capabilities())
+    requires: set[str] = Field(default_factory=set)   # NEW — explicit extra tokens
+    def requirements(self) -> set[str]:
+        return set(self.requires)                      # base; subclasses super()-union
 ```
 
-The harness loops `can_serve_task` over tasks. No benchmark-level aggregate.
+Subclasses fold `requires` via `super().requirements()`:
+`VMResourceConfig` → `… | ({"kvm"} if requires_kvm else set())`;
+`DockerServiceConfig` → `… | {"docker"}`;
+`ContainerConfig` → `… | {"docker"}` (+ `"gpu:nvidia"` if `gpu`).
 
-## MODIFIED — `benchmark/spec.md`: `Benchmark.setup` reads `infra.on_incompatible`
+`requires` is the source of truth a cube stamps (e.g. tbench2 codegen sets
+`{"container:root"}` on every task). Backward-compatible: default empty adds nothing.
 
-`setup` keeps its signature; it reads the infra's policy and loops the
-per-task bool **before any episode is created**:
+## ADDED — `resource/spec.md`: `InfraConfig.on_incompatible` + `IncompatibleInfraError`
 
 ```python
-def setup(self, infra: InfraConfig | None) -> None:
-    if infra is not None and infra.on_incompatible != "force":
-        incompatible = [
-            SkippedTask(tid, sorted(m.container_config.requires - infra.capabilities()))
-            for tid, m in self.tasks.items()
-            if m.container_config and not infra.can_serve_task(m.container_config)
-        ]
-        if incompatible and infra.on_incompatible == "raise":
-            raise IncompatibleInfraError(
-                f"{type(infra).__name__} cannot run {len(incompatible)}/{len(self.tasks)} "
-                f"tasks of {self.config.metadata.name}: "
-                f"{[(s.task_id, s.missing_capabilities) for s in incompatible[:5]]}"
-            )
-        skip = {s.task_id for s in incompatible}          # skip mode
-        self._runnable_tasks = [t for t in self.tasks if t not in skip]
-        self._skipped_tasks = incompatible
-    else:
-        self._runnable_tasks, self._skipped_tasks = list(self.tasks), []
-    # ... existing resource-provisioning setup
+class InfraConfig(...):
+    on_incompatible: Literal["raise", "skip", "force"] = "raise"
 ```
 
-`infra is None` (debug runs) → no-op, whole list passes through.
+`can_serve(resource)` (existing — `requirements() <= capabilities()`) is the per-resource
+unit; **no new method**. `IncompatibleInfraError(RuntimeError)` is raised by the gate.
 
-## ADDED — `benchmark/spec.md`: `IncompatibleInfraError`, `SkippedTask`
+Capability declarations: `Local` (when docker present), `AWS`, `Azure`, `Daytona`, `Modal`
+publish `container:root`; `Toolkit` does not (pins a non-root uid).
 
-```python
-class IncompatibleInfraError(Exception):
-    """Raised by Benchmark.setup when infra.on_incompatible == 'raise' and the
-    per-task can_serve_task loop finds ≥1 incompatible task. Setup-time,
-    pre-episode: the experiment aborts before launching, so no retry budget
-    is consumed."""
+## MODIFIED — `benchmark/spec.md`: `BenchmarkConfig.make()` gate
 
-@dataclass
-class SkippedTask:
-    task_id: str
-    missing_capabilities: list[str]   # sorted
-```
+`make(infra)` runs the capability gate **before provisioning** when `infra` is set and
+`on_incompatible != "force"`: loop `can_serve` over each task's `container_config` and the
+benchmark's `resources`, then apply the policy:
 
-`BenchmarkSummary` gains `n_skipped: int` and `skipped_tasks: list[SkippedTask]`;
-accuracy is computed over completed (runnable) tasks, not over the skipped set.
+- `"raise"` — any incompatible resource → `IncompatibleInfraError` (pre-episode, no spend).
+- `"skip"` — narrow the task view to the compatible subset (`subset_from_list`); a shared
+  benchmark-scoped incompatible resource still raises.
+- `"force"` — skip the gate entirely.
 
-## CONSUMED (cube-harness follow-up, not modified here)
+## CONSUMED (cube-harness follow-up, not in this change)
 
-- **skip mode** writes each skipped episode as the existing terminal,
-  non-retriable `INVALID_CONFIG` (`cube_harness.episode_status`); the
-  auto-retry loop excludes it by construction.
-- **raise mode**: `IncompatibleInfraError` propagates out of `setup` before
-  the episode loop — reported as a run-level setup failure.
-- An optional dedicated `INCOMPATIBLE` status is a future refinement; not
-  required for correct retry semantics.
+- **skip mode** episodes map to the existing terminal, non-retriable `INVALID_CONFIG`.
+- tbench2 (and other root-needing cubes) codegen stamps `requires={"container:root"}`.
 
 ## Migration
 
-| Audience | Change |
-|---|---|
-| Cubes with no `requires` | None — `can_serve_task` always True; loop is a no-op. |
-| Existing `InfraConfig` subclasses | None — inherit `on_incompatible="raise"` + default `can_serve_task`, both no-op until a task declares `requires`. |
-| `Benchmark.setup` callers | No signature change. |
-| tbench2 | Codegen stamps `requires={"container:root"}` on every task. |
-| Root-capable infras | Publish `container:root` in `capabilities()`. |
-| cube-harness runner | Read `infra.on_incompatible`; map skip-mode episodes to `INVALID_CONFIG`. |
-
-No silent behaviour change — the gate fires only for tasks that stamp
-`requires`.
+Backward-compatible by default: `requires` defaults to empty (so `requirements()` is
+unchanged for existing resources) and `on_incompatible` is a no-op until a task declares a
+token the infra lacks. Behaviour changes only when a cube stamps `requires` AND a paired
+infra lacks the token.

--- a/openspec/changes/task-permission-requirements/deltas.md
+++ b/openspec/changes/task-permission-requirements/deltas.md
@@ -25,18 +25,13 @@ class ContainerConfig(TypedBaseModel):
     disk_gb: float = 10.0
     ports: list[int] | None = None
     requires: set[str] = Field(default_factory=set)   # NEW
-
-    def requirements(self) -> set[str]:               # NEW
-        out = set(self.requires)
-        if self.gpu:
-            out.add("gpu:nvidia")
-        return out
+    """Capability tokens this task's container needs, e.g. {"container:root"}.
+    Empty (default) = runs on any infra."""
 ```
 
 `requires` is the source of truth. A blanket per-benchmark need is stamped
 on every task by the cube's metadata-generation script; heterogeneous
-benchmarks set it per task. Mirrors `VMResourceConfig.requires_kvm` →
-`requirements() -> {"kvm"}`.
+benchmarks set it per task.
 
 ## ADDED — `resource/spec.md`: `InfraConfig.can_serve_task()` + `on_incompatible`
 
@@ -51,10 +46,10 @@ class InfraConfig(TypedBaseModel, ABC):
     mark the rest INVALID_CONFIG. 'force': attempt every task anyway."""
 
     def can_serve_task(self, container_config: ContainerConfig) -> bool:
-        """Per-task compatibility bool — set-inclusion of the task's
-        requirements against this infra's capabilities. Mirrors the existing
+        """Per-task compatibility bool — set-inclusion of the task's requires
+        against this infra's capabilities. Mirrors the existing
         can_serve(resource); cheap, metadata-only, no launch."""
-        return container_config.requirements().issubset(self.capabilities())
+        return container_config.requires.issubset(self.capabilities())
 ```
 
 The harness loops `can_serve_task` over tasks. No benchmark-level aggregate.
@@ -68,7 +63,7 @@ per-task bool **before any episode is created**:
 def setup(self, infra: InfraConfig | None) -> None:
     if infra is not None and infra.on_incompatible != "force":
         incompatible = [
-            SkippedTask(tid, sorted(m.container_config.requirements() - infra.capabilities()))
+            SkippedTask(tid, sorted(m.container_config.requires - infra.capabilities()))
             for tid, m in self.tasks.items()
             if m.container_config and not infra.can_serve_task(m.container_config)
         ]

--- a/openspec/changes/task-permission-requirements/deltas.md
+++ b/openspec/changes/task-permission-requirements/deltas.md
@@ -21,23 +21,30 @@ benchmarks/tasks default to **not** requiring one. The pre-existing
 vocabulary (`kvm`, `docker`, `vm`, `gpu:nvidia`, `network:egress`) is
 unchanged.
 
-## ADDED — `openspec/specs/benchmark/spec.md`: `BenchmarkConfig.requirements()`
+## ADDED — `openspec/specs/benchmark/spec.md`: `BenchmarkConfig.aggregate_requirements()` (derived)
 
 ```python
 class BenchmarkConfig(TypedBaseModel, ABC):
     ...
-    def requirements(self) -> set[str]:
-        """Permission tokens EVERY task in this benchmark needs from its
-        infra. Default empty = runs on any infra. The primary, blanket
-        mechanism: a benchmark whose tasks broadly need root declares it
-        once here rather than annotating each task. Composes (union) with
-        any per-task ContainerConfig.requires."""
-        return set()
+    def aggregate_requirements(self) -> set[str]:
+        """Union of every task's container_config.requirements(). DERIVED
+        from the per-task resources — there is no separately-declared
+        benchmark-level requirement to drift out of sync. Reads task
+        metadata only (no archive load, no container launch); the infra
+        introspects this at setup to decide whole-benchmark compatibility."""
+        out: set[str] = set()
+        for meta in self.tasks_metadata().values():
+            if meta.container_config is not None:
+                out |= meta.container_config.requirements()
+        return out
 ```
 
-This is the **primary** requirement-declaration surface. The effective
-requirement for a single task is
-`benchmark.requirements() | task.metadata.container_config.requirements()`.
+The **source of truth is the per-task `ContainerConfig.requires`** (below).
+`aggregate_requirements()` is a read-only projection over the tasks, used
+for setup-time whole-benchmark gating and the static compatibility report.
+The blanket "all of tbench2 needs root" case is realised by the
+metadata-generation script stamping `requires={"container:root"}` on every
+task's `ContainerConfig` — not by a second benchmark-level declaration.
 
 ## MODIFIED — `openspec/specs/container/spec.md`: `ContainerConfig`
 
@@ -64,9 +71,11 @@ class ContainerConfig(TypedBaseModel):
     disk_gb: float = 10.0
     ports: list[int] | None = None
     requires: set[str] = Field(default_factory=set)
-    """Optional per-task permission tokens, for heterogeneous benchmarks
-    where requirements differ across tasks. Most cubes leave this empty
-    and declare blanket needs via BenchmarkConfig.requirements()."""
+    """Permission tokens this task's container needs from its infra. The
+    source of truth for requirements. A blanket-per-benchmark need (e.g.
+    'all of tbench2 needs root') is realised by the cube's metadata-
+    generation script stamping this on every task; heterogeneous benchmarks
+    set it per task. Empty (default) = runs on any infra."""
 
     def requirements(self) -> set[str]:
         out = set(self.requires)
@@ -78,6 +87,25 @@ class ContainerConfig(TypedBaseModel):
 Mirrors the existing `VMResourceConfig.requires_kvm: bool` →
 `requirements() -> {"kvm"}` projection.
 
+## MODIFIED — `openspec/specs/resource/spec.md` + `cube.task_infra`: thread `requires` into the per-task resource
+
+`DockerServiceConfig` gains a `requires: set[str] = Field(default_factory=set)`
+field; its existing `requirements()` returns it (currently returns `set()`).
+`cube.task_infra.launch_task_container` threads the task's tokens through:
+
+```python
+resource = DockerServiceConfig(
+    name=name, scope="task", docker_images=[image],
+    requires=container_config.requirements(),   # NEW (was implicitly empty)
+    launch_script=build_docker_run_script(container_name, image, ram_gb, cpu_cores),
+)
+```
+
+This makes the **already-existing** `InfraConfig.can_serve(resource)`
+(= `resource.requirements().issubset(infra.capabilities())`) answer per-task
+compatibility with no new primitive. `launch_task_container` (or `setup` in
+skip mode) consults `can_serve` before `launch`.
+
 ## MODIFIED — `openspec/specs/benchmark/spec.md`: `Benchmark.setup` gate
 
 `Benchmark.setup` gains an `on_incompatible` parameter and an explicit
@@ -88,7 +116,8 @@ OnIncompatible = Literal["raise", "skip", "force"]
 
 def setup(self, infra: InfraConfig | None, *, on_incompatible: OnIncompatible = "raise") -> None:
     if infra is not None and on_incompatible != "force":
-        bench_missing = self.config.requirements() - infra.capabilities()
+        # Whole-benchmark gate: derived union over the per-task resources.
+        bench_missing = self.config.aggregate_requirements() - infra.capabilities()
         if bench_missing and on_incompatible == "raise":
             raise IncompatibleInfraError(
                 f"{type(infra).__name__} cannot run {self.config.metadata.name}: "
@@ -96,12 +125,11 @@ def setup(self, infra: InfraConfig | None, *, on_incompatible: OnIncompatible = 
                 f"Use on_incompatible='skip' to run the compatible subset, or "
                 f"'force' to attempt anyway."
             )
-        # skip mode: partition tasks; benchmark-level miss skips ALL tasks
+        # skip mode: check each task's own resource via the existing can_serve.
         runnable, skipped = [], []
         for task_id, meta in self.tasks.items():
-            cc = meta.container_config
-            task_req = self.config.requirements() | (cc.requirements() if cc else set())
-            missing = task_req - infra.capabilities()
+            req = meta.container_config.requirements() if meta.container_config else set()
+            missing = req - infra.capabilities()
             (skipped if missing else runnable).append(
                 SkippedTask(task_id, sorted(missing)) if missing else task_id
             )
@@ -111,9 +139,9 @@ def setup(self, infra: InfraConfig | None, *, on_incompatible: OnIncompatible = 
     # ... existing resource-provisioning setup
 ```
 
-- **`"raise"`** (default): benchmark-level incompatibility aborts setup
-  with `IncompatibleInfraError`. No episodes created → cube-harness
-  surfaces a setup/system failure → nothing to retry.
+- **`"raise"`** (default): whole-benchmark incompatibility (derived from the
+  per-task resources) aborts setup with `IncompatibleInfraError`. No episodes
+  created → cube-harness surfaces a setup/system failure → nothing to retry.
 - **`"skip"`**: incompatible tasks are excluded from `_runnable_tasks` and
   recorded in `_skipped_tasks`; the experiment runs the compatible subset.
 - **`"force"`**: gate skipped entirely; every task runs (per-task launch may
@@ -127,9 +155,10 @@ the whole task list passes through — matching today's behaviour.
 ```python
 class IncompatibleInfraError(Exception):
     """Raised by Benchmark.setup(on_incompatible='raise') when the benchmark's
-    requirements() are not satisfied by the target infra's capabilities().
-    A setup-time, pre-episode failure: the experiment aborts before launching
-    work, so no retry budget is consumed."""
+    aggregate_requirements() (derived from the per-task resources) are not
+    satisfied by the target infra's capabilities(). A setup-time, pre-episode
+    failure: the experiment aborts before launching work, so no retry budget
+    is consumed."""
 
 @dataclass
 class SkippedTask:
@@ -175,12 +204,13 @@ Documented here for reviewer context (cube-harness follow-up PR):
 
 | Audience | Change | When |
 |---|---|---|
-| **Cubes that declare no requirements** | None. `requirements()` defaults `set()`; gate is a no-op. | Immediate. |
-| **Existing `InfraConfig` subclasses** | None. New tokens unrequested until a cube opts in. | Immediate. |
-| **`Benchmark.setup` callers** | New keyword-only `on_incompatible="raise"` with a no-op default when `requirements()` is empty. Existing call sites unaffected. | This PR (spec); cube-harness wires the knob. |
-| **Cubes adopting requirements (tbench2)** | Implement `BenchmarkConfig.requirements()`. Gated on infras lacking the tokens. | Per-cube follow-up. |
+| **Cubes that stamp no `requires`** | None. `ContainerConfig.requires` defaults `set()` → `aggregate_requirements()` empty → gate is a no-op. | Immediate. |
+| **Existing `InfraConfig` subclasses** | None. New token unrequested until a cube opts in. | Immediate. |
+| **`DockerServiceConfig` consumers** | New `requires` field defaults `set()`; existing `requirements()` returns it. No change unless populated. | This PR (spec). |
+| **`Benchmark.setup` callers** | New keyword-only `on_incompatible="raise"`, no-op when `aggregate_requirements()` is empty. Existing call sites unaffected. | This PR (spec); cube-harness wires the knob. |
+| **Cubes adopting requirements (tbench2)** | Stamp `ContainerConfig.requires` (via the codegen script). Gated on infras lacking the token. | Per-cube follow-up. |
 | **Root-capable infras** | Publish `container:root` in `capabilities()`. | Paired with the first adopting cube. |
 | **cube-harness runner** | Forward `on_incompatible` from `Experiment`/`run_*`; map skip-mode episodes to `INVALID_CONFIG`. | cube-harness follow-up. |
 
-No silent behaviour change: the gate only fires for benchmarks that
-explicitly declare requirements.
+No silent behaviour change: the gate only fires for benchmarks whose tasks
+stamp `requires`.

--- a/openspec/changes/task-permission-requirements/deltas.md
+++ b/openspec/changes/task-permission-requirements/deltas.md
@@ -21,30 +21,35 @@ benchmarks/tasks default to **not** requiring one. The pre-existing
 vocabulary (`kvm`, `docker`, `vm`, `gpu:nvidia`, `network:egress`) is
 unchanged.
 
-## ADDED — `openspec/specs/benchmark/spec.md`: `BenchmarkConfig.aggregate_requirements()` (derived)
+## ADDED — `openspec/specs/resource/spec.md`: `InfraConfig.can_serve_task()` (per-task bool) + `on_incompatible`
+
+The compatibility primitive is a **per-task bool** the infra returns; the
+harness loops over tasks. No benchmark-level aggregate (awkward to build).
 
 ```python
-class BenchmarkConfig(TypedBaseModel, ABC):
+OnIncompatible = Literal["raise", "skip", "force"]
+
+class InfraConfig(TypedBaseModel, ABC):
     ...
-    def aggregate_requirements(self) -> set[str]:
-        """Union of every task's container_config.requirements(). DERIVED
-        from the per-task resources — there is no separately-declared
-        benchmark-level requirement to drift out of sync. Reads task
-        metadata only (no archive load, no container launch); the infra
-        introspects this at setup to decide whole-benchmark compatibility."""
-        out: set[str] = set()
-        for meta in self.tasks_metadata().values():
-            if meta.container_config is not None:
-                out |= meta.container_config.requirements()
-        return out
+    on_incompatible: OnIncompatible = "raise"
+    """Policy when a task needs a capability this infra lacks. 'raise':
+    abort setup if ANY task is incompatible. 'skip': run the compatible
+    subset, mark the rest INVALID_CONFIG. 'force': attempt every task
+    anyway (override for probing stale requirements)."""
+
+    def can_serve_task(self, container_config: ContainerConfig) -> bool:
+        """True iff this infra provides every capability the task's container
+        requires. Cheap, metadata-only — no resource built, no launch.
+        Mirrors the existing can_serve(resource) set-inclusion test."""
+        return container_config.requirements().issubset(self.capabilities())
 ```
 
 The **source of truth is the per-task `ContainerConfig.requires`** (below).
-`aggregate_requirements()` is a read-only projection over the tasks, used
-for setup-time whole-benchmark gating and the static compatibility report.
+"Is the whole benchmark incompatible?" is answered by the harness looping
+`can_serve_task` over the tasks — there is no aggregate method to maintain.
 The blanket "all of tbench2 needs root" case is realised by the
 metadata-generation script stamping `requires={"container:root"}` on every
-task's `ContainerConfig` — not by a second benchmark-level declaration.
+task's `ContainerConfig`.
 
 ## MODIFIED — `openspec/specs/container/spec.md`: `ContainerConfig`
 
@@ -87,78 +92,62 @@ class ContainerConfig(TypedBaseModel):
 Mirrors the existing `VMResourceConfig.requires_kvm: bool` →
 `requirements() -> {"kvm"}` projection.
 
-## MODIFIED — `openspec/specs/resource/spec.md` + `cube.task_infra`: thread `requires` into the per-task resource
+## MODIFIED — `openspec/specs/benchmark/spec.md`: `Benchmark.setup` gate (per-task loop, infra-owned policy)
 
-`DockerServiceConfig` gains a `requires: set[str] = Field(default_factory=set)`
-field; its existing `requirements()` returns it (currently returns `set()`).
-`cube.task_infra.launch_task_container` threads the task's tokens through:
-
-```python
-resource = DockerServiceConfig(
-    name=name, scope="task", docker_images=[image],
-    requires=container_config.requirements(),   # NEW (was implicitly empty)
-    launch_script=build_docker_run_script(container_name, image, ram_gb, cpu_cores),
-)
-```
-
-This makes the **already-existing** `InfraConfig.can_serve(resource)`
-(= `resource.requirements().issubset(infra.capabilities())`) answer per-task
-compatibility with no new primitive. `launch_task_container` (or `setup` in
-skip mode) consults `can_serve` before `launch`.
-
-## MODIFIED — `openspec/specs/benchmark/spec.md`: `Benchmark.setup` gate
-
-`Benchmark.setup` gains an `on_incompatible` parameter and an explicit
-capability gate that fires **before any episode is created**:
+`Benchmark.setup` reads `infra.on_incompatible` and loops the per-task bool
+`infra.can_serve_task(...)`. No new `setup` parameter, no benchmark-level
+aggregate:
 
 ```python
-OnIncompatible = Literal["raise", "skip", "force"]
-
-def setup(self, infra: InfraConfig | None, *, on_incompatible: OnIncompatible = "raise") -> None:
-    if infra is not None and on_incompatible != "force":
-        # Whole-benchmark gate: derived union over the per-task resources.
-        bench_missing = self.config.aggregate_requirements() - infra.capabilities()
-        if bench_missing and on_incompatible == "raise":
+def setup(self, infra: InfraConfig | None) -> None:
+    if infra is not None and infra.on_incompatible != "force":
+        incompatible = [
+            SkippedTask(task_id, sorted(meta.container_config.requirements() - infra.capabilities()))
+            for task_id, meta in self.tasks.items()
+            if meta.container_config is not None and not infra.can_serve_task(meta.container_config)
+        ]
+        if incompatible and infra.on_incompatible == "raise":
             raise IncompatibleInfraError(
-                f"{type(infra).__name__} cannot run {self.config.metadata.name}: "
-                f"missing required capabilities {sorted(bench_missing)}. "
-                f"Use on_incompatible='skip' to run the compatible subset, or "
-                f"'force' to attempt anyway."
+                f"{type(infra).__name__} cannot run {len(incompatible)}/{len(self.tasks)} "
+                f"tasks of {self.config.metadata.name}: "
+                f"{[(s.task_id, s.missing_capabilities) for s in incompatible[:5]]}. "
+                f"Set infra.on_incompatible='skip' to run the compatible subset, "
+                f"or 'force' to attempt anyway."
             )
-        # skip mode: check each task's own resource via the existing can_serve.
-        runnable, skipped = [], []
-        for task_id, meta in self.tasks.items():
-            req = meta.container_config.requirements() if meta.container_config else set()
-            missing = req - infra.capabilities()
-            (skipped if missing else runnable).append(
-                SkippedTask(task_id, sorted(missing)) if missing else task_id
-            )
-        self._runnable_tasks, self._skipped_tasks = runnable, skipped
+        skipped_ids = {s.task_id for s in incompatible}    # skip mode
+        self._runnable_tasks = [t for t in self.tasks if t not in skipped_ids]
+        self._skipped_tasks = incompatible
     else:
         self._runnable_tasks, self._skipped_tasks = list(self.tasks), []
     # ... existing resource-provisioning setup
 ```
 
-- **`"raise"`** (default): whole-benchmark incompatibility (derived from the
-  per-task resources) aborts setup with `IncompatibleInfraError`. No episodes
-  created → cube-harness surfaces a setup/system failure → nothing to retry.
+- **`"raise"`** (default): if the per-task loop finds **any** incompatible
+  task, abort setup with `IncompatibleInfraError`. No episodes created →
+  cube-harness surfaces a setup/system failure → nothing to retry.
 - **`"skip"`**: incompatible tasks are excluded from `_runnable_tasks` and
   recorded in `_skipped_tasks`; the experiment runs the compatible subset.
-- **`"force"`**: gate skipped entirely; every task runs (per-task launch may
-  still fail, but the harness no longer pre-empts it). A warning is logged.
+- **`"force"`**: loop skipped entirely; every task runs (per-task launch may
+  still fail naturally, but the harness no longer pre-empts it). A warning is
+  logged once.
 
 When `infra is None` (debug / non-container runs) the gate is a no-op and
 the whole task list passes through — matching today's behaviour.
+
+(Optional, not required by this RFC: `cube.task_infra.launch_task_container`
+may additionally thread `container_config.requirements()` into the
+`DockerServiceConfig` it builds, so the existing `can_serve(resource)` also
+enforces at launch time — defense in depth. The setup-time `can_serve_task`
+loop is the primary gate.)
 
 ## ADDED — `openspec/specs/benchmark/spec.md`: `IncompatibleInfraError`, `SkippedTask`, `CompatibilityReport`
 
 ```python
 class IncompatibleInfraError(Exception):
-    """Raised by Benchmark.setup(on_incompatible='raise') when the benchmark's
-    aggregate_requirements() (derived from the per-task resources) are not
-    satisfied by the target infra's capabilities(). A setup-time, pre-episode
-    failure: the experiment aborts before launching work, so no retry budget
-    is consumed."""
+    """Raised by Benchmark.setup when infra.on_incompatible == 'raise' and the
+    per-task can_serve_task loop finds ≥1 task whose requirements the infra's
+    capabilities don't satisfy. A setup-time, pre-episode failure: the
+    experiment aborts before launching work, so no retry budget is consumed."""
 
 @dataclass
 class SkippedTask:
@@ -204,13 +193,13 @@ Documented here for reviewer context (cube-harness follow-up PR):
 
 | Audience | Change | When |
 |---|---|---|
-| **Cubes that stamp no `requires`** | None. `ContainerConfig.requires` defaults `set()` → `aggregate_requirements()` empty → gate is a no-op. | Immediate. |
-| **Existing `InfraConfig` subclasses** | None. New token unrequested until a cube opts in. | Immediate. |
-| **`DockerServiceConfig` consumers** | New `requires` field defaults `set()`; existing `requirements()` returns it. No change unless populated. | This PR (spec). |
-| **`Benchmark.setup` callers** | New keyword-only `on_incompatible="raise"`, no-op when `aggregate_requirements()` is empty. Existing call sites unaffected. | This PR (spec); cube-harness wires the knob. |
+| **Cubes that stamp no `requires`** | None. `ContainerConfig.requires` defaults `set()` → `can_serve_task` returns True for every task → loop is a no-op. | Immediate. |
+| **Existing `InfraConfig` subclasses** | None. They inherit `on_incompatible="raise"` + the default `can_serve_task`; both no-op until a task declares `requires`. | Immediate. |
+| **`Benchmark.setup` callers** | No signature change — `setup` reads `infra.on_incompatible` internally. Existing call sites unaffected. | This PR (spec). |
 | **Cubes adopting requirements (tbench2)** | Stamp `ContainerConfig.requires` (via the codegen script). Gated on infras lacking the token. | Per-cube follow-up. |
 | **Root-capable infras** | Publish `container:root` in `capabilities()`. | Paired with the first adopting cube. |
-| **cube-harness runner** | Forward `on_incompatible` from `Experiment`/`run_*`; map skip-mode episodes to `INVALID_CONFIG`. | cube-harness follow-up. |
+| **Constrained infras (toolkit)** | Optionally set `on_incompatible` default (e.g. `"raise"`); otherwise inherit the base default. | Optional. |
+| **cube-harness runner** | Read `infra.on_incompatible` in `setup`/launch; map skip-mode episodes to `INVALID_CONFIG`. | cube-harness follow-up. |
 
 No silent behaviour change: the gate only fires for benchmarks whose tasks
 stamp `requires`.

--- a/openspec/changes/task-permission-requirements/proposal.md
+++ b/openspec/changes/task-permission-requirements/proposal.md
@@ -1,0 +1,210 @@
+# Task permission requirements + infra capability handshake (extension)
+
+**Status:** Proposed
+**Date:** 2026-05-21
+**Scope:** `cube.container.ContainerConfig`, `cube.resource.InfraConfig`,
+`cube.benchmark.Benchmark._setup` (filter behaviour)
+**Targets:** `dev`
+**Related:** Surfaced by cube-harness session `2026-05-20_tbench2-infra-model-matrix`
+([REPORT](https://github.com/The-AI-Alliance/cube-harness/blob/dev/...))
+finding F7 ("toolkit's non-root user vs tbench2's apt-installing tasks").
+
+---
+
+## Problem
+
+Some cube tasks need infra permissions that not every `InfraConfig`
+provides:
+
+- `terminalbench2-cube/nginx-request-logging` and `install-windows-3.11`
+  ask the agent to `apt-get install` packages and write to `/etc/`,
+  `/var/log/` — only achievable inside a container running as **root**.
+- `cube-infra-toolkit` (EAI Toolkit) hard-enforces **uid 13011** in every
+  container by cluster policy; `apt-get` is unreachable.
+
+Today this mismatch surfaces as **silent low scores**: the agent runs,
+tries `apt-get`, gets `Permission denied`, eventually emits `final_step`
+with a wrong solution, the evaluator scores reward=0. The cube/infra
+combination is *partially incompatible* but the contract has no way to
+say so. A user looking at `tbench2 on toolkit ⇒ 0.17` cannot tell
+whether the gap is a model-quality issue, a cube-installation issue, or
+a fundamental infra mismatch.
+
+Empirical evidence from the surfacing session:
+
+| | daytona (root) | toolkit (uid 13011) |
+|---|---|---|
+| haiku × 25 tasks | 9/23 = **0.39** | 4/23 = **0.17** |
+| sonnet × 12 tasks | 3/6 = **0.50** | 1/9 = **0.11** |
+
+Stronger model lifts daytona but does not lift toolkit — because the
+toolkit-impossible subset is impossible regardless of reasoning.
+
+Heuristic classification of all 89 tbench2 tasks against root-needing
+operations (apt, `/etc/*`, `/var/*`, ports <1024, `systemctl`): only
+**~5–7 tasks** truly require root; the remaining 82+ would run fine on
+non-root infras if the framework gated only the incompatible tasks
+instead of silently mis-scoring them.
+
+The framework **already has** the right mechanism. `InfraConfig` exposes
+`capabilities() -> set[str]`. `ResourceConfig` exposes
+`requirements() -> set[str]`. `InfraConfig.can_serve(resource)` does
+`requirements.issubset(capabilities)`. The pattern is in place for
+hardware-level requirements (`"kvm"`, `"docker"`, `"gpu:nvidia"`,
+`"network:egress"`). This proposal extends it to **permission-shaped
+tokens** and wires the check into `Benchmark._setup` at task-selection
+time, so incompatible tasks are **declined fast** with a clear reason
+instead of failing silently.
+
+## Proposal
+
+Three small additions, all on top of existing types:
+
+### 1. Standard permission token vocabulary
+
+Add to `cube.resource.InfraConfig.capabilities` docstring (the
+authoritative token list):
+
+| Token | Meaning |
+|---|---|
+| `"container:root"` | Container processes run as uid 0 |
+| `"container:apt"` | `apt-get install` works (implies root + Debian-mirror egress) |
+| `"container:privileged-ports"` | Process can `bind()` ports <1024 |
+| `"container:systemd"` | `systemctl` / `service` work |
+
+These are *additional* to the existing vocabulary (`"kvm"`, `"docker"`,
+`"gpu:nvidia"`, `"network:egress"`). Adding a token is non-breaking:
+infras default to absence; only infras that explicitly claim a token
+satisfy a task that requires it.
+
+### 2. `ContainerConfig.requirements()`
+
+Add a typed `requires` field to `ContainerConfig`, mirroring how
+`VMResourceConfig.requires_kvm: bool` projects into `requirements() ->
+{"kvm"}`:
+
+```python
+class ContainerConfig(TypedBaseModel):
+    image: str
+    ram_gb: float = 4.0
+    cpu_cores: float = 2.0
+    gpu: bool = False
+    disk_gb: float = 10.0
+    ports: list[int] | None = None
+    requires: set[str] = Field(default_factory=set)   # NEW
+
+    def requirements(self) -> set[str]:
+        """Permission tokens this container needs. Composes with the gpu/kvm
+        booleans already on this class; cubes can also set free-form tokens
+        via `requires`."""
+        out = set(self.requires)
+        if self.gpu:
+            out.add("gpu:nvidia")
+        return out
+```
+
+This is the *task-level* projection: `TaskMetadata.container_config.requirements()`
+becomes the canonical answer to "what does this task need from its infra".
+
+### 3. Benchmark `_setup` task filter
+
+The base `Benchmark._setup(infra)` iterates declared tasks and partitions
+them:
+
+```python
+for task_id, task_meta in self.tasks.items():
+    cc = task_meta.container_config
+    if cc is None:
+        runnable.append(task_id)
+        continue
+    missing = cc.requirements() - infra.capabilities()
+    if missing:
+        skipped.append((task_id, sorted(missing)))
+    else:
+        runnable.append(task_id)
+```
+
+Two modes (controlled by `BenchmarkConfig.on_incompatible_task: Literal["skip", "raise"] = "skip"`):
+
+- **`"skip"`** (default) — incompatible tasks are recorded in
+  `BenchmarkSummary.skipped_tasks: list[SkippedTask]`. Accuracy is
+  reported over `len(runnable)` tasks, not over `len(all_tasks)`, with
+  `n_skipped` and the reason set surfaced in summary output. The
+  experiment continues; cross-infra comparisons of the *attempted*
+  task overlap remain meaningful.
+- **`"raise"`** — first incompatibility raises `IncompatibleTaskError`
+  at setup, before any episode runs. For users who want strict
+  same-task comparisons.
+
+`BenchmarkConfig` may opt to expose a compatibility preview without
+launching anything:
+
+```python
+@classmethod
+def compatibility_report(cls, infra: InfraConfig) -> CompatibilityReport: ...
+```
+
+Returns a structured report (count runnable / skipped, distribution of
+missing tokens) so tooling (`cube list --infra=toolkit`) can show
+"tbench2: 84/89 runnable on toolkit; 5 need `container:root`" without
+spinning up containers.
+
+## Migration impact
+
+Backward compatibility is the default:
+
+- Existing `ContainerConfig` instances default to `requires = set()`. No
+  task gets newly gated by this PR alone.
+- Existing `InfraConfig.capabilities()` implementations don't declare
+  the new tokens. As long as no task requires them, nothing changes.
+- Behaviour change happens **only** when a cube starts declaring
+  `container:root` (or similar) AND a paired infra-side PR teaches
+  root-capable infras to publish the token.
+
+Recommended rollout order (handled in follow-up PRs, **not** this RFC):
+
+1. Land this RFC (vocabulary + type extensions + filter behaviour).
+2. cube-resources side: `LocalInfraConfig`, `DaytonaInfraConfig`,
+   `AWSInfraConfig`, `AzureInfraConfig` publish
+   `"container:root", "container:apt", "container:privileged-ports"`
+   (root-capable infras). `ToolkitInfraConfig` publishes none of these.
+3. cube-harness side: `terminalbench2-cube` annotates the ~5 root-required
+   tasks via `container_config.requires = {"container:root", "container:apt"}`.
+4. Tooling: `cube list` and CI dashboards display the compatibility matrix.
+
+After (3), tbench2 on toolkit declines 5 tasks fast with reason, scores
+the rest, and reports `0.X over 84 tasks attempted` instead of `0.17 over
+all 89`. The metric becomes legible.
+
+## Alternatives considered
+
+- **Mark the whole benchmark as root-required, not per task.** Rejected:
+  too coarse for tbench2 (84 of 89 tasks are fine non-root). Forces a
+  binary cube/infra compatibility that hides the runnable subset.
+- **Encode requirements in the image** (e.g., `LABEL cube.requires=root`).
+  Rejected: image-side is a foreign system to cube-standard; couples
+  the requirement-declaration cadence to image rebuilds. Python-side
+  is the configuration (per the constitution, Pillar II).
+- **Boolean fields per requirement** (`requires_root: bool`,
+  `requires_apt: bool`, …). Rejected: doesn't grow gracefully. The
+  existing `set[str]` token vocabulary already proved this point — new
+  capabilities arrive without breaking older serialisations.
+- **Tool-layer wrapping (the simulate-non-root flag for fairness
+  benchmarking).** Adjacent but orthogonal — covered by a separate
+  proposal once this contract lands.
+
+## Open questions
+
+1. Where do the tokens *live*? Two options:
+   (a) free-form strings, documented in `resource/spec.md`. Cheap.
+   (b) `Literal` type or `Enum`. Stronger typing but every new token
+   becomes a contract change. **Lean toward (a)** for v1; can promote
+   to `Literal` later without breaking existing declarations.
+2. Should `Benchmark._setup` distinguish `infra is None` (debug-run, no
+   container launches) from compatibility check? Probably yes — when
+   `infra is None`, skip the filter (no enforcement makes sense without
+   a target infra to compare against).
+3. Should the skipped-tasks summary include a hint at which infras
+   *would* serve them (`"these tasks need container:root; available
+   on: daytona, aws, azure, local"`)? Useful but requires the framework
+   to know about other infras at setup time. Defer to tooling.

--- a/openspec/changes/task-permission-requirements/proposal.md
+++ b/openspec/changes/task-permission-requirements/proposal.md
@@ -43,11 +43,8 @@ already owns a `ContainerConfig` (tbench2: 89 tasks, 89 distinct images):
 class ContainerConfig(TypedBaseModel):
     ...
     requires: set[str] = Field(default_factory=set)
-    def requirements(self) -> set[str]:
-        out = set(self.requires)
-        if self.gpu:
-            out.add("gpu:nvidia")
-        return out
+    """Capability tokens this task's container needs, e.g. {"container:root"}.
+    Empty (default) = runs on any infra."""
 ```
 
 The blanket "all of tbench2 needs root" case is handled by the
@@ -62,7 +59,7 @@ build); the infra answers one task at a time, reusing `capabilities()`:
 class InfraConfig(TypedBaseModel, ABC):
     ...
     def can_serve_task(self, container_config: ContainerConfig) -> bool:
-        return container_config.requirements().issubset(self.capabilities())
+        return container_config.requires.issubset(self.capabilities())
 ```
 
 The harness loops this over tasks; "is the whole benchmark incompatible?"

--- a/openspec/changes/task-permission-requirements/proposal.md
+++ b/openspec/changes/task-permission-requirements/proposal.md
@@ -49,14 +49,24 @@ gates at `Benchmark.setup` time with a clear three-mode policy.
 
 ### 1. Permission token vocabulary (additive)
 
-Add to the `InfraConfig.capabilities()` documented vocabulary:
+Add one token to the `InfraConfig.capabilities()` documented vocabulary:
 
 | Token | Meaning |
 |---|---|
 | `container:root` | Container processes run as uid 0 |
-| `container:apt` | `apt-get install` works (implies root + Debian-mirror egress) |
-| `container:privileged-ports` | A process may `bind()` ports <1024 |
-| `container:systemd` | `systemctl` / `service` work |
+
+A single `container:root` token is deliberate. In practice the
+finer-grained needs — `apt-get install`, writing to `/etc` and `/var`,
+binding ports <1024, `systemctl` — are **all root-gated**, and they
+correlate near-perfectly on both sides: an infra either grants root (and
+thus all of them) or it doesn't (Daytona/local/AWS/Azure run as root;
+EAI Toolkit forces uid 13011 and so denies the whole set). Splitting into
+`container:apt` / `container:systemd` / `container:privileged-ports`
+would be speculative granularity with no current consumer that needs the
+distinction. The token vocabulary is open (`set[str]`), so a future infra
+that offers a *partial* root surface — e.g. rootless Podman with
+`CAP_NET_BIND_SERVICE` but no apt — can introduce a finer token then,
+without breaking anything.
 
 Adding a token is non-breaking: infras default to *not* publishing it;
 benchmarks/tasks default to *not* requiring it.
@@ -83,7 +93,7 @@ class BenchmarkConfig(TypedBaseModel, ABC):
 # cubes/terminalbench2-cube
 class TerminalBench2BenchmarkConfig(BenchmarkConfig):
     def requirements(self) -> set[str]:
-        return {"container:root", "container:apt"}
+        return {"container:root"}
 ```
 
 A per-task override stays available for genuinely heterogeneous
@@ -116,7 +126,7 @@ Resolved at experiment-setup time (default `"raise"`):
   If non-empty, **raise `IncompatibleInfraError` immediately, before any
   episode is created**. tbench2 on toolkit stops at setup with:
   `"ToolkitInfraConfig cannot run terminalbench2-cube: missing
-  {container:apt, container:root}."` No episodes, no retries, no spend.
+  {container:root}."` No episodes, no retries, no spend.
 
 - **`"skip"`**. Run the compatible subset. A task whose effective
   requirement isn't met is **not launched**; its episode is recorded with
@@ -175,7 +185,7 @@ def compatibility_report(cls, infra: InfraConfig) -> CompatibilityReport: ...
 
 Reads metadata only (no container launches) so `cube list --infra=toolkit`
 and CI gates can show "tbench2: incompatible on toolkit (needs
-container:root, container:apt)" before anyone spends a dollar.
+container:root)" before anyone spends a dollar.
 
 ## Migration impact
 
@@ -194,11 +204,10 @@ Recommended rollout (follow-up PRs, not this RFC):
 
 1. Land this RFC (vocabulary + types + gate behaviour + status mapping).
 2. cube-resources: `LocalInfraConfig`, `DaytonaInfraConfig`, `AWSInfraConfig`,
-   `AzureInfraConfig` publish `container:root`, `container:apt`,
-   `container:privileged-ports`. `ToolkitInfraConfig` publishes none of these.
+   `AzureInfraConfig` publish `container:root`. `ToolkitInfraConfig` does not.
 3. cube-harness: `terminalbench2-cube` declares
-   `requirements() = {"container:root", "container:apt"}`. tbench2 on
-   toolkit now fails fast at setup with a clear message.
+   `requirements() = {"container:root"}`. tbench2 on toolkit now fails fast
+   at setup with a clear message.
 4. cube-harness: wire the `on_incompatible` knob into `Experiment` / `run_*`
    and the episode-status `INVALID_CONFIG` mapping for skip mode.
 5. Tooling: `cube list --infra=<name>` and CI dashboards display the

--- a/openspec/changes/task-permission-requirements/proposal.md
+++ b/openspec/changes/task-permission-requirements/proposal.md
@@ -1,138 +1,50 @@
 # Task permission requirements + infra capability handshake
 
-**Status:** Proposed
-**Date:** 2026-05-21
-**Scope:** `cube.container.ContainerConfig`, `cube.resource.InfraConfig`,
-`cube.benchmark.Benchmark.setup`
+**Status:** Implemented
+**Date:** 2026-05-22
+**Scope:** `cube.resource` (`ResourceConfig`, `InfraConfig`), `cube.benchmark` (`make`),
+the `cube-resources` infra packages.
 **Targets:** `dev`
-**Related:** cube-harness session `2026-05-20_tbench2-infra-model-matrix`,
-finding F7 (toolkit's non-root user vs tbench2's apt-installing tasks).
-
----
+**Related:** cube-harness session `2026-05-20_tbench2-infra-model-matrix`, finding F7
+(EAI Toolkit's non-root uid vs tbench2's apt-installing tasks). Builds on the
+`ContainerConfig` → `ResourceConfig` unification (#201).
 
 ## Problem
 
-Some cube tasks need infra permissions not every `InfraConfig` provides —
-e.g. tbench2 tasks `apt-get install` packages and write to `/etc`, `/var`,
-which needs a **root** container; EAI Toolkit forces **uid 13011** by
-cluster policy. Today this mismatch surfaces as **silent low scores** (the
-agent tries `apt-get`, gets `Permission denied`, fails the task at reward 0)
-and can even burn the auto-retry budget re-running episodes that fail
-identically every time.
+Some tasks need infra permissions not every infra provides — tbench2 tasks `apt-get install`
+and write to `/etc`, `/var` (need a **root** container); EAI Toolkit pins **uid 13011** by
+cluster policy. Today the mismatch surfaces as **silent reward-0 failures** and can burn the
+auto-retry budget re-running episodes that fail identically.
 
-The framework already has the matching mechanism: `InfraConfig.capabilities()
--> set[str]`, `ResourceConfig.requirements() -> set[str]`, and
-`InfraConfig.can_serve(resource)` doing the set-inclusion test (tokens in use:
-`kvm`, `docker`, `gpu:nvidia`, `network:egress`). This proposal extends it
-with a permission token, a per-task compatibility check, and an
-infra-owned policy for handling mismatches.
+## Design (implemented)
 
-## Design
+The framework already has the handshake — `ResourceConfig.requirements()` vs
+`InfraConfig.capabilities()`, matched by `InfraConfig.can_serve(resource)`. Since the
+unification a task's `container_config` **is** a `ResourceConfig`, so the existing
+**per-resource `can_serve` is the unit** — no new `can_serve_task`, no benchmark aggregate.
 
-**1. One token.** Add `container:root` to the `capabilities()` vocabulary
-("container processes run as uid 0"). A single token is deliberate: `apt`,
-writes to `/etc`/`/var`, ports <1024, and `systemctl` are all root-gated and
-correlate with "is the container root?" on both sides. The vocabulary stays
-open (`set[str]`) so a finer token can be added later if a partial-root
-infra ever needs it.
+1. **Token.** Add `container:root` to the capability vocabulary (uid 0). Root-capable infras
+   (Local, AWS, Azure, Daytona, Modal) publish it; Toolkit deliberately does not.
+2. **Declaration.** `ResourceConfig.requires: set[str]` (base field), folded into
+   `requirements()` by each subclass via `super().requirements()`. A task declares
+   `requires={"container:root"}`.
+3. **Policy.** `InfraConfig.on_incompatible: Literal["raise","skip","force"] = "raise"`.
+4. **Gate.** `BenchmarkConfig.make()` runs `can_serve` over each task's `container_config`
+   and the benchmark's declared `resources` **before provisioning**:
+   `"raise"` → `IncompatibleInfraError` (pre-episode, no spend); `"skip"` → narrow the task
+   view to the compatible subset (harness records the dropped ones as the existing terminal,
+   non-retriable `INVALID_CONFIG`); `"force"` → run everything. Metadata-only and launch-free.
 
-**2. Per-task `ContainerConfig.requires` (source of truth).** Each task
-already owns a `ContainerConfig` (tbench2: 89 tasks, 89 distinct images):
+## Why this shape
 
-```python
-class ContainerConfig(TypedBaseModel):
-    ...
-    requires: set[str] = Field(default_factory=set)
-    """Capability tokens this task's container needs, e.g. {"container:root"}.
-    Empty (default) = runs on any infra."""
-```
+- **Per-resource `can_serve`** (not a `can_serve_task`, not a benchmark-level aggregate) is
+  the overridable unit. It composes with *composite* resources and with a future **meta-infra**
+  that overrides `can_serve` to delegate per-resource to children — the gate is forward-
+  compatible by construction.
+- **`requires` on the base `ResourceConfig`** generalizes the escape hatch to any resource/token.
 
-The blanket "all of tbench2 needs root" case is handled by the
-metadata-generation script (`create_task_metadata.py`) stamping
-`requires={"container:root"}` on every task — no per-task triage.
-Heterogeneous benchmarks set `requires` per task.
+## Out of scope / follow-ups
 
-**3. Per-task bool from the infra.** No benchmark-level aggregate (awkward to
-build); the infra answers one task at a time, reusing `capabilities()`:
-
-```python
-class InfraConfig(TypedBaseModel, ABC):
-    ...
-    def can_serve_task(self, container_config: ContainerConfig) -> bool:
-        return container_config.requires.issubset(self.capabilities())
-```
-
-The harness loops this over tasks; "is the whole benchmark incompatible?"
-falls out of the loop — nothing to keep in sync.
-
-**4. Policy flag on `InfraConfig`.** The infra owns how to handle a mismatch:
-
-```python
-OnIncompatible = Literal["raise", "skip", "force"]
-
-class InfraConfig(TypedBaseModel, ABC):
-    on_incompatible: OnIncompatible = "raise"
-```
-
-`Benchmark.setup(infra)` reads it (no new setup parameter):
-
-- **`"raise"`** (default) — if **any** task is incompatible, raise
-  `IncompatibleInfraError` at setup, **before any episode is created**. No
-  spend, no retries. tbench2 on toolkit refuses outright.
-- **`"skip"`** — run the compatible subset; each incompatible task's episode
-  is recorded `INVALID_CONFIG` (§5) and excluded from the accuracy
-  denominator (`n_skipped`).
-- **`"force"`** — launch everything anyway. The escape hatch for probing
-  whether an infra/image change has obviated a stale requirement.
-
-You pick the policy where you pick the infra:
-`ToolkitInfraConfig(on_incompatible="skip")`.
-
-**5. Status reuse — no new status.** cube-harness already has
-`INVALID_CONFIG`: terminal and **non-retriable** (`RETRIABLE_STATUSES =
-{FAILED, CANCELLED, STALE}` excludes it) — documented as "the identical
-request will fail identically on retry". An incompatible task is exactly
-that. `"raise"` aborts at setup (no episode). `"skip"` writes
-`INVALID_CONFIG`, which the auto-retry loop leaves alone by construction. A
-dedicated `INCOMPATIBLE` status is an optional future refinement for
-reporting, not required for correct retry semantics.
-
-## Migration
-
-Backward-compatible by default: `ContainerConfig.requires` defaults to
-`set()` (so `can_serve_task` is always True), and `on_incompatible` defaults
-to `"raise"` but is a no-op until a task declares `requires`. Behaviour
-changes only when a cube stamps `requires` AND a paired infra-side PR
-publishes the token. Rollout (follow-up PRs, not this RFC):
-
-1. This RFC: token + `ContainerConfig.requires` + `InfraConfig.can_serve_task`
-   + `on_incompatible` + the `setup` loop + `INVALID_CONFIG` mapping.
-2. cube-resources: root-capable infras (`Local`, `Daytona`, `AWS`, `Azure`)
-   publish `container:root`; `Toolkit` does not.
-3. cube-harness: tbench2 codegen stamps `requires={"container:root"}`.
-4. cube-harness: read `infra.on_incompatible` in setup/launch; map skip-mode
-   episodes to `INVALID_CONFIG`.
-
-## Alternatives considered
-
-- **Benchmark-level aggregate requirement** (a declared `requirements()`
-  field, or a derived `aggregate_requirements()`). Rejected: a declared
-  field duplicates the per-task `ContainerConfig` and drifts; an aggregate is
-  awkward to build (materialise/union every task resource). The per-task
-  `can_serve_task` bool + harness loop needs neither.
-- **A new `INCOMPATIBLE` episode status as the v1 mechanism.** Rejected for
-  v1: `INVALID_CONFIG` already has the exact non-retriable-terminal
-  semantics. Clean later refinement, not a prerequisite.
-- **Encode requirements in the Docker image** (`LABEL cube.requires=root`).
-  Rejected: foreign system; couples requirement cadence to image rebuilds;
-  violates "Python is the configuration".
-
-## Open questions
-
-1. Infra field only, or also a per-run override (`Experiment` field that
-   wins over the infra default)? Lean: infra field only for v1.
-2. `can_serve_task` takes a `ContainerConfig` (cube.container) but lives on
-   `InfraConfig` (cube.resource) — confirm import direction is clean, or make
-   it a free function / `ContainerConfig.is_served_by(infra)`. Implementation
-   detail; doesn't change the design.
-3. Confirm `INVALID_CONFIG` reuse is acceptable vs. adding `INCOMPATIBLE` now.
+- **cube-harness:** tbench2 (and other root-needing cubes) codegen stamps
+  `requires={"container:root"}`; harness maps skip-mode tasks to `INVALID_CONFIG`.
+- **Meta-infra + composite resources:** a separate effort. This gate already supports it.

--- a/openspec/changes/task-permission-requirements/proposal.md
+++ b/openspec/changes/task-permission-requirements/proposal.md
@@ -71,33 +71,16 @@ without breaking anything.
 Adding a token is non-breaking: infras default to *not* publishing it;
 benchmarks/tasks default to *not* requiring it.
 
-### 2. Requirements at the benchmark level (primary) and task level (optional)
+### 2. Requirements ride on the per-task resource; the benchmark exposes a derived aggregate
 
-The **main expected use case** is blanket: "all of tbench2 needs root".
-Investigating which individual tasks truly need root is too costly and
-fragile, so a benchmark declares its requirement once:
-
-```python
-class BenchmarkConfig(TypedBaseModel, ABC):
-    ...
-    def requirements(self) -> set[str]:
-        """Permission tokens EVERY task in this benchmark needs from its
-        infra. Default empty = runs anywhere. Cubes with heterogeneous
-        needs may instead declare per-task via ContainerConfig.requires
-        and leave this empty; the effective requirement for a task is the
-        union of the two."""
-        return set()
-```
-
-```python
-# cubes/terminalbench2-cube
-class TerminalBench2BenchmarkConfig(BenchmarkConfig):
-    def requirements(self) -> set[str]:
-        return {"container:root"}
-```
-
-A per-task override stays available for genuinely heterogeneous
-benchmarks (kept from rev 1):
+Requirements live where the resource lives — on each task's
+`ContainerConfig` — and flow through the **existing** resource machinery.
+Each tbench2 task already instantiates its own `ContainerConfig`
+(89 tasks, 89 distinct images, no shared template) which `launch_task_container`
+turns into a per-task `DockerServiceConfig`. We thread `requires` through
+that build so `DockerServiceConfig.requirements()` returns the tokens and
+the **already-existing** `InfraConfig.can_serve(resource)` answers
+per-task compatibility — no new check primitive:
 
 ```python
 class ContainerConfig(TypedBaseModel):
@@ -110,8 +93,45 @@ class ContainerConfig(TypedBaseModel):
         return out
 ```
 
-Effective requirement for a task = `benchmark.requirements() ∪
-task.container_config.requirements()`.
+```python
+# cube.task_infra.launch_task_container — thread the tokens into the resource
+resource = DockerServiceConfig(
+    name=name, scope="task", docker_images=[image],
+    requires=container_config.requirements(),   # NEW: was implicitly empty
+    launch_script=build_docker_run_script(...),
+)
+```
+
+**Blanket use case stays cheap.** "All of tbench2 needs root" is achieved
+not by per-task investigation but by the metadata-generation script
+(`scripts/create_task_metadata.py`) stamping `requires={"container:root"}`
+on every task's `ContainerConfig` at generation time. One line in the
+codegen, all 89 tasks covered, zero manual triage. Heterogeneous benchmarks
+that genuinely differ per task set `requires` per task instead.
+
+**Benchmark-level compatibility is derived, not separately declared.** A
+benchmark exposes an introspection helper that unions the per-task
+requirements so an infra can answer "is the *whole* benchmark
+incompatible?" without launching anything:
+
+```python
+class BenchmarkConfig(TypedBaseModel, ABC):
+    ...
+    def aggregate_requirements(self) -> set[str]:
+        """Union of every task's container_config.requirements(). Reads
+        task metadata only (no archive load, no container launch). The
+        infra introspects this at setup to decide whole-benchmark
+        compatibility. Derived — there is no separately-declared
+        benchmark-level requirement to drift out of sync with the tasks."""
+        out: set[str] = set()
+        for meta in self.tasks_metadata().values():
+            if meta.container_config is not None:
+                out |= meta.container_config.requirements()
+        return out
+```
+
+For tbench2 this returns `{"container:root"}` (every task stamped); for a
+benchmark with no root-needing tasks it returns `set()`.
 
 ### 3. The gate: `Benchmark.setup(infra, on_incompatible=...)` — three modes
 
@@ -121,31 +141,33 @@ OnIncompatible = Literal["raise", "skip", "force"]
 
 Resolved at experiment-setup time (default `"raise"`):
 
-- **`"raise"`** (default — the main use case). At `setup`, compute the
-  benchmark-level `missing = benchmark.requirements() - infra.capabilities()`.
+- **`"raise"`** (default). At `setup`, introspect the per-task resources
+  via `aggregate_requirements()` and compute
+  `missing = benchmark.aggregate_requirements() - infra.capabilities()`.
   If non-empty, **raise `IncompatibleInfraError` immediately, before any
   episode is created**. tbench2 on toolkit stops at setup with:
   `"ToolkitInfraConfig cannot run terminalbench2-cube: missing
   {container:root}."` No episodes, no retries, no spend.
 
-- **`"skip"`**. Run the compatible subset. A task whose effective
-  requirement isn't met is **not launched**; its episode is recorded with
-  a terminal, **non-retriable** status (see §4) and excluded from the
-  accuracy denominator. Reported as `n_skipped` in the summary. Useful
-  when a benchmark is heterogeneous (per-task requirements) and you want
-  the runnable overlap.
+- **`"skip"`**. Run the compatible subset. Each task is checked
+  individually via its own resource (`infra.can_serve(task_resource)`); a
+  task whose requirement isn't met is **not launched**, its episode is
+  recorded with a terminal, **non-retriable** status (§4), and it is
+  excluded from the accuracy denominator. Reported as `n_skipped`. This is
+  where per-task granularity earns its keep: a heterogeneous benchmark runs
+  its root-free tasks and skips the rest.
 
-- **`"force"`** (try-anyway override). Ignore the check entirely; launch
-  every task regardless. The escape hatch for probing whether a new image
-  policy / infra change has obviated a stale requirement — e.g. "did
-  toolkit start allowing root? run tbench2 with `force` and see." Logs a
-  warning per forced task so the override is visible in the trace.
+- **`"force"`** (try-anyway override). Skip the gate entirely; launch every
+  task regardless. The escape hatch for probing whether a new image policy /
+  infra change has obviated a stale requirement — "did toolkit start
+  allowing root? run with `force` and see." Logs a warning so the override
+  is visible in the trace.
 
 Where the mode lives: a field on the experiment-run path (cube-harness
 `Experiment` / `run_*`), forwarded into `Benchmark.setup`. cube-standard
 defines the enum + the `setup` parameter; cube-harness wires the CLI/recipe
-knob. A given infra MAY also pin a default (e.g. `ToolkitInfraConfig` could
-default callers to `"raise"`), but the per-run setting wins.
+knob. A given infra MAY also pin a stricter default, but the per-run setting
+wins.
 
 ### 4. Status mapping — reuse the existing non-retriable terminal bucket
 
@@ -176,14 +198,15 @@ cube-harness — modest but non-trivial. Recommendation: **ship v1 reusing
 distinction proves valuable. Either way, the retry semantics are correct
 from day one because both are non-retriable terminal.
 
-### 5. Static compatibility preview (unchanged from rev 1)
+### 5. Static compatibility preview
 
 ```python
 @classmethod
 def compatibility_report(cls, infra: InfraConfig) -> CompatibilityReport: ...
 ```
 
-Reads metadata only (no container launches) so `cube list --infra=toolkit`
+Reads metadata only (no container launches) — built on the same
+`aggregate_requirements()` introspection — so `cube list --infra=toolkit`
 and CI gates can show "tbench2: incompatible on toolkit (needs
 container:root)" before anyone spends a dollar.
 
@@ -191,23 +214,27 @@ container:root)" before anyone spends a dollar.
 
 Backward compatibility is the default:
 
-- `BenchmarkConfig.requirements()` defaults to `set()`; `ContainerConfig.requires`
-  defaults to `set()`. No benchmark is newly gated by this PR alone.
+- `ContainerConfig.requires` defaults to `set()`, so
+  `aggregate_requirements()` returns `set()` for every existing cube. No
+  benchmark is newly gated by this PR alone.
 - Existing `InfraConfig.capabilities()` implementations are unchanged.
-- `Benchmark.setup` gains an `on_incompatible="raise"` parameter with a
-  default that is a **no-op when `requirements()` is empty** — so existing
-  cubes see no behaviour change.
+- `Benchmark.setup` gains an `on_incompatible="raise"` parameter that is a
+  **no-op when `aggregate_requirements()` is empty** — existing cubes see
+  no behaviour change.
+- `DockerServiceConfig` gains a `requires` field defaulting to `set()`;
+  the `requirements()` it already exposes simply returns it.
 
-Behaviour changes only when a cube declares `requirements()` AND a paired
-infra-side PR teaches root-capable infras to publish the matching tokens.
+Behaviour changes only when a cube stamps `ContainerConfig.requires` AND a
+paired infra-side PR teaches root-capable infras to publish the token.
 Recommended rollout (follow-up PRs, not this RFC):
 
-1. Land this RFC (vocabulary + types + gate behaviour + status mapping).
+1. Land this RFC (token + `ContainerConfig.requires` + `DockerServiceConfig`
+   threading + `aggregate_requirements()` + `setup` gate + status mapping).
 2. cube-resources: `LocalInfraConfig`, `DaytonaInfraConfig`, `AWSInfraConfig`,
    `AzureInfraConfig` publish `container:root`. `ToolkitInfraConfig` does not.
-3. cube-harness: `terminalbench2-cube` declares
-   `requirements() = {"container:root"}`. tbench2 on toolkit now fails fast
-   at setup with a clear message.
+3. cube-harness: `terminalbench2-cube`'s `scripts/create_task_metadata.py`
+   stamps `requires={"container:root"}` on every task's `ContainerConfig`.
+   tbench2 on toolkit now fails fast at setup with a clear message.
 4. cube-harness: wire the `on_incompatible` knob into `Experiment` / `run_*`
    and the episode-status `INVALID_CONFIG` mapping for skip mode.
 5. Tooling: `cube list --infra=<name>` and CI dashboards display the
@@ -215,10 +242,13 @@ Recommended rollout (follow-up PRs, not this RFC):
 
 ## Alternatives considered
 
-- **Per-task-only requirements (rev 1's primary framing).** Rejected as the
-  *primary* mechanism — the main use case is blanket-per-benchmark, and
-  per-task investigation is too costly. Kept as an optional override for
-  heterogeneous benchmarks.
+- **A separately-declared benchmark-level `requirements()` field (rev 2).**
+  Rejected: it duplicates information that already lives on the per-task
+  `ContainerConfig` and can drift out of sync with the tasks. The benchmark
+  view is *derived* (`aggregate_requirements()`) from the per-task
+  resources instead — single source of truth, and the infra introspects
+  the real per-task resources. The blanket "all tasks need root" case is
+  handled by the codegen stamping each task, not by a second declaration.
 - **A brand-new `INCOMPATIBLE` episode status as the v1 mechanism.**
   Rejected for v1: `INVALID_CONFIG` already carries the exact
   non-retriable-terminal semantics. New status is a clean later refinement,

--- a/openspec/changes/task-permission-requirements/proposal.md
+++ b/openspec/changes/task-permission-requirements/proposal.md
@@ -1,210 +1,235 @@
-# Task permission requirements + infra capability handshake (extension)
+# Benchmark/task permission requirements + infra capability handshake
 
-**Status:** Proposed
+**Status:** Proposed (rev 2 — incorporates review feedback on status reuse,
+benchmark-level requirements, and the three-mode policy)
 **Date:** 2026-05-21
-**Scope:** `cube.container.ContainerConfig`, `cube.resource.InfraConfig`,
-`cube.benchmark.Benchmark._setup` (filter behaviour)
+**Scope:** `cube.container.ContainerConfig`, `cube.benchmark.BenchmarkConfig`,
+`cube.resource.InfraConfig`, `cube.benchmark.Benchmark.setup` (gate behaviour)
 **Targets:** `dev`
 **Related:** Surfaced by cube-harness session `2026-05-20_tbench2-infra-model-matrix`
-([REPORT](https://github.com/The-AI-Alliance/cube-harness/blob/dev/...))
 finding F7 ("toolkit's non-root user vs tbench2's apt-installing tasks").
+cube-harness consumes via `Benchmark.setup` + the episode-status taxonomy.
 
 ---
 
 ## Problem
 
-Some cube tasks need infra permissions that not every `InfraConfig`
+Some cube benchmarks need infra permissions that not every `InfraConfig`
 provides:
 
-- `terminalbench2-cube/nginx-request-logging` and `install-windows-3.11`
-  ask the agent to `apt-get install` packages and write to `/etc/`,
-  `/var/log/` — only achievable inside a container running as **root**.
+- `terminalbench2-cube` tasks ask the agent to `apt-get install` packages
+  and write to `/etc/`, `/var/log/` — achievable only inside a container
+  running as **root**.
 - `cube-infra-toolkit` (EAI Toolkit) hard-enforces **uid 13011** in every
   container by cluster policy; `apt-get` is unreachable.
 
-Today this mismatch surfaces as **silent low scores**: the agent runs,
+Today this mismatch surfaces as **silent low scores**. The agent runs,
 tries `apt-get`, gets `Permission denied`, eventually emits `final_step`
-with a wrong solution, the evaluator scores reward=0. The cube/infra
-combination is *partially incompatible* but the contract has no way to
-say so. A user looking at `tbench2 on toolkit ⇒ 0.17` cannot tell
-whether the gap is a model-quality issue, a cube-installation issue, or
-a fundamental infra mismatch.
+with a wrong solution, the evaluator scores reward=0. A user looking at
+`tbench2 on toolkit ⇒ 0.17` cannot tell whether that's a model-quality
+issue, a cube-installation issue, or a fundamental infra mismatch. Worse,
+under cube-harness's auto-retry loop these episodes can be classified
+`FAILED` (retriable) and **burn the retry budget re-running an episode
+that will fail identically every time**.
 
-Empirical evidence from the surfacing session:
+Empirical evidence (haiku × 25 tasks): daytona 0.39 vs toolkit 0.17; the
+gap is mostly silent partial failure, not model capability — stronger
+models (sonnet) lift daytona but not toolkit.
 
-| | daytona (root) | toolkit (uid 13011) |
-|---|---|---|
-| haiku × 25 tasks | 9/23 = **0.39** | 4/23 = **0.17** |
-| sonnet × 12 tasks | 3/6 = **0.50** | 1/9 = **0.11** |
+The framework **already has** the matching mechanism. `InfraConfig` exposes
+`capabilities() -> set[str]`; `ResourceConfig` exposes
+`requirements() -> set[str]`; `InfraConfig.can_serve(resource)` does
+`requirements.issubset(capabilities)`. The token vocabulary in use today is
+hardware-shaped (`kvm`, `docker`, `gpu:nvidia`, `network:egress`). This
+proposal (a) extends the vocabulary with permission tokens, (b) lets a
+**benchmark** (not just a per-task container) declare requirements, and (c)
+gates at `Benchmark.setup` time with a clear three-mode policy.
 
-Stronger model lifts daytona but does not lift toolkit — because the
-toolkit-impossible subset is impossible regardless of reasoning.
+## Design
 
-Heuristic classification of all 89 tbench2 tasks against root-needing
-operations (apt, `/etc/*`, `/var/*`, ports <1024, `systemctl`): only
-**~5–7 tasks** truly require root; the remaining 82+ would run fine on
-non-root infras if the framework gated only the incompatible tasks
-instead of silently mis-scoring them.
+### 1. Permission token vocabulary (additive)
 
-The framework **already has** the right mechanism. `InfraConfig` exposes
-`capabilities() -> set[str]`. `ResourceConfig` exposes
-`requirements() -> set[str]`. `InfraConfig.can_serve(resource)` does
-`requirements.issubset(capabilities)`. The pattern is in place for
-hardware-level requirements (`"kvm"`, `"docker"`, `"gpu:nvidia"`,
-`"network:egress"`). This proposal extends it to **permission-shaped
-tokens** and wires the check into `Benchmark._setup` at task-selection
-time, so incompatible tasks are **declined fast** with a clear reason
-instead of failing silently.
-
-## Proposal
-
-Three small additions, all on top of existing types:
-
-### 1. Standard permission token vocabulary
-
-Add to `cube.resource.InfraConfig.capabilities` docstring (the
-authoritative token list):
+Add to the `InfraConfig.capabilities()` documented vocabulary:
 
 | Token | Meaning |
 |---|---|
-| `"container:root"` | Container processes run as uid 0 |
-| `"container:apt"` | `apt-get install` works (implies root + Debian-mirror egress) |
-| `"container:privileged-ports"` | Process can `bind()` ports <1024 |
-| `"container:systemd"` | `systemctl` / `service` work |
+| `container:root` | Container processes run as uid 0 |
+| `container:apt` | `apt-get install` works (implies root + Debian-mirror egress) |
+| `container:privileged-ports` | A process may `bind()` ports <1024 |
+| `container:systemd` | `systemctl` / `service` work |
 
-These are *additional* to the existing vocabulary (`"kvm"`, `"docker"`,
-`"gpu:nvidia"`, `"network:egress"`). Adding a token is non-breaking:
-infras default to absence; only infras that explicitly claim a token
-satisfy a task that requires it.
+Adding a token is non-breaking: infras default to *not* publishing it;
+benchmarks/tasks default to *not* requiring it.
 
-### 2. `ContainerConfig.requirements()`
+### 2. Requirements at the benchmark level (primary) and task level (optional)
 
-Add a typed `requires` field to `ContainerConfig`, mirroring how
-`VMResourceConfig.requires_kvm: bool` projects into `requirements() ->
-{"kvm"}`:
+The **main expected use case** is blanket: "all of tbench2 needs root".
+Investigating which individual tasks truly need root is too costly and
+fragile, so a benchmark declares its requirement once:
+
+```python
+class BenchmarkConfig(TypedBaseModel, ABC):
+    ...
+    def requirements(self) -> set[str]:
+        """Permission tokens EVERY task in this benchmark needs from its
+        infra. Default empty = runs anywhere. Cubes with heterogeneous
+        needs may instead declare per-task via ContainerConfig.requires
+        and leave this empty; the effective requirement for a task is the
+        union of the two."""
+        return set()
+```
+
+```python
+# cubes/terminalbench2-cube
+class TerminalBench2BenchmarkConfig(BenchmarkConfig):
+    def requirements(self) -> set[str]:
+        return {"container:root", "container:apt"}
+```
+
+A per-task override stays available for genuinely heterogeneous
+benchmarks (kept from rev 1):
 
 ```python
 class ContainerConfig(TypedBaseModel):
-    image: str
-    ram_gb: float = 4.0
-    cpu_cores: float = 2.0
-    gpu: bool = False
-    disk_gb: float = 10.0
-    ports: list[int] | None = None
-    requires: set[str] = Field(default_factory=set)   # NEW
-
+    ...
+    requires: set[str] = Field(default_factory=set)
     def requirements(self) -> set[str]:
-        """Permission tokens this container needs. Composes with the gpu/kvm
-        booleans already on this class; cubes can also set free-form tokens
-        via `requires`."""
         out = set(self.requires)
         if self.gpu:
             out.add("gpu:nvidia")
         return out
 ```
 
-This is the *task-level* projection: `TaskMetadata.container_config.requirements()`
-becomes the canonical answer to "what does this task need from its infra".
+Effective requirement for a task = `benchmark.requirements() ∪
+task.container_config.requirements()`.
 
-### 3. Benchmark `_setup` task filter
-
-The base `Benchmark._setup(infra)` iterates declared tasks and partitions
-them:
+### 3. The gate: `Benchmark.setup(infra, on_incompatible=...)` — three modes
 
 ```python
-for task_id, task_meta in self.tasks.items():
-    cc = task_meta.container_config
-    if cc is None:
-        runnable.append(task_id)
-        continue
-    missing = cc.requirements() - infra.capabilities()
-    if missing:
-        skipped.append((task_id, sorted(missing)))
-    else:
-        runnable.append(task_id)
+OnIncompatible = Literal["raise", "skip", "force"]
 ```
 
-Two modes (controlled by `BenchmarkConfig.on_incompatible_task: Literal["skip", "raise"] = "skip"`):
+Resolved at experiment-setup time (default `"raise"`):
 
-- **`"skip"`** (default) — incompatible tasks are recorded in
-  `BenchmarkSummary.skipped_tasks: list[SkippedTask]`. Accuracy is
-  reported over `len(runnable)` tasks, not over `len(all_tasks)`, with
-  `n_skipped` and the reason set surfaced in summary output. The
-  experiment continues; cross-infra comparisons of the *attempted*
-  task overlap remain meaningful.
-- **`"raise"`** — first incompatibility raises `IncompatibleTaskError`
-  at setup, before any episode runs. For users who want strict
-  same-task comparisons.
+- **`"raise"`** (default — the main use case). At `setup`, compute the
+  benchmark-level `missing = benchmark.requirements() - infra.capabilities()`.
+  If non-empty, **raise `IncompatibleInfraError` immediately, before any
+  episode is created**. tbench2 on toolkit stops at setup with:
+  `"ToolkitInfraConfig cannot run terminalbench2-cube: missing
+  {container:apt, container:root}."` No episodes, no retries, no spend.
 
-`BenchmarkConfig` may opt to expose a compatibility preview without
-launching anything:
+- **`"skip"`**. Run the compatible subset. A task whose effective
+  requirement isn't met is **not launched**; its episode is recorded with
+  a terminal, **non-retriable** status (see §4) and excluded from the
+  accuracy denominator. Reported as `n_skipped` in the summary. Useful
+  when a benchmark is heterogeneous (per-task requirements) and you want
+  the runnable overlap.
+
+- **`"force"`** (try-anyway override). Ignore the check entirely; launch
+  every task regardless. The escape hatch for probing whether a new image
+  policy / infra change has obviated a stale requirement — e.g. "did
+  toolkit start allowing root? run tbench2 with `force` and see." Logs a
+  warning per forced task so the override is visible in the trace.
+
+Where the mode lives: a field on the experiment-run path (cube-harness
+`Experiment` / `run_*`), forwarded into `Benchmark.setup`. cube-standard
+defines the enum + the `setup` parameter; cube-harness wires the CLI/recipe
+knob. A given infra MAY also pin a default (e.g. `ToolkitInfraConfig` could
+default callers to `"raise"`), but the per-run setting wins.
+
+### 4. Status mapping — reuse the existing non-retriable terminal bucket
+
+**No new episode status is required.** cube-harness already has
+`INVALID_CONFIG`: a terminal, non-retriable status whose documented meaning
+is *"a permanent error… the identical request will fail identically on
+retry, so replaying only burns the retry budget."* `RETRIABLE_STATUSES =
+{FAILED, CANCELLED, STALE}` deliberately excludes it.
+
+An incompatible task is exactly that shape: it will fail identically every
+retry. So:
+
+- **`"raise"` mode**: the failure happens at `Benchmark.setup`, before
+  episodes exist. It surfaces as a **setup/system failure** in cube-harness
+  — the experiment aborts; nothing to retry.
+- **`"skip"` mode**: each skipped task's episode is written with status
+  `INVALID_CONFIG` (terminal, non-retriable). The auto-retry loop leaves it
+  alone by construction; the summary counts it under `n_skipped` /
+  `n_invalid_config` rather than `n_failed`, keeping the accuracy
+  denominator honest.
+
+A dedicated `INCOMPATIBLE` / `SKIPPED` status is an **optional future
+refinement** for cleaner dashboards (it would distinguish "infra can't
+serve" from "bad model name"). It touches the `Status` `Literal`,
+`TERMINAL_STATUSES`, `STATUS_ICONS`, and exhaustive matches in
+cube-harness — modest but non-trivial. Recommendation: **ship v1 reusing
+`INVALID_CONFIG`**; add `INCOMPATIBLE` later only if the reporting
+distinction proves valuable. Either way, the retry semantics are correct
+from day one because both are non-retriable terminal.
+
+### 5. Static compatibility preview (unchanged from rev 1)
 
 ```python
 @classmethod
 def compatibility_report(cls, infra: InfraConfig) -> CompatibilityReport: ...
 ```
 
-Returns a structured report (count runnable / skipped, distribution of
-missing tokens) so tooling (`cube list --infra=toolkit`) can show
-"tbench2: 84/89 runnable on toolkit; 5 need `container:root`" without
-spinning up containers.
+Reads metadata only (no container launches) so `cube list --infra=toolkit`
+and CI gates can show "tbench2: incompatible on toolkit (needs
+container:root, container:apt)" before anyone spends a dollar.
 
 ## Migration impact
 
 Backward compatibility is the default:
 
-- Existing `ContainerConfig` instances default to `requires = set()`. No
-  task gets newly gated by this PR alone.
-- Existing `InfraConfig.capabilities()` implementations don't declare
-  the new tokens. As long as no task requires them, nothing changes.
-- Behaviour change happens **only** when a cube starts declaring
-  `container:root` (or similar) AND a paired infra-side PR teaches
-  root-capable infras to publish the token.
+- `BenchmarkConfig.requirements()` defaults to `set()`; `ContainerConfig.requires`
+  defaults to `set()`. No benchmark is newly gated by this PR alone.
+- Existing `InfraConfig.capabilities()` implementations are unchanged.
+- `Benchmark.setup` gains an `on_incompatible="raise"` parameter with a
+  default that is a **no-op when `requirements()` is empty** — so existing
+  cubes see no behaviour change.
 
-Recommended rollout order (handled in follow-up PRs, **not** this RFC):
+Behaviour changes only when a cube declares `requirements()` AND a paired
+infra-side PR teaches root-capable infras to publish the matching tokens.
+Recommended rollout (follow-up PRs, not this RFC):
 
-1. Land this RFC (vocabulary + type extensions + filter behaviour).
-2. cube-resources side: `LocalInfraConfig`, `DaytonaInfraConfig`,
-   `AWSInfraConfig`, `AzureInfraConfig` publish
-   `"container:root", "container:apt", "container:privileged-ports"`
-   (root-capable infras). `ToolkitInfraConfig` publishes none of these.
-3. cube-harness side: `terminalbench2-cube` annotates the ~5 root-required
-   tasks via `container_config.requires = {"container:root", "container:apt"}`.
-4. Tooling: `cube list` and CI dashboards display the compatibility matrix.
-
-After (3), tbench2 on toolkit declines 5 tasks fast with reason, scores
-the rest, and reports `0.X over 84 tasks attempted` instead of `0.17 over
-all 89`. The metric becomes legible.
+1. Land this RFC (vocabulary + types + gate behaviour + status mapping).
+2. cube-resources: `LocalInfraConfig`, `DaytonaInfraConfig`, `AWSInfraConfig`,
+   `AzureInfraConfig` publish `container:root`, `container:apt`,
+   `container:privileged-ports`. `ToolkitInfraConfig` publishes none of these.
+3. cube-harness: `terminalbench2-cube` declares
+   `requirements() = {"container:root", "container:apt"}`. tbench2 on
+   toolkit now fails fast at setup with a clear message.
+4. cube-harness: wire the `on_incompatible` knob into `Experiment` / `run_*`
+   and the episode-status `INVALID_CONFIG` mapping for skip mode.
+5. Tooling: `cube list --infra=<name>` and CI dashboards display the
+   compatibility matrix.
 
 ## Alternatives considered
 
-- **Mark the whole benchmark as root-required, not per task.** Rejected:
-  too coarse for tbench2 (84 of 89 tasks are fine non-root). Forces a
-  binary cube/infra compatibility that hides the runnable subset.
-- **Encode requirements in the image** (e.g., `LABEL cube.requires=root`).
-  Rejected: image-side is a foreign system to cube-standard; couples
-  the requirement-declaration cadence to image rebuilds. Python-side
-  is the configuration (per the constitution, Pillar II).
-- **Boolean fields per requirement** (`requires_root: bool`,
-  `requires_apt: bool`, …). Rejected: doesn't grow gracefully. The
-  existing `set[str]` token vocabulary already proved this point — new
-  capabilities arrive without breaking older serialisations.
-- **Tool-layer wrapping (the simulate-non-root flag for fairness
-  benchmarking).** Adjacent but orthogonal — covered by a separate
-  proposal once this contract lands.
+- **Per-task-only requirements (rev 1's primary framing).** Rejected as the
+  *primary* mechanism — the main use case is blanket-per-benchmark, and
+  per-task investigation is too costly. Kept as an optional override for
+  heterogeneous benchmarks.
+- **A brand-new `INCOMPATIBLE` episode status as the v1 mechanism.**
+  Rejected for v1: `INVALID_CONFIG` already carries the exact
+  non-retriable-terminal semantics. New status is a clean later refinement,
+  not a prerequisite.
+- **Two modes only (raise / skip).** Rejected: the "force / try-anyway"
+  mode is operationally important for validating that an infra/image
+  policy change has made an old requirement obsolete without editing the
+  cube.
+- **Encode requirements in the Docker image** (`LABEL cube.requires=root`).
+  Rejected: foreign system; couples requirement cadence to image rebuilds;
+  violates "Python is the configuration".
 
 ## Open questions
 
-1. Where do the tokens *live*? Two options:
-   (a) free-form strings, documented in `resource/spec.md`. Cheap.
-   (b) `Literal` type or `Enum`. Stronger typing but every new token
-   becomes a contract change. **Lean toward (a)** for v1; can promote
-   to `Literal` later without breaking existing declarations.
-2. Should `Benchmark._setup` distinguish `infra is None` (debug-run, no
-   container launches) from compatibility check? Probably yes — when
-   `infra is None`, skip the filter (no enforcement makes sense without
-   a target infra to compare against).
-3. Should the skipped-tasks summary include a hint at which infras
-   *would* serve them (`"these tasks need container:root; available
-   on: daytona, aws, azure, local"`)? Useful but requires the framework
-   to know about other infras at setup time. Defer to tooling.
+1. Where exactly does the `on_incompatible` knob live in cube-harness —
+   `Experiment` field, `run_*` arg, or both? (cube-standard only defines
+   the `setup` parameter + enum; cube-harness owns the surface.)
+2. Should `"force"` mode downgrade the requirement check to a logged
+   warning at *every* task launch, or just once at setup? (Lean: once at
+   setup + a per-task trace breadcrumb.)
+3. Confirm `INVALID_CONFIG` reuse is acceptable to cube-harness owners vs.
+   adding `INCOMPATIBLE` now. (This RFC recommends reuse; flagging for
+   explicit sign-off since it slightly overloads the status's meaning.)

--- a/openspec/changes/task-permission-requirements/proposal.md
+++ b/openspec/changes/task-permission-requirements/proposal.md
@@ -71,16 +71,12 @@ without breaking anything.
 Adding a token is non-breaking: infras default to *not* publishing it;
 benchmarks/tasks default to *not* requiring it.
 
-### 2. Requirements ride on the per-task resource; the benchmark exposes a derived aggregate
+### 2. Requirements ride on the per-task `ContainerConfig`; the infra answers a per-task bool
 
 Requirements live where the resource lives — on each task's
-`ContainerConfig` — and flow through the **existing** resource machinery.
-Each tbench2 task already instantiates its own `ContainerConfig`
-(89 tasks, 89 distinct images, no shared template) which `launch_task_container`
-turns into a per-task `DockerServiceConfig`. We thread `requires` through
-that build so `DockerServiceConfig.requirements()` returns the tokens and
-the **already-existing** `InfraConfig.can_serve(resource)` answers
-per-task compatibility — no new check primitive:
+`ContainerConfig`. Each tbench2 task already instantiates its own
+`ContainerConfig` (89 tasks, 89 distinct images, no shared template), so
+this is a natural home:
 
 ```python
 class ContainerConfig(TypedBaseModel):
@@ -93,81 +89,76 @@ class ContainerConfig(TypedBaseModel):
         return out
 ```
 
-```python
-# cube.task_infra.launch_task_container — thread the tokens into the resource
-resource = DockerServiceConfig(
-    name=name, scope="task", docker_images=[image],
-    requires=container_config.requirements(),   # NEW: was implicitly empty
-    launch_script=build_docker_run_script(...),
-)
-```
-
 **Blanket use case stays cheap.** "All of tbench2 needs root" is achieved
 not by per-task investigation but by the metadata-generation script
 (`scripts/create_task_metadata.py`) stamping `requires={"container:root"}`
 on every task's `ContainerConfig` at generation time. One line in the
 codegen, all 89 tasks covered, zero manual triage. Heterogeneous benchmarks
-that genuinely differ per task set `requires` per task instead.
+set `requires` per task instead.
 
-**Benchmark-level compatibility is derived, not separately declared.** A
-benchmark exposes an introspection helper that unions the per-task
-requirements so an infra can answer "is the *whole* benchmark
-incompatible?" without launching anything:
+**The compatibility primitive is a per-task bool the infra returns.** Rather
+than a benchmark-level aggregate (awkward to build — the benchmark would
+have to materialise or union every task's resource), the infra answers one
+task at a time, reusing its existing `capabilities()`:
 
 ```python
-class BenchmarkConfig(TypedBaseModel, ABC):
+class InfraConfig(TypedBaseModel, ABC):
     ...
-    def aggregate_requirements(self) -> set[str]:
-        """Union of every task's container_config.requirements(). Reads
-        task metadata only (no archive load, no container launch). The
-        infra introspects this at setup to decide whole-benchmark
-        compatibility. Derived — there is no separately-declared
-        benchmark-level requirement to drift out of sync with the tasks."""
-        out: set[str] = set()
-        for meta in self.tasks_metadata().values():
-            if meta.container_config is not None:
-                out |= meta.container_config.requirements()
-        return out
+    def can_serve_task(self, container_config: ContainerConfig) -> bool:
+        """True iff this infra provides every capability the task's container
+        requires. Cheap, metadata-only — no resource built, no launch."""
+        return container_config.requirements().issubset(self.capabilities())
 ```
 
-For tbench2 this returns `{"container:root"}` (every task stamped); for a
-benchmark with no root-needing tasks it returns `set()`.
+This mirrors the existing `InfraConfig.can_serve(resource)` (which checks a
+`ResourceConfig`); `can_serve_task` is the same set-inclusion test against a
+task's `ContainerConfig`. The harness loops over tasks and collects the
+per-task bool — there is **no aggregate method to keep in sync**, and
+"is the whole benchmark incompatible?" is simply "did every task come back
+False?".
 
-### 3. The gate: `Benchmark.setup(infra, on_incompatible=...)` — three modes
+### 3. The mode is a flag on the `InfraConfig`
+
+The policy for handling incompatible tasks belongs to the infra — it is the
+component that knows its own constraints. Add a field:
 
 ```python
 OnIncompatible = Literal["raise", "skip", "force"]
+
+class InfraConfig(TypedBaseModel, ABC):
+    on_incompatible: OnIncompatible = "raise"
 ```
 
-Resolved at experiment-setup time (default `"raise"`):
+At `Benchmark.setup(infra)` / before launch, the harness walks the tasks,
+calls `infra.can_serve_task(task.container_config)` for each, and applies
+`infra.on_incompatible`:
 
-- **`"raise"`** (default). At `setup`, introspect the per-task resources
-  via `aggregate_requirements()` and compute
-  `missing = benchmark.aggregate_requirements() - infra.capabilities()`.
-  If non-empty, **raise `IncompatibleInfraError` immediately, before any
-  episode is created**. tbench2 on toolkit stops at setup with:
-  `"ToolkitInfraConfig cannot run terminalbench2-cube: missing
-  {container:root}."` No episodes, no retries, no spend.
+- **`"raise"`** (default). If **any** task is incompatible, **raise
+  `IncompatibleInfraError` immediately, before any episode is created**.
+  tbench2 on toolkit stops at setup with:
+  `"ToolkitInfraConfig cannot run 5/89 tasks of terminalbench2-cube
+  (missing container:root): nginx-request-logging, …"`. No episodes, no
+  retries, no spend. (This is the whole-benchmark fail-fast, achieved by
+  the per-task loop — no aggregate needed.)
 
-- **`"skip"`**. Run the compatible subset. Each task is checked
-  individually via its own resource (`infra.can_serve(task_resource)`); a
-  task whose requirement isn't met is **not launched**, its episode is
-  recorded with a terminal, **non-retriable** status (§4), and it is
-  excluded from the accuracy denominator. Reported as `n_skipped`. This is
-  where per-task granularity earns its keep: a heterogeneous benchmark runs
-  its root-free tasks and skips the rest.
+- **`"skip"`**. Run the compatible subset. Each incompatible task is **not
+  launched**; its episode is recorded with a terminal, **non-retriable**
+  status (§4) and excluded from the accuracy denominator. Reported as
+  `n_skipped`. Where per-task granularity earns its keep: a heterogeneous
+  benchmark runs its root-free tasks and skips the rest.
 
-- **`"force"`** (try-anyway override). Skip the gate entirely; launch every
-  task regardless. The escape hatch for probing whether a new image policy /
+- **`"force"`** (try-anyway override). Skip the check; launch every task
+  regardless. The escape hatch for probing whether a new image policy /
   infra change has obviated a stale requirement — "did toolkit start
-  allowing root? run with `force` and see." Logs a warning so the override
-  is visible in the trace.
+  allowing root? set `force` and see." Logs a warning so the override is
+  visible in the trace.
 
-Where the mode lives: a field on the experiment-run path (cube-harness
-`Experiment` / `run_*`), forwarded into `Benchmark.setup`. cube-standard
-defines the enum + the `setup` parameter; cube-harness wires the CLI/recipe
-knob. A given infra MAY also pin a stricter default, but the per-run setting
-wins.
+Putting the flag on `InfraConfig` means a user picks the policy where they
+pick the infra — e.g. `ToolkitInfraConfig(on_incompatible="skip")` to run
+the compatible subset on toolkit, or the default `"raise"` to refuse the
+combination outright. cube-standard owns the field + enum; cube-harness
+reads `infra.on_incompatible` in `setup`/launch and maps skip-mode episodes
+to `INVALID_CONFIG`.
 
 ### 4. Status mapping — reuse the existing non-retriable terminal bucket
 
@@ -180,9 +171,10 @@ retry, so replaying only burns the retry budget."* `RETRIABLE_STATUSES =
 An incompatible task is exactly that shape: it will fail identically every
 retry. So:
 
-- **`"raise"` mode**: the failure happens at `Benchmark.setup`, before
-  episodes exist. It surfaces as a **setup/system failure** in cube-harness
-  — the experiment aborts; nothing to retry.
+- **`"raise"` mode**: the failure happens at `Benchmark.setup` (the per-task
+  loop hit ≥1 incompatible task), before episodes exist. It surfaces as a
+  **setup/system failure** in cube-harness — the experiment aborts; nothing
+  to retry.
 - **`"skip"` mode**: each skipped task's episode is written with status
   `INVALID_CONFIG` (terminal, non-retriable). The auto-retry loop leaves it
   alone by construction; the summary counts it under `n_skipped` /
@@ -205,50 +197,49 @@ from day one because both are non-retriable terminal.
 def compatibility_report(cls, infra: InfraConfig) -> CompatibilityReport: ...
 ```
 
-Reads metadata only (no container launches) — built on the same
-`aggregate_requirements()` introspection — so `cube list --infra=toolkit`
-and CI gates can show "tbench2: incompatible on toolkit (needs
-container:root)" before anyone spends a dollar.
+Reads metadata only (no container launches) — the same per-task
+`infra.can_serve_task(meta.container_config)` loop — so `cube list
+--infra=toolkit` and CI gates can show "tbench2: 84/89 runnable on toolkit;
+5 need container:root" before anyone spends a dollar.
 
 ## Migration impact
 
 Backward compatibility is the default:
 
 - `ContainerConfig.requires` defaults to `set()`, so
-  `aggregate_requirements()` returns `set()` for every existing cube. No
+  `can_serve_task` returns `True` for every task of every existing cube. No
   benchmark is newly gated by this PR alone.
 - Existing `InfraConfig.capabilities()` implementations are unchanged.
-- `Benchmark.setup` gains an `on_incompatible="raise"` parameter that is a
-  **no-op when `aggregate_requirements()` is empty** — existing cubes see
-  no behaviour change.
-- `DockerServiceConfig` gains a `requires` field defaulting to `set()`;
-  the `requirements()` it already exposes simply returns it.
+- `InfraConfig` gains `on_incompatible: OnIncompatible = "raise"` and a
+  `can_serve_task()` default method — both no-ops when no task declares
+  `requires`.
 
 Behaviour changes only when a cube stamps `ContainerConfig.requires` AND a
 paired infra-side PR teaches root-capable infras to publish the token.
 Recommended rollout (follow-up PRs, not this RFC):
 
-1. Land this RFC (token + `ContainerConfig.requires` + `DockerServiceConfig`
-   threading + `aggregate_requirements()` + `setup` gate + status mapping).
+1. Land this RFC (token + `ContainerConfig.requires` + `InfraConfig.can_serve_task`
+   + `InfraConfig.on_incompatible` + the setup/launch loop + status mapping).
 2. cube-resources: `LocalInfraConfig`, `DaytonaInfraConfig`, `AWSInfraConfig`,
    `AzureInfraConfig` publish `container:root`. `ToolkitInfraConfig` does not.
 3. cube-harness: `terminalbench2-cube`'s `scripts/create_task_metadata.py`
    stamps `requires={"container:root"}` on every task's `ContainerConfig`.
    tbench2 on toolkit now fails fast at setup with a clear message.
-4. cube-harness: wire the `on_incompatible` knob into `Experiment` / `run_*`
-   and the episode-status `INVALID_CONFIG` mapping for skip mode.
+4. cube-harness: read `infra.on_incompatible` in `setup`/launch; map
+   skip-mode episodes to `INVALID_CONFIG`.
 5. Tooling: `cube list --infra=<name>` and CI dashboards display the
    compatibility matrix.
 
 ## Alternatives considered
 
-- **A separately-declared benchmark-level `requirements()` field (rev 2).**
-  Rejected: it duplicates information that already lives on the per-task
-  `ContainerConfig` and can drift out of sync with the tasks. The benchmark
-  view is *derived* (`aggregate_requirements()`) from the per-task
-  resources instead — single source of truth, and the infra introspects
-  the real per-task resources. The blanket "all tasks need root" case is
-  handled by the codegen stamping each task, not by a second declaration.
+- **A benchmark-level aggregate requirement (rev 4 `aggregate_requirements()`,
+  or a separately-declared rev-2 `requirements()` field).** Rejected: the
+  aggregate is awkward to implement (the benchmark would have to materialise
+  or union every task's resource) and a separately-declared field duplicates
+  what already lives on the per-task `ContainerConfig`. Instead the infra
+  answers a **per-task bool** (`can_serve_task`) and the harness loops;
+  "is the whole benchmark incompatible?" falls out of the loop with no
+  aggregate to maintain.
 - **A brand-new `INCOMPATIBLE` episode status as the v1 mechanism.**
   Rejected for v1: `INVALID_CONFIG` already carries the exact
   non-retriable-terminal semantics. New status is a clean later refinement,
@@ -263,12 +254,18 @@ Recommended rollout (follow-up PRs, not this RFC):
 
 ## Open questions
 
-1. Where exactly does the `on_incompatible` knob live in cube-harness —
-   `Experiment` field, `run_*` arg, or both? (cube-standard only defines
-   the `setup` parameter + enum; cube-harness owns the surface.)
-2. Should `"force"` mode downgrade the requirement check to a logged
-   warning at *every* task launch, or just once at setup? (Lean: once at
-   setup + a per-task trace breadcrumb.)
+1. `on_incompatible` lives on `InfraConfig` (a config field, serialised with
+   the infra). Should a per-run override also exist (e.g. an `Experiment`
+   field that wins over the infra default), or is the infra field the single
+   source? (Lean: infra field only for v1 — simplest; add an override later
+   if a need appears.)
+2. Should `"force"` mode log a warning once at setup or per forced task?
+   (Lean: once at setup + a per-task trace breadcrumb.)
 3. Confirm `INVALID_CONFIG` reuse is acceptable to cube-harness owners vs.
    adding `INCOMPATIBLE` now. (This RFC recommends reuse; flagging for
    explicit sign-off since it slightly overloads the status's meaning.)
+4. `can_serve_task` takes a `ContainerConfig` (cube.container), but
+   `InfraConfig` lives in cube.resource. Confirm the import direction is
+   clean, or whether the check should live as a free function /
+   `ContainerConfig.is_served_by(infra)` to avoid a resource→container
+   dependency. (Implementation detail; doesn't change the design.)

--- a/openspec/changes/task-permission-requirements/proposal.md
+++ b/openspec/changes/task-permission-requirements/proposal.md
@@ -1,82 +1,43 @@
-# Benchmark/task permission requirements + infra capability handshake
+# Task permission requirements + infra capability handshake
 
-**Status:** Proposed (rev 2 — incorporates review feedback on status reuse,
-benchmark-level requirements, and the three-mode policy)
+**Status:** Proposed
 **Date:** 2026-05-21
-**Scope:** `cube.container.ContainerConfig`, `cube.benchmark.BenchmarkConfig`,
-`cube.resource.InfraConfig`, `cube.benchmark.Benchmark.setup` (gate behaviour)
+**Scope:** `cube.container.ContainerConfig`, `cube.resource.InfraConfig`,
+`cube.benchmark.Benchmark.setup`
 **Targets:** `dev`
-**Related:** Surfaced by cube-harness session `2026-05-20_tbench2-infra-model-matrix`
-finding F7 ("toolkit's non-root user vs tbench2's apt-installing tasks").
-cube-harness consumes via `Benchmark.setup` + the episode-status taxonomy.
+**Related:** cube-harness session `2026-05-20_tbench2-infra-model-matrix`,
+finding F7 (toolkit's non-root user vs tbench2's apt-installing tasks).
 
 ---
 
 ## Problem
 
-Some cube benchmarks need infra permissions that not every `InfraConfig`
-provides:
+Some cube tasks need infra permissions not every `InfraConfig` provides —
+e.g. tbench2 tasks `apt-get install` packages and write to `/etc`, `/var`,
+which needs a **root** container; EAI Toolkit forces **uid 13011** by
+cluster policy. Today this mismatch surfaces as **silent low scores** (the
+agent tries `apt-get`, gets `Permission denied`, fails the task at reward 0)
+and can even burn the auto-retry budget re-running episodes that fail
+identically every time.
 
-- `terminalbench2-cube` tasks ask the agent to `apt-get install` packages
-  and write to `/etc/`, `/var/log/` — achievable only inside a container
-  running as **root**.
-- `cube-infra-toolkit` (EAI Toolkit) hard-enforces **uid 13011** in every
-  container by cluster policy; `apt-get` is unreachable.
-
-Today this mismatch surfaces as **silent low scores**. The agent runs,
-tries `apt-get`, gets `Permission denied`, eventually emits `final_step`
-with a wrong solution, the evaluator scores reward=0. A user looking at
-`tbench2 on toolkit ⇒ 0.17` cannot tell whether that's a model-quality
-issue, a cube-installation issue, or a fundamental infra mismatch. Worse,
-under cube-harness's auto-retry loop these episodes can be classified
-`FAILED` (retriable) and **burn the retry budget re-running an episode
-that will fail identically every time**.
-
-Empirical evidence (haiku × 25 tasks): daytona 0.39 vs toolkit 0.17; the
-gap is mostly silent partial failure, not model capability — stronger
-models (sonnet) lift daytona but not toolkit.
-
-The framework **already has** the matching mechanism. `InfraConfig` exposes
-`capabilities() -> set[str]`; `ResourceConfig` exposes
-`requirements() -> set[str]`; `InfraConfig.can_serve(resource)` does
-`requirements.issubset(capabilities)`. The token vocabulary in use today is
-hardware-shaped (`kvm`, `docker`, `gpu:nvidia`, `network:egress`). This
-proposal (a) extends the vocabulary with permission tokens, (b) lets a
-**benchmark** (not just a per-task container) declare requirements, and (c)
-gates at `Benchmark.setup` time with a clear three-mode policy.
+The framework already has the matching mechanism: `InfraConfig.capabilities()
+-> set[str]`, `ResourceConfig.requirements() -> set[str]`, and
+`InfraConfig.can_serve(resource)` doing the set-inclusion test (tokens in use:
+`kvm`, `docker`, `gpu:nvidia`, `network:egress`). This proposal extends it
+with a permission token, a per-task compatibility check, and an
+infra-owned policy for handling mismatches.
 
 ## Design
 
-### 1. Permission token vocabulary (additive)
+**1. One token.** Add `container:root` to the `capabilities()` vocabulary
+("container processes run as uid 0"). A single token is deliberate: `apt`,
+writes to `/etc`/`/var`, ports <1024, and `systemctl` are all root-gated and
+correlate with "is the container root?" on both sides. The vocabulary stays
+open (`set[str]`) so a finer token can be added later if a partial-root
+infra ever needs it.
 
-Add one token to the `InfraConfig.capabilities()` documented vocabulary:
-
-| Token | Meaning |
-|---|---|
-| `container:root` | Container processes run as uid 0 |
-
-A single `container:root` token is deliberate. In practice the
-finer-grained needs — `apt-get install`, writing to `/etc` and `/var`,
-binding ports <1024, `systemctl` — are **all root-gated**, and they
-correlate near-perfectly on both sides: an infra either grants root (and
-thus all of them) or it doesn't (Daytona/local/AWS/Azure run as root;
-EAI Toolkit forces uid 13011 and so denies the whole set). Splitting into
-`container:apt` / `container:systemd` / `container:privileged-ports`
-would be speculative granularity with no current consumer that needs the
-distinction. The token vocabulary is open (`set[str]`), so a future infra
-that offers a *partial* root surface — e.g. rootless Podman with
-`CAP_NET_BIND_SERVICE` but no apt — can introduce a finer token then,
-without breaking anything.
-
-Adding a token is non-breaking: infras default to *not* publishing it;
-benchmarks/tasks default to *not* requiring it.
-
-### 2. Requirements ride on the per-task `ContainerConfig`; the infra answers a per-task bool
-
-Requirements live where the resource lives — on each task's
-`ContainerConfig`. Each tbench2 task already instantiates its own
-`ContainerConfig` (89 tasks, 89 distinct images, no shared template), so
-this is a natural home:
+**2. Per-task `ContainerConfig.requires` (source of truth).** Each task
+already owns a `ContainerConfig` (tbench2: 89 tasks, 89 distinct images):
 
 ```python
 class ContainerConfig(TypedBaseModel):
@@ -89,38 +50,25 @@ class ContainerConfig(TypedBaseModel):
         return out
 ```
 
-**Blanket use case stays cheap.** "All of tbench2 needs root" is achieved
-not by per-task investigation but by the metadata-generation script
-(`scripts/create_task_metadata.py`) stamping `requires={"container:root"}`
-on every task's `ContainerConfig` at generation time. One line in the
-codegen, all 89 tasks covered, zero manual triage. Heterogeneous benchmarks
-set `requires` per task instead.
+The blanket "all of tbench2 needs root" case is handled by the
+metadata-generation script (`create_task_metadata.py`) stamping
+`requires={"container:root"}` on every task — no per-task triage.
+Heterogeneous benchmarks set `requires` per task.
 
-**The compatibility primitive is a per-task bool the infra returns.** Rather
-than a benchmark-level aggregate (awkward to build — the benchmark would
-have to materialise or union every task's resource), the infra answers one
-task at a time, reusing its existing `capabilities()`:
+**3. Per-task bool from the infra.** No benchmark-level aggregate (awkward to
+build); the infra answers one task at a time, reusing `capabilities()`:
 
 ```python
 class InfraConfig(TypedBaseModel, ABC):
     ...
     def can_serve_task(self, container_config: ContainerConfig) -> bool:
-        """True iff this infra provides every capability the task's container
-        requires. Cheap, metadata-only — no resource built, no launch."""
         return container_config.requirements().issubset(self.capabilities())
 ```
 
-This mirrors the existing `InfraConfig.can_serve(resource)` (which checks a
-`ResourceConfig`); `can_serve_task` is the same set-inclusion test against a
-task's `ContainerConfig`. The harness loops over tasks and collects the
-per-task bool — there is **no aggregate method to keep in sync**, and
-"is the whole benchmark incompatible?" is simply "did every task come back
-False?".
+The harness loops this over tasks; "is the whole benchmark incompatible?"
+falls out of the loop — nothing to keep in sync.
 
-### 3. The mode is a flag on the `InfraConfig`
-
-The policy for handling incompatible tasks belongs to the infra — it is the
-component that knows its own constraints. Add a field:
+**4. Policy flag on `InfraConfig`.** The infra owns how to handle a mismatch:
 
 ```python
 OnIncompatible = Literal["raise", "skip", "force"]
@@ -129,143 +77,65 @@ class InfraConfig(TypedBaseModel, ABC):
     on_incompatible: OnIncompatible = "raise"
 ```
 
-At `Benchmark.setup(infra)` / before launch, the harness walks the tasks,
-calls `infra.can_serve_task(task.container_config)` for each, and applies
-`infra.on_incompatible`:
+`Benchmark.setup(infra)` reads it (no new setup parameter):
 
-- **`"raise"`** (default). If **any** task is incompatible, **raise
-  `IncompatibleInfraError` immediately, before any episode is created**.
-  tbench2 on toolkit stops at setup with:
-  `"ToolkitInfraConfig cannot run 5/89 tasks of terminalbench2-cube
-  (missing container:root): nginx-request-logging, …"`. No episodes, no
-  retries, no spend. (This is the whole-benchmark fail-fast, achieved by
-  the per-task loop — no aggregate needed.)
+- **`"raise"`** (default) — if **any** task is incompatible, raise
+  `IncompatibleInfraError` at setup, **before any episode is created**. No
+  spend, no retries. tbench2 on toolkit refuses outright.
+- **`"skip"`** — run the compatible subset; each incompatible task's episode
+  is recorded `INVALID_CONFIG` (§5) and excluded from the accuracy
+  denominator (`n_skipped`).
+- **`"force"`** — launch everything anyway. The escape hatch for probing
+  whether an infra/image change has obviated a stale requirement.
 
-- **`"skip"`**. Run the compatible subset. Each incompatible task is **not
-  launched**; its episode is recorded with a terminal, **non-retriable**
-  status (§4) and excluded from the accuracy denominator. Reported as
-  `n_skipped`. Where per-task granularity earns its keep: a heterogeneous
-  benchmark runs its root-free tasks and skips the rest.
+You pick the policy where you pick the infra:
+`ToolkitInfraConfig(on_incompatible="skip")`.
 
-- **`"force"`** (try-anyway override). Skip the check; launch every task
-  regardless. The escape hatch for probing whether a new image policy /
-  infra change has obviated a stale requirement — "did toolkit start
-  allowing root? set `force` and see." Logs a warning so the override is
-  visible in the trace.
+**5. Status reuse — no new status.** cube-harness already has
+`INVALID_CONFIG`: terminal and **non-retriable** (`RETRIABLE_STATUSES =
+{FAILED, CANCELLED, STALE}` excludes it) — documented as "the identical
+request will fail identically on retry". An incompatible task is exactly
+that. `"raise"` aborts at setup (no episode). `"skip"` writes
+`INVALID_CONFIG`, which the auto-retry loop leaves alone by construction. A
+dedicated `INCOMPATIBLE` status is an optional future refinement for
+reporting, not required for correct retry semantics.
 
-Putting the flag on `InfraConfig` means a user picks the policy where they
-pick the infra — e.g. `ToolkitInfraConfig(on_incompatible="skip")` to run
-the compatible subset on toolkit, or the default `"raise"` to refuse the
-combination outright. cube-standard owns the field + enum; cube-harness
-reads `infra.on_incompatible` in `setup`/launch and maps skip-mode episodes
-to `INVALID_CONFIG`.
+## Migration
 
-### 4. Status mapping — reuse the existing non-retriable terminal bucket
+Backward-compatible by default: `ContainerConfig.requires` defaults to
+`set()` (so `can_serve_task` is always True), and `on_incompatible` defaults
+to `"raise"` but is a no-op until a task declares `requires`. Behaviour
+changes only when a cube stamps `requires` AND a paired infra-side PR
+publishes the token. Rollout (follow-up PRs, not this RFC):
 
-**No new episode status is required.** cube-harness already has
-`INVALID_CONFIG`: a terminal, non-retriable status whose documented meaning
-is *"a permanent error… the identical request will fail identically on
-retry, so replaying only burns the retry budget."* `RETRIABLE_STATUSES =
-{FAILED, CANCELLED, STALE}` deliberately excludes it.
-
-An incompatible task is exactly that shape: it will fail identically every
-retry. So:
-
-- **`"raise"` mode**: the failure happens at `Benchmark.setup` (the per-task
-  loop hit ≥1 incompatible task), before episodes exist. It surfaces as a
-  **setup/system failure** in cube-harness — the experiment aborts; nothing
-  to retry.
-- **`"skip"` mode**: each skipped task's episode is written with status
-  `INVALID_CONFIG` (terminal, non-retriable). The auto-retry loop leaves it
-  alone by construction; the summary counts it under `n_skipped` /
-  `n_invalid_config` rather than `n_failed`, keeping the accuracy
-  denominator honest.
-
-A dedicated `INCOMPATIBLE` / `SKIPPED` status is an **optional future
-refinement** for cleaner dashboards (it would distinguish "infra can't
-serve" from "bad model name"). It touches the `Status` `Literal`,
-`TERMINAL_STATUSES`, `STATUS_ICONS`, and exhaustive matches in
-cube-harness — modest but non-trivial. Recommendation: **ship v1 reusing
-`INVALID_CONFIG`**; add `INCOMPATIBLE` later only if the reporting
-distinction proves valuable. Either way, the retry semantics are correct
-from day one because both are non-retriable terminal.
-
-### 5. Static compatibility preview
-
-```python
-@classmethod
-def compatibility_report(cls, infra: InfraConfig) -> CompatibilityReport: ...
-```
-
-Reads metadata only (no container launches) — the same per-task
-`infra.can_serve_task(meta.container_config)` loop — so `cube list
---infra=toolkit` and CI gates can show "tbench2: 84/89 runnable on toolkit;
-5 need container:root" before anyone spends a dollar.
-
-## Migration impact
-
-Backward compatibility is the default:
-
-- `ContainerConfig.requires` defaults to `set()`, so
-  `can_serve_task` returns `True` for every task of every existing cube. No
-  benchmark is newly gated by this PR alone.
-- Existing `InfraConfig.capabilities()` implementations are unchanged.
-- `InfraConfig` gains `on_incompatible: OnIncompatible = "raise"` and a
-  `can_serve_task()` default method — both no-ops when no task declares
-  `requires`.
-
-Behaviour changes only when a cube stamps `ContainerConfig.requires` AND a
-paired infra-side PR teaches root-capable infras to publish the token.
-Recommended rollout (follow-up PRs, not this RFC):
-
-1. Land this RFC (token + `ContainerConfig.requires` + `InfraConfig.can_serve_task`
-   + `InfraConfig.on_incompatible` + the setup/launch loop + status mapping).
-2. cube-resources: `LocalInfraConfig`, `DaytonaInfraConfig`, `AWSInfraConfig`,
-   `AzureInfraConfig` publish `container:root`. `ToolkitInfraConfig` does not.
-3. cube-harness: `terminalbench2-cube`'s `scripts/create_task_metadata.py`
-   stamps `requires={"container:root"}` on every task's `ContainerConfig`.
-   tbench2 on toolkit now fails fast at setup with a clear message.
-4. cube-harness: read `infra.on_incompatible` in `setup`/launch; map
-   skip-mode episodes to `INVALID_CONFIG`.
-5. Tooling: `cube list --infra=<name>` and CI dashboards display the
-   compatibility matrix.
+1. This RFC: token + `ContainerConfig.requires` + `InfraConfig.can_serve_task`
+   + `on_incompatible` + the `setup` loop + `INVALID_CONFIG` mapping.
+2. cube-resources: root-capable infras (`Local`, `Daytona`, `AWS`, `Azure`)
+   publish `container:root`; `Toolkit` does not.
+3. cube-harness: tbench2 codegen stamps `requires={"container:root"}`.
+4. cube-harness: read `infra.on_incompatible` in setup/launch; map skip-mode
+   episodes to `INVALID_CONFIG`.
 
 ## Alternatives considered
 
-- **A benchmark-level aggregate requirement (rev 4 `aggregate_requirements()`,
-  or a separately-declared rev-2 `requirements()` field).** Rejected: the
-  aggregate is awkward to implement (the benchmark would have to materialise
-  or union every task's resource) and a separately-declared field duplicates
-  what already lives on the per-task `ContainerConfig`. Instead the infra
-  answers a **per-task bool** (`can_serve_task`) and the harness loops;
-  "is the whole benchmark incompatible?" falls out of the loop with no
-  aggregate to maintain.
-- **A brand-new `INCOMPATIBLE` episode status as the v1 mechanism.**
-  Rejected for v1: `INVALID_CONFIG` already carries the exact
-  non-retriable-terminal semantics. New status is a clean later refinement,
-  not a prerequisite.
-- **Two modes only (raise / skip).** Rejected: the "force / try-anyway"
-  mode is operationally important for validating that an infra/image
-  policy change has made an old requirement obsolete without editing the
-  cube.
+- **Benchmark-level aggregate requirement** (a declared `requirements()`
+  field, or a derived `aggregate_requirements()`). Rejected: a declared
+  field duplicates the per-task `ContainerConfig` and drifts; an aggregate is
+  awkward to build (materialise/union every task resource). The per-task
+  `can_serve_task` bool + harness loop needs neither.
+- **A new `INCOMPATIBLE` episode status as the v1 mechanism.** Rejected for
+  v1: `INVALID_CONFIG` already has the exact non-retriable-terminal
+  semantics. Clean later refinement, not a prerequisite.
 - **Encode requirements in the Docker image** (`LABEL cube.requires=root`).
   Rejected: foreign system; couples requirement cadence to image rebuilds;
   violates "Python is the configuration".
 
 ## Open questions
 
-1. `on_incompatible` lives on `InfraConfig` (a config field, serialised with
-   the infra). Should a per-run override also exist (e.g. an `Experiment`
-   field that wins over the infra default), or is the infra field the single
-   source? (Lean: infra field only for v1 — simplest; add an override later
-   if a need appears.)
-2. Should `"force"` mode log a warning once at setup or per forced task?
-   (Lean: once at setup + a per-task trace breadcrumb.)
-3. Confirm `INVALID_CONFIG` reuse is acceptable to cube-harness owners vs.
-   adding `INCOMPATIBLE` now. (This RFC recommends reuse; flagging for
-   explicit sign-off since it slightly overloads the status's meaning.)
-4. `can_serve_task` takes a `ContainerConfig` (cube.container), but
-   `InfraConfig` lives in cube.resource. Confirm the import direction is
-   clean, or whether the check should live as a free function /
-   `ContainerConfig.is_served_by(infra)` to avoid a resource→container
-   dependency. (Implementation detail; doesn't change the design.)
+1. Infra field only, or also a per-run override (`Experiment` field that
+   wins over the infra default)? Lean: infra field only for v1.
+2. `can_serve_task` takes a `ContainerConfig` (cube.container) but lives on
+   `InfraConfig` (cube.resource) — confirm import direction is clean, or make
+   it a free function / `ContainerConfig.is_served_by(infra)`. Implementation
+   detail; doesn't change the design.
+3. Confirm `INVALID_CONFIG` reuse is acceptable vs. adding `INCOMPATIBLE` now.

--- a/openspec/specs/benchmark/spec.md
+++ b/openspec/specs/benchmark/spec.md
@@ -179,16 +179,20 @@ encoded as their own columns; complex types in subclass fields go through
 JSON-encoded strings as well.
 
 **The factory:**
-- `make(infra: InfraConfig | None = None) -> Benchmark` — for every
-  resource whose `infra.provision_status(resource) != "ready"`, call
-  `infra.provision(resource)` (idempotent), then instantiate
-  `type(self).benchmark_class(config=self, infra=infra)`, call
-  `benchmark.setup()`, and return the live `Benchmark`. `infra` is
-  forwarded to the runtime constructor so subclasses can reach it via
-  `self._infra` from `_setup()`. When `infra` is None and `resources` is
-  non-empty, provisioning is skipped with a debug log — benchmarks that use
-  only task-scoped (L3) resources launched per-task can legitimately pass
-  `infra=None` at `make` time.
+- `make(infra: InfraConfig | None = None) -> Benchmark` — runs the **capability
+  gate** first (when `infra` is set and `infra.on_incompatible != "force"`):
+  `can_serve` is checked over every task's `container_config` and the benchmark's
+  declared `resources`, applying `infra.on_incompatible` (`"raise"` →
+  `IncompatibleInfraError` before any provisioning; `"skip"` → task view narrowed to
+  the compatible subset; an incompatible benchmark-scoped resource always raises). This
+  is metadata-only and launch-free, so it stays cheap. Then, for every resource whose
+  `infra.provision_status(resource) != "ready"`, call `infra.provision(resource)`
+  (idempotent), instantiate `type(cfg).benchmark_class(config=cfg, infra=infra)`, call
+  `benchmark.setup()`, and return the live `Benchmark`. `infra` is forwarded to the
+  runtime constructor so subclasses can reach it via `self._infra` from `_setup()`. When
+  `infra` is None the gate is skipped (and, if `resources` is non-empty, provisioning is
+  skipped with a debug log) — benchmarks that use only task-scoped (L3) resources
+  launched per-task can legitimately pass `infra=None` at `make` time.
 
 ### `Benchmark` (abstract, plain Python class — not serializable)
 

--- a/openspec/specs/resource/spec.md
+++ b/openspec/specs/resource/spec.md
@@ -38,18 +38,27 @@ class ResourceConfig(TypedBaseModel):
     source_hash: str | None = None                   # informational; not used for dedup
     default_ttl_seconds: int | None = 3600           # auto-cleanup TTL
     bootstrap_script_extra: str | None = None        # benchmark-specific VM setup
+    requires: set[str] = set()                       # explicit extra tokens, e.g. {"container:root"}
 
-    def requirements(self) -> set[str]               # capability tokens infra must support
+    def requirements(self) -> set[str]               # folds `requires`; subclasses super()-union
 ```
 
-Standard capability tokens: `"kvm"`, `"docker"`, `"gpu:nvidia"`, `"network:egress"`.
+Standard capability tokens: `"kvm"`, `"docker"`, `"gpu:nvidia"`, `"network:egress"`,
+`"container:root"` (container processes run as uid 0 — needed by tasks that `apt`-install
+or write to `/etc`, `/var`; absent on infras that pin a non-root uid, e.g. EAI Toolkit).
+
+`requires` is the declarative escape hatch: any resource adds tokens here and every
+subclass folds them via `super().requirements()`, so `requirements()` is the single
+read point used by `can_serve`.
 
 **Subclasses:**
 - `VMResourceConfig(requires_kvm: bool = True)` — VM-based (OSWorld, WindowsAgentArena, AndroidWorld…)
 - `DockerServiceConfig(docker_images, services, launch_script, endpoint_to_site, volumes)` —
   multi-container stack (WebArena, WorkArena)
-- `DockerImageConfig(image, ram_gb, cpu_cores, disk_gb, gpu, ports)` — single image per
-  task (SWE-bench, MLE-bench, CTF)
+- `ContainerConfig(image, ram_gb, cpu_cores, disk_gb, gpu, ports)` — single image per task
+  (SWE-bench, terminal-bench, CTF). Defined in `cube.resource`, re-exported from
+  `cube.container`; declared on `TaskMetadata.container_config`. `requirements()` →
+  `{"docker"}` (+ `"gpu:nvidia"` if `gpu`) ∪ `requires`.
 
 ### `VolumeSpec` (used by `DockerServiceConfig`)
 ```python
@@ -67,6 +76,7 @@ class VolumeSpec(TypedBaseModel):
 class InfraConfig(TypedBaseModel, ABC):
     default_ttl_seconds: int | None = 86400          # 1 day; overrides resource TTL
     image_name_suffix: str = ""                       # e.g. "-test" to isolate CI
+    on_incompatible: Literal["raise", "skip", "force"] = "raise"  # capability-gate policy
 
     @abstractmethod
     def fingerprint(self) -> str                     # "aws:us-east-2", "azure:westus2", "local"
@@ -89,7 +99,10 @@ class InfraConfig(TypedBaseModel, ABC):
 **Concrete helpers** (provided):
 - `register(resource, resource_info: dict)` — record that an image is available
 - `provision_status(resource)` → `"ready" | "needs_provisioning"`
-- `can_serve(resource)` → bool — `resource.requirements() <= self.capabilities()`
+- `can_serve(resource)` → bool — `resource.requirements() <= self.capabilities()`. The unit
+  of the capability handshake; `BenchmarkConfig.make()` runs it over every task's
+  `container_config` and the benchmark's declared `resources` before provisioning, applying
+  `on_incompatible`. A meta-infra overrides `can_serve` to delegate per-resource to children.
 
 `fingerprint()` rule: encode provider + region/location only. Two configs with the
 same fingerprint share the same provisioned image. Do NOT encode instance size,
@@ -118,6 +131,18 @@ class ResourceHandle(ABC):
 ### Exceptions
 - `ResourceNotReadyError` — `launch()` called before `provision()` or `register()`
 - `UnsupportedResourceType` — infra doesn't support the given `ResourceConfig` subclass
+- `IncompatibleInfraError` — raised by `BenchmarkConfig.make()` (pre-provision, pre-episode)
+  when `on_incompatible == "raise"` and a resource is not servable
+
+### `on_incompatible` policy
+Checked at `make()` by running `can_serve` over each task's `container_config` and the
+benchmark's `resources`:
+- `"raise"` (default) — abort with `IncompatibleInfraError` if **any** resource is
+  incompatible. No provisioning, no episodes, no spend.
+- `"skip"` — run only the compatible tasks (the task view is narrowed); the harness records
+  the dropped ones terminally (`INVALID_CONFIG`). An incompatible *benchmark-scoped* resource
+  is shared and still raises.
+- `"force"` — attempt everything anyway (escape hatch to probe a stale requirement).
 
 ## Cleanup Methods Reference
 

--- a/scripts/smoke/capability_gate_smoke.py
+++ b/scripts/smoke/capability_gate_smoke.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Smoke: infra capability gate (`container:root` + `on_incompatible`) — beyond CI.
+
+The unit tests exercise the gate against a *stub* infra. This smoke validates the two
+things only a real infra + a real container can show:
+
+Part A — handshake against the REAL `LocalInfraConfig.capabilities()` (no daemon needed;
+  capabilities() keys off the docker *binary*): when docker is present, local advertises
+  `container:root` and `can_serve` a root-requiring `ContainerConfig`, and refuses one
+  that needs a capability it lacks.
+
+Part B — `BenchmarkConfig.make()` gate end-to-end with real local infra capabilities
+  (install() no-op'd — orthogonal system-dep step we are not testing):
+    * a non-root infra (real local minus `container:root`, mirroring EAI Toolkit) →
+      `on_incompatible="raise"` aborts with `IncompatibleInfraError`; `"skip"` drops only
+      the root task; `"force"` keeps everything.
+    * a root-capable infra serves both tasks.
+
+Part C — capability TRUTH (docker daemon required, else SKIP): launch a container on local
+  docker and assert `id -u` == 0. CI asserts the *advertised* token; only a real launch
+  proves the container actually runs as uid 0.
+
+SMOKE OK / FAIL / SKIP. Run from the cube-standard repo root::
+
+    uv run scripts/smoke/capability_gate_smoke.py
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+
+from cube.benchmark import Benchmark, BenchmarkConfig, BenchmarkMetadata
+from cube.infra_local import LocalInfraConfig
+from cube.resource import ContainerConfig, IncompatibleInfraError
+from cube.task import TaskConfig, TaskMetadata
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+log = logging.getLogger("cap-gate-smoke")
+
+NAME = "capability_gate_smoke"
+IMAGE = "python:3.12-slim"
+
+
+def banner(status: str, reason: str = "") -> int:
+    line = f"SMOKE {status}: {NAME}"
+    if reason:
+        line += f" — {reason}"
+    print(line)
+    return {"OK": 0, "FAIL": 1, "SKIP": 2}[status]
+
+
+# ── A real LocalInfraConfig, with install() no-op'd (not what this smoke tests) ──
+
+
+class _RootLocal(LocalInfraConfig):
+    def install(self) -> None:  # avoid the orthogonal `brew/apt install qemu` side-effect
+        pass
+
+
+class _NonRootLocal(_RootLocal):
+    """Mirrors a non-root infra (e.g. EAI Toolkit): real local minus `container:root`."""
+
+    def capabilities(self) -> set[str]:
+        return super().capabilities() - {"container:root"}
+
+
+# ── Minimal benchmark: one root-requiring task, one plain ──────────────────────
+
+
+class _GateTaskConfig(TaskConfig):
+    def make(self, runtime_context=None):
+        raise NotImplementedError("the gate smoke never spawns tasks")
+
+
+class _GateBench(Benchmark):
+    def _setup(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+class _GateBenchConfig(BenchmarkConfig):
+    benchmark_metadata = BenchmarkMetadata(name="cap-gate-smoke", version="1", description="x")
+    task_metadata = {
+        "root": TaskMetadata(id="root", container_config=ContainerConfig(image=IMAGE, requires={"container:root"})),
+        "plain": TaskMetadata(id="plain", container_config=ContainerConfig(image=IMAGE)),
+    }
+    task_config_class = _GateTaskConfig
+    benchmark_class = _GateBench
+
+
+def _raises_incompatible(infra) -> bool:
+    try:
+        _GateBenchConfig().make(infra)
+        return False
+    except IncompatibleInfraError:
+        return True
+
+
+def check_handshake() -> None:
+    """Part A — real LocalInfraConfig capability handshake."""
+    caps = LocalInfraConfig().capabilities()
+    has_docker = "docker" in caps
+    root_cc = ContainerConfig(image=IMAGE, requires={"container:root"})
+    if has_docker:
+        assert "container:root" in caps, f"local advertises docker but not container:root: {sorted(caps)}"
+        assert LocalInfraConfig().can_serve(root_cc) is True
+    assert _NonRootLocal().can_serve(root_cc) is False, "a non-root infra must NOT serve a root task"
+    assert _NonRootLocal().can_serve(ContainerConfig(image=IMAGE)) is has_docker
+    log.info("  [A] capability handshake OK (docker=%s, container:root=%s)", has_docker, "container:root" in caps)
+
+
+def check_gate() -> None:
+    """Part B — make() gate with real local capabilities."""
+    has_docker = "docker" in LocalInfraConfig().capabilities()
+
+    # raise: a non-root infra refuses the root task (holds regardless of docker —
+    # container:root is absent either way).
+    assert _raises_incompatible(_NonRootLocal(on_incompatible="raise")), "raise mode must abort on the root task"
+    log.info("  [B] raise -> IncompatibleInfraError on non-root infra OK")
+
+    if not has_docker:
+        log.info("  [B] no docker binary — skipping skip/force/positive cases (plain task needs docker)")
+        return
+
+    # skip: drop only the incompatible (root) task.
+    bench = _GateBenchConfig().make(_NonRootLocal(on_incompatible="skip"))
+    try:
+        assert set(bench.config.tasks()) == {"plain"}, set(bench.config.tasks())
+    finally:
+        bench.close()
+    log.info("  [B] skip -> {plain} kept, {root} dropped OK")
+
+    # force: keep everything.
+    bench = _GateBenchConfig().make(_NonRootLocal(on_incompatible="force"))
+    try:
+        assert set(bench.config.tasks()) == {"root", "plain"}
+    finally:
+        bench.close()
+    log.info("  [B] force -> all tasks kept OK")
+
+    # root-capable infra serves both under the default raise policy.
+    bench = _GateBenchConfig().make(_RootLocal(on_incompatible="raise"))
+    try:
+        assert set(bench.config.tasks()) == {"root", "plain"}
+    finally:
+        bench.close()
+    log.info("  [B] root-capable infra serves the root task OK")
+
+
+def _docker_daemon_ok() -> bool:
+    try:
+        return subprocess.run(["docker", "info"], capture_output=True, timeout=20).returncode == 0
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def check_runtime_uid() -> tuple[bool, str]:
+    """Part C — the container actually runs as uid 0. Returns (ran, detail)."""
+    if "docker" not in LocalInfraConfig().capabilities():
+        return (False, "no docker binary — runtime uid check skipped")
+    if not _docker_daemon_ok():
+        return (False, "docker daemon unreachable — runtime uid check skipped")
+    from cube.task_infra import launch_task_container
+
+    log.info("  [C] launching %s to verify uid 0 ...", IMAGE)
+    handle, container = launch_task_container(
+        {"infra": LocalInfraConfig(enable_kvm=False)},
+        name="cap-gate-smoke",
+        image=IMAGE,
+        ram_gb=1.0,
+        cpu_cores=1.0,
+    )
+    try:
+        res = container.exec("id -u")
+        assert res.exit_code == 0, f"exit_code={res.exit_code} stderr={res.stderr!r}"
+        assert res.stdout.strip() == "0", f"container:root claimed but `id -u` returned {res.stdout!r}"
+    finally:
+        handle.close()
+    log.info("  [C] container runs as uid 0 — container:root claim is truthful")
+    return (True, "launched, id -u == 0, closed")
+
+
+def main() -> int:
+    try:
+        log.info("Part A — capability handshake")
+        check_handshake()
+        log.info("Part B — make() gate")
+        check_gate()
+        log.info("Part C — runtime uid")
+        uid_ran, uid_detail = check_runtime_uid()
+        log.info("  [C] %s", uid_detail)
+    except AssertionError as exc:
+        return banner("FAIL", f"check failed: {exc}")
+    except Exception as exc:  # noqa: BLE001
+        log.exception("unexpected error")
+        return banner("FAIL", f"{type(exc).__name__}: {exc}")
+
+    return banner("OK", f"handshake + make() gate OK; runtime uid {'verified' if uid_ran else 'skipped'}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/cube/benchmark.py
+++ b/src/cube/benchmark.py
@@ -63,7 +63,7 @@ from pydantic import Field, SerializeAsAny
 
 from cube import get_cache_dir
 from cube.core import TypedBaseModel, ValidatedConfig
-from cube.resource import InfraConfig, ResourceConfig
+from cube.resource import IncompatibleInfraError, InfraConfig, ResourceConfig
 from cube.seed import AbstractSeedGenerator
 from cube.task import RuntimeContext, Task, TaskConfig, TaskMetadata
 from cube.tool import ToolConfig
@@ -656,16 +656,21 @@ class BenchmarkConfig[TTMetadata: TaskMetadata](ValidatedConfig, ABC):
         for per-task container launches can do so from ``_setup()`` without
         overriding ``make``.
         """
-        if self.resources:
+        # 0. Capability gate (fail-fast, before any provisioning or episode).
+        cfg: Self = self
+        if infra is not None and infra.on_incompatible != "force":
+            cfg = self._gate_infra_compatibility(infra)
+
+        if cfg.resources:
             if infra is None:
                 logger.debug(
                     "%s.make() called without infra but %d resource(s) are declared; "
                     "skipping provisioning (task-scoped resources will be launched per-task).",
-                    type(self).__name__,
-                    len(self.resources),
+                    type(cfg).__name__,
+                    len(cfg.resources),
                 )
             else:
-                for resource in self.resources:
+                for resource in cfg.resources:
                     status = infra.provision_status(resource)
                     if status == "ready":
                         logger.info("Resource %s already provisioned on %s", resource.name, infra.fingerprint())
@@ -673,9 +678,49 @@ class BenchmarkConfig[TTMetadata: TaskMetadata](ValidatedConfig, ABC):
                     logger.info("Provisioning resource %s on %s...", resource.name, infra.fingerprint())
                     infra.provision(resource)
 
-        benchmark = type(self).benchmark_class(config=self, infra=infra)
+        benchmark = type(cfg).benchmark_class(config=cfg, infra=infra)
         benchmark.setup()
         return benchmark
+
+    def _gate_infra_compatibility(self, infra: InfraConfig) -> Self:
+        """Run ``infra.can_serve`` over every resource this benchmark needs and apply
+        ``infra.on_incompatible``. Returns ``self`` (or, in ``"skip"`` mode, a task-narrowed
+        copy); raises ``IncompatibleInfraError`` in ``"raise"`` mode. Metadata-only and
+        launch-free, so it stays cheap even for large benchmarks. Never called for
+        ``on_incompatible == "force"``.
+        """
+        # Benchmark-scoped resources are shared by every task → an incompatible one is
+        # always fatal (it cannot be skipped), regardless of the policy.
+        bad_shared = [r for r in self.resources if not infra.can_serve(r)]
+        incompatible = {
+            tid: sorted(tm.container_config.requirements())
+            for tid, tm in self.tasks().items()
+            if tm.container_config is not None and not infra.can_serve(tm.container_config)
+        }
+        if not bad_shared and not incompatible:
+            return self
+
+        if bad_shared or infra.on_incompatible == "raise":
+            detail = {r.name: sorted(r.requirements()) for r in bad_shared}
+            detail.update(dict(list(incompatible.items())[:5]))
+            more = "" if len(incompatible) <= 5 else f" (+{len(incompatible) - 5} more tasks)"
+            raise IncompatibleInfraError(
+                f"{type(infra).__name__} (capabilities={sorted(infra.capabilities())}) cannot "
+                f"serve {len(bad_shared) + len(incompatible)} resource(s) of benchmark "
+                f"{self.benchmark_metadata.name!r}: {detail}{more}"
+            )
+
+        # skip mode: drop the incompatible tasks, keep the compatible subset.
+        keep = [tid for tid in self.tasks() if tid not in incompatible]
+        logger.warning(
+            "on_incompatible='skip': %s cannot serve %d/%d task(s) of %r; skipping %s",
+            type(infra).__name__,
+            len(incompatible),
+            len(self.tasks()),
+            self.benchmark_metadata.name,
+            sorted(incompatible),
+        )
+        return self.subset_from_list(keep)
 
 
 class Benchmark[TBenchConfig: BenchmarkConfig](ABC):

--- a/src/cube/infra_local.py
+++ b/src/cube/infra_local.py
@@ -505,6 +505,7 @@ class LocalInfraConfig(InfraConfig):
                 pass
         if shutil.which("docker"):
             caps.add("docker")
+            caps.add("container:root")  # local Docker containers run as uid 0
         return caps
 
     def provision(self, resource: ResourceConfig) -> None:

--- a/src/cube/resource.py
+++ b/src/cube/resource.py
@@ -111,6 +111,15 @@ class UnsupportedResourceType(NotImplementedError):
         )
 
 
+class IncompatibleInfraError(RuntimeError):
+    """Raised at ``BenchmarkConfig.make`` — before any provisioning or episode — when an
+    infra cannot serve one or more of a benchmark's resources and its ``on_incompatible``
+    policy is ``"raise"``.
+
+    Setup-time and pre-launch by construction: nothing is provisioned and no retry budget
+    is consumed, so the same request will not be re-attempted."""
+
+
 # ── ResourceConfig ────────────────────────────────────────────────────────────
 
 
@@ -141,14 +150,20 @@ class ResourceConfig(TypedBaseModel):
     source_hash: str | None = None
     default_ttl_seconds: int | None = 3600
     bootstrap_script_extra: str | None = None
+    requires: set[str] = Field(default_factory=set)
+    """Explicit capability tokens this resource needs beyond what its subclass implies,
+    e.g. ``{"container:root"}``. Folded into ``requirements()``; empty (default) adds
+    nothing, so existing resources are unaffected."""
 
     def requirements(self) -> set[str]:
         """Declare what the infra must support to run this resource.
 
-        Checked against InfraConfig.capabilities() before provisioning or launch.
-        Standard tokens: "kvm", "docker", "gpu:nvidia", "network:egress".
+        Checked against ``InfraConfig.capabilities()`` (via ``InfraConfig.can_serve``)
+        before provisioning or launch. Subclasses union their structural needs onto the
+        explicit ``requires`` tokens via ``super().requirements()``.
+        Standard tokens: "kvm", "docker", "gpu:nvidia", "network:egress", "container:root".
         """
-        return set()
+        return set(self.requires)
 
 
 class VMResourceConfig(ResourceConfig):
@@ -184,7 +199,7 @@ class VMResourceConfig(ResourceConfig):
     parallel workers can share a host without colliding on a fixed local port."""
 
     def requirements(self) -> set[str]:
-        return {"kvm"} if self.requires_kvm else set()
+        return super().requirements() | ({"kvm"} if self.requires_kvm else set())
 
 
 class VolumeSpec(TypedBaseModel):
@@ -251,7 +266,7 @@ class DockerServiceConfig(ResourceConfig):
     volumes: list[VolumeSpec] = []
 
     def requirements(self) -> set[str]:
-        return {"docker"}
+        return super().requirements() | {"docker"}
 
 
 class ContainerConfig(ResourceConfig):
@@ -280,7 +295,7 @@ class ContainerConfig(ResourceConfig):
     ports: list[int] | None = None
 
     def requirements(self) -> set[str]:
-        reqs = {"docker"}
+        reqs = super().requirements() | {"docker"}
         if self.gpu:
             reqs.add("gpu:nvidia")
         return reqs
@@ -405,6 +420,8 @@ class ResourceHandle(ABC):
 
 # ── InfraConfig ───────────────────────────────────────────────────────────────
 
+OnIncompatible = Literal["raise", "skip", "force"]
+
 
 class InfraConfig(ValidatedConfig, ABC):
     """Harness-owned config + executor for resource provisioning and lifecycle.
@@ -450,6 +467,19 @@ class InfraConfig(ValidatedConfig, ABC):
     the resource name.  E.g. image_name_suffix="-test" and resource.name="foo"
     → image named "foo-test", store key "foo-test@<fingerprint>"."""
 
+    on_incompatible: OnIncompatible = "raise"
+    """Policy when a resource needs a capability this infra lacks — checked at
+    ``BenchmarkConfig.make`` (before provisioning) by running ``can_serve`` over each
+    task's container and the benchmark's declared resources:
+
+    - ``"raise"`` (default) — abort with ``IncompatibleInfraError`` if ANY resource is
+      incompatible. No provisioning, no episodes, no spend.
+    - ``"skip"`` — run only the compatible tasks; incompatible ones are dropped from the
+      task view (the harness records them terminally). An incompatible *benchmark-scoped*
+      resource still raises — it is shared and cannot be skipped.
+    - ``"force"`` — attempt everything anyway; the escape hatch to probe whether a stale
+      requirement still holds."""
+
     # ── Abstract interface ────────────────────────────────────────────────────
 
     @abstractmethod
@@ -469,7 +499,9 @@ class InfraConfig(ValidatedConfig, ABC):
         """Declare what this infra supports.
 
         Checked against resource.requirements() before provisioning or launch.
-        Standard tokens: "kvm", "docker", "gpu:nvidia", "network:egress".
+        Standard tokens: "kvm", "docker", "gpu:nvidia", "network:egress",
+        "container:root" (container processes run as uid 0 — needed by tasks that
+        apt-install or write to /etc, /var; absent on infras that pin a non-root uid).
         """
         ...
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -9,6 +9,13 @@ import pytest
 
 from cube.benchmark import Benchmark, BenchmarkConfig, BenchmarkMetadata
 from cube.core import Observation
+from cube.resource import (
+    ContainerConfig,
+    IncompatibleInfraError,
+    InfraConfig,
+    ResourceConfig,
+    ResourceHandle,
+)
 from cube.seed import AbstractSeedGenerator
 from cube.task import Task, TaskConfig, TaskMetadata
 from cube.tool import Tool, ToolConfig, tool_action
@@ -650,6 +657,7 @@ def test_setup_calls_cleanup_stale_when_infra_set() -> None:
     from cube.resource import InfraConfig
 
     infra = MagicMock(spec=InfraConfig)
+    infra.on_incompatible = "force"  # spec'd mocks don't expose pydantic fields; skip the gate here
     infra.cleanup_stale.return_value = []
 
     bench = MyBenchmarkConfig().make(infra=infra)
@@ -675,6 +683,7 @@ def test_setup_cleanup_stale_failure_does_not_block_setup() -> None:
     from cube.resource import InfraConfig
 
     infra = MagicMock(spec=InfraConfig)
+    infra.on_incompatible = "force"  # spec'd mocks don't expose pydantic fields; skip the gate here
     infra.cleanup_stale.side_effect = RuntimeError("transient cloud 503")
 
     # Must not raise — failure is swallowed and logged.
@@ -692,6 +701,7 @@ def test_setup_cleanup_stale_called_before_subclass_setup() -> None:
 
     call_order: list[str] = []
     infra = MagicMock(spec=InfraConfig)
+    infra.on_incompatible = "force"  # spec'd mocks don't expose pydantic fields; skip the gate here
     infra.cleanup_stale.side_effect = lambda: call_order.append("cleanup_stale") or []
 
     class _OrderingTaskConfig(_TaskConfig):
@@ -714,5 +724,91 @@ def test_setup_cleanup_stale_called_before_subclass_setup() -> None:
     bench = _OrderingBenchConfig().make(infra=infra)
     try:
         assert call_order == ["cleanup_stale", "_setup"]
+    finally:
+        bench.close()
+
+
+# ── make() capability gate: on_incompatible raise / skip / force (RFC #191) ────
+
+
+class _GateInfra(InfraConfig):
+    """Minimal concrete infra whose capabilities are set per-test."""
+
+    caps: list[str] = []
+
+    def fingerprint(self) -> str:
+        return "gate"
+
+    def capabilities(self) -> set[str]:
+        return set(self.caps)
+
+    def provision(self, resource: ResourceConfig) -> None:
+        pass
+
+    def launch(self, resource: ResourceConfig, run_id: str, ttl_seconds: int | None = None) -> ResourceHandle:
+        raise NotImplementedError
+
+    def list_active(self, run_id: str | None = None) -> list[ResourceHandle]:
+        return []
+
+    def cleanup(self, run_id: str) -> None:
+        pass
+
+    def cleanup_stale(self, max_age_seconds: int | None = None) -> list[str]:
+        return []
+
+
+class _GateTaskConfig(TaskConfig):
+    def make(self, runtime_context=None):
+        return _Task(metadata=self.metadata, tool_config=self.tool_config or _ToolConfig())
+
+
+class _GateBench(Benchmark):
+    def _setup(self):
+        pass
+
+    def close(self):
+        pass
+
+
+class _GateBenchConfig(BenchmarkConfig):
+    benchmark_metadata = BenchmarkMetadata(name="gate-bench", version="1", description="x")
+    task_metadata = {
+        "root": TaskMetadata(id="root", container_config=ContainerConfig(image="img", requires={"container:root"})),
+        "plain": TaskMetadata(id="plain", container_config=ContainerConfig(image="img")),
+    }
+    task_config_class = _GateTaskConfig
+    benchmark_class = _GateBench
+
+
+def test_make_raise_aborts_when_a_task_is_incompatible() -> None:
+    infra = _GateInfra(caps=["docker"], on_incompatible="raise")  # no container:root
+    with pytest.raises(IncompatibleInfraError, match="cannot serve"):
+        _GateBenchConfig().make(infra=infra)
+
+
+def test_make_skip_drops_only_the_incompatible_tasks() -> None:
+    infra = _GateInfra(caps=["docker"], on_incompatible="skip")
+    bench = _GateBenchConfig().make(infra=infra)
+    try:
+        assert set(bench.config.tasks()) == {"plain"}
+    finally:
+        bench.close()
+
+
+def test_make_force_keeps_every_task() -> None:
+    infra = _GateInfra(caps=["docker"], on_incompatible="force")
+    bench = _GateBenchConfig().make(infra=infra)
+    try:
+        assert set(bench.config.tasks()) == {"root", "plain"}
+    finally:
+        bench.close()
+
+
+def test_make_passes_when_infra_serves_root() -> None:
+    infra = _GateInfra(caps=["docker", "container:root"], on_incompatible="raise")
+    bench = _GateBenchConfig().make(infra=infra)
+    try:
+        assert set(bench.config.tasks()) == {"root", "plain"}
     finally:
         bench.close()

--- a/tests/test_resource_lifecycle.py
+++ b/tests/test_resource_lifecycle.py
@@ -242,6 +242,38 @@ class TestContainerConfigUnification:
         assert reloaded.requirements() == {"docker", "gpu:nvidia"}
 
 
+# ── requires folding + container:root handshake (RFC #191) ────────────────────
+
+
+class TestResourceRequires:
+    """Every ResourceConfig folds its explicit ``requires`` tokens into ``requirements()``,
+    and ``container:root`` participates in the ``can_serve`` capability handshake."""
+
+    def test_base_requires_is_the_requirements(self) -> None:
+        assert ResourceConfig(name="x", requires={"container:root"}).requirements() == {"container:root"}
+
+    def test_container_requires_unions_with_docker(self) -> None:
+        assert ContainerConfig(image="i", requires={"container:root"}).requirements() == {
+            "docker",
+            "container:root",
+        }
+
+    def test_container_requires_composes_with_gpu(self) -> None:
+        cc = ContainerConfig(image="i", gpu=True, requires={"container:root"})
+        assert cc.requirements() == {"docker", "gpu:nvidia", "container:root"}
+
+    def test_vm_requires_unions_with_kvm(self) -> None:
+        assert VMResourceConfig(name="v", requires={"extra"}).requirements() == {"kvm", "extra"}
+
+    def test_empty_requires_changes_nothing(self) -> None:
+        assert ContainerConfig(image="i").requirements() == {"docker"}
+
+    def test_can_serve_respects_container_root(self) -> None:
+        cc = ContainerConfig(image="i", requires={"container:root"})
+        assert _StubInfra(name="root", caps=["docker", "container:root"]).can_serve(cc) is True
+        assert _StubInfra(name="nonroot", caps=["docker"]).can_serve(cc) is False
+
+
 # ── InfraConfig base: register / provision_status / can_serve ─────────────────
 
 


### PR DESCRIPTION
## What

Tasks declare the infra capabilities they need; infras declare what they provide; `BenchmarkConfig.make()` **fails fast (or skips)** when an infra can't serve a benchmark's resources — turning silent reward-0 failures (e.g. tbench2 apt-tasks on EAI Toolkit's non-root uid) into a clear setup-time error **before any spend**.

Implements the design in `openspec/changes/task-permission-requirements/` (now **Implemented**; deltas applied to the living `resource/` and `benchmark/` specs).

## Design — reuse the existing per-resource handshake

Since the `ContainerConfig` → `ResourceConfig` unification (#201), a task's `container_config` **is** a `ResourceConfig`, so the existing `InfraConfig.can_serve(resource)` is the unit — **no new `can_serve_task`, no benchmark aggregate.**

- **Token:** `container:root` added to the capability vocabulary (uid 0).
- **Declaration:** `ResourceConfig.requires: set[str]` (base field) folded into `requirements()` via `super()`-chaining in each subclass.
- **Policy:** `InfraConfig.on_incompatible: Literal["raise","skip","force"] = "raise"`.
- **Gate:** `make()` runs `can_serve` over each task's `container_config` + the benchmark's `resources` before provisioning — `"raise"` → `IncompatibleInfraError` (pre-episode); `"skip"` → narrow to the compatible task subset; `"force"` → run all. Metadata-only, launch-free.
- **Capabilities:** Local (when docker present), AWS, Azure, Daytona, Modal publish `container:root`; **Toolkit deliberately does not** (pins a non-root uid).

## Forward-compatible by construction

Per-resource `can_serve` (not `can_serve_task`) is the overridable unit, so this composes with **composite resources** and a future **meta-infra** that overrides `can_serve` to delegate per-resource to children — no rework needed. `requires` on the base `ResourceConfig` generalizes the escape hatch to any resource/token.

## Verification

- **656 passed, 1 skipped**; `make lint` clean.
- New tests: `requires`-folding (base + container + vm, gpu composition), the `container:root` `can_serve` handshake, and `make()`'s raise/skip/force (`tests/test_resource_lifecycle.py`, `tests/test_benchmark.py`).
- Backward-compatible: `requires` defaults empty (so `requirements()` is unchanged for existing resources) and `on_incompatible` is a no-op until a task declares a token the infra lacks.

## Spec reconciliation

Applying the deltas also fixes pre-existing drift: `resource/spec.md` still listed the deleted `DockerImageConfig` — now `ContainerConfig` (per #201).

## Follow-up (cube-harness, separate PR)

tbench2 (and other root-needing cubes) codegen stamps `requires={"container:root"}`; the harness maps skip-mode tasks to the existing terminal `INVALID_CONFIG` status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
