### PR TITLE
refactor(benchmark): base Benchmark.setup() owns cleanup_stale()

### DIFF
--- a/openspec/specs/benchmark/spec.md
+++ b/openspec/specs/benchmark/spec.md
@@ -198,8 +198,15 @@ per-task container launches can do so from `_setup()` without overriding
 - `close()` — tear down what `_setup()` created.
 
 **Concrete methods:**
-- `setup()` — public wrapper. Calls `_setup()`. Emits a debug log listing
-  unset optional config fields. Called exactly once by `make()`.
+- `setup()` — public wrapper. Owns the "harness startup" hook: if `self._infra`
+  is set, calls `self._infra.cleanup_stale()` to reclaim TTL-expired resources
+  from prior crashed runs *before* dispatching to `_setup()`. Cube authors do
+  not call `cleanup_stale()` themselves — the base handles it for every
+  benchmark. `cleanup_stale` failures are logged at WARNING and never block
+  setup. Concurrent benchmarks in the same resource group are unaffected
+  because only resources with `cube:expires_at` in the past are deleted.
+  Then calls `_setup()`. Emits a debug log listing unset optional config
+  fields. Called exactly once by `make()`.
 - `spawn(task_config)` — validate `task_config.task_id` against
   `self.config.tasks()`, then call
   `task_config.make(runtime_context=self._runtime_context)`.

--- a/openspec/specs/resource/spec.md
+++ b/openspec/specs/resource/spec.md
@@ -125,14 +125,14 @@ class ResourceHandle(ABC):
 |--------|--------|--------------|--------------|
 | `handle.close()` | L2/L3 | After each task (L3) or at run end (L2) | Tears down this specific resource |
 | `infra.cleanup(run_id)` | L2/L3 | Harness shutdown (catch-all) | Deletes everything tagged with `run_id` |
-| `infra.cleanup_stale(max_age)` | L2/L3 | Harness startup | GCs TTL-expired resources across all runs |
+| `infra.cleanup_stale(max_age)` | L2/L3 | Called automatically by `Benchmark.setup()` (the "harness startup" hook); harnesses may also call it explicitly on lifecycle exit as a defense-in-depth sweep | GCs TTL-expired resources across all runs |
 | `infra.unprovision(resource)` | L1 | Manual (retire / switch region) | Removes provisioned image + store entry |
 
 ## Recommended Harness Lifecycle
 
 ```python
-infra.cleanup_stale()                       # startup: GC orphans from prior crashes
-benchmark.setup()                           # creates L2 resource if needed
+benchmark.setup()                           # base setup() auto-calls infra.cleanup_stale()
+                                            # to GC orphans from prior crashes, then runs _setup()
 for task in tasks:
     handle = infra.launch(resource)         # creates L3 resource
     try:

--- a/src/cube/benchmark.py
+++ b/src/cube/benchmark.py
@@ -716,9 +716,37 @@ class Benchmark[TBenchConfig: BenchmarkConfig](ABC):
     def setup(self) -> None:
         """Public wrapper around ``_setup``. Called automatically by ``BenchmarkConfig.make``.
 
+        Before dispatching to the subclass's ``_setup()``, sweeps TTL-expired
+        cloud resources via ``self._infra.cleanup_stale()`` so prior-run
+        orphans (from crashes, SIGKILLs, machine reboots, etc.) are reclaimed
+        before this run launches new work. This is the "harness startup"
+        hook documented in ``resource/spec.md``. Concurrent benchmarks in
+        the same resource group are unaffected because ``cleanup_stale``
+        only deletes resources whose ``cube:expires_at`` tag is in the past.
+
+        Safe on any failure path: ``cleanup_stale`` exceptions are logged at
+        WARNING and not propagated — a transient cloud error must not block
+        benchmark setup.
+
         Emits a debug line listing optional config fields left unset — useful
         sanity signal for minimal benchmarks.
         """
+        if self._infra is not None:
+            try:
+                deleted = self._infra.cleanup_stale()
+                if deleted:
+                    logger.info(
+                        "%s.setup: cleanup_stale reclaimed %d expired resource(s) from prior runs",
+                        type(self).__name__,
+                        len(deleted),
+                    )
+            except Exception:
+                logger.warning(
+                    "%s.setup: cleanup_stale failed — continuing with setup",
+                    type(self).__name__,
+                    exc_info=True,
+                )
+
         self._setup()
         missing: list[str] = []
         if not self._runtime_context:

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -615,3 +615,83 @@ class _BenchWithRichDefaults(BenchmarkConfig):
     task_metadata = {"t1": TaskMetadata(id="t1")}
     task_config_class = _RichTaskConfig
     benchmark_class = MyBenchmark
+
+
+# ── Benchmark.setup() owns the cleanup_stale hook ─────────────────────────────
+
+
+def test_setup_calls_cleanup_stale_when_infra_set() -> None:
+    """Base ``Benchmark.setup()`` must call ``infra.cleanup_stale()`` before
+    dispatching to the subclass's ``_setup()``. Owns the "harness startup"
+    hook so cube authors don't have to remember it in every cube."""
+    from unittest.mock import MagicMock
+
+    from cube.resource import InfraConfig
+
+    infra = MagicMock(spec=InfraConfig)
+    infra.cleanup_stale.return_value = []
+
+    bench = MyBenchmarkConfig().make(infra=infra)
+    try:
+        infra.cleanup_stale.assert_called_once_with()
+    finally:
+        bench.close()
+
+
+def test_setup_skips_cleanup_stale_when_infra_none() -> None:
+    """No infra → no sweep. Local-only / Docker benchmarks must not require a
+    cloud API roundtrip at setup."""
+    bench = MyBenchmarkConfig().make()
+    bench.close()
+    # No assertion needed beyond "did not raise" — there is no infra to inspect.
+
+
+def test_setup_cleanup_stale_failure_does_not_block_setup() -> None:
+    """A transient cloud error from ``cleanup_stale`` must not block the
+    benchmark setup. The base logs at WARNING and proceeds to ``_setup()``."""
+    from unittest.mock import MagicMock
+
+    from cube.resource import InfraConfig
+
+    infra = MagicMock(spec=InfraConfig)
+    infra.cleanup_stale.side_effect = RuntimeError("transient cloud 503")
+
+    # Must not raise — failure is swallowed and logged.
+    bench = MyBenchmarkConfig().make(infra=infra)
+    bench.close()
+    infra.cleanup_stale.assert_called_once_with()
+
+
+def test_setup_cleanup_stale_called_before_subclass_setup() -> None:
+    """Ordering invariant: ``cleanup_stale()`` runs *before* ``_setup()``,
+    not after. New work must not be launched until prior orphans are reaped."""
+    from unittest.mock import MagicMock
+
+    from cube.resource import InfraConfig
+
+    call_order: list[str] = []
+    infra = MagicMock(spec=InfraConfig)
+    infra.cleanup_stale.side_effect = lambda: call_order.append("cleanup_stale") or []
+
+    class _OrderingTaskConfig(_TaskConfig):
+        """Per-benchmark TaskConfig (cube-standard requires each
+        BenchmarkConfig to declare its own subclass)."""
+
+    class _OrderingBench(Benchmark):
+        def _setup(self) -> None:
+            call_order.append("_setup")
+
+        def close(self) -> None:
+            pass
+
+    class _OrderingBenchConfig(BenchmarkConfig):
+        benchmark_metadata = BenchmarkMetadata(name="ordering", version="1", description="x")
+        task_metadata = {"t": TaskMetadata(id="t")}
+        task_config_class = _OrderingTaskConfig
+        benchmark_class = _OrderingBench
+
+    bench = _OrderingBenchConfig().make(infra=infra)
+    try:
+        assert call_order == ["cleanup_stale", "_setup"]
+    finally:
+        bench.close()


### PR DESCRIPTION
## Summary

Hoist the per-cube `infra.cleanup_stale()` call into the base `Benchmark.setup()` so cube authors don't have to remember it in every cube. The resource spec at [`openspec/specs/resource/spec.md:128`](openspec/specs/resource/spec.md#L128) already says `cleanup_stale` is the "harness startup" hook — this makes the spec real by giving the harness (via the base `setup()` wrapper) ownership of the call.

## Motivation

Today, 5 cubes each redundantly call `self._infra.cleanup_stale()` in their `_setup()`:

- `swebench-verified-cube`
- `swebench-live-cube`
- `terminalbench2-cube`
- `osworld-cube`  (added in cube-harness #422)
- `windows-agent-arena-cube`  (added in cube-harness #422)

Every new Azure-using cube must remember to do the same. That's a maintenance burr and a foot-gun. Aman flagged it: the cleanest design is option **D** — put it in the base.

## Behavior

```python
def setup(self) -> None:
    if self._infra is not None:
        try:
            deleted = self._infra.cleanup_stale()
            if deleted:
                logger.info("%s.setup: cleanup_stale reclaimed %d expired resource(s) from prior runs", ...)
        except Exception:
            logger.warning("%s.setup: cleanup_stale failed — continuing with setup", ..., exc_info=True)
    self._setup()
    ...  # existing missing-fields debug logging
```

- **Auto-runs for every benchmark** that has `self._infra` set.
- **Skipped for local/Docker** (`infra=None`) — no cloud API roundtrip.
- **Failures are isolated** — logged at WARNING, never block `_setup()`. A transient cloud error must not break benchmark setup.
- **Ordering invariant**: `cleanup_stale()` runs *before* `_setup()`. New work is not launched until prior orphans are reaped.
- **Concurrent benchmarks safe**: `cleanup_stale` only deletes resources whose `cube:expires_at` is in the past, so concurrent runs in the same RG are untouched.

## Spec updates (lean, no `openspec/changes/` folder)

- `benchmark/spec.md`: `setup()` description updated to document the hook ownership.
- `resource/spec.md`: cleanup_stale row points at `Benchmark.setup()`; the Recommended Harness Lifecycle no longer shows a separate `infra.cleanup_stale()` call before `benchmark.setup()`.

Per the established convention for small additive contract changes, this updates the living specs directly without a separate proposal+deltas folder.

## Tests

4 new unit tests in `tests/test_benchmark.py`:

- `test_setup_calls_cleanup_stale_when_infra_set` — happy path
- `test_setup_skips_cleanup_stale_when_infra_none` — local-only benchmarks
- `test_setup_cleanup_stale_failure_does_not_block_setup` — exception isolation
- `test_setup_cleanup_stale_called_before_subclass_setup` — ordering invariant

All 44 tests in `tests/test_benchmark.py` pass. The pre-existing test failure in `tests/test_infra_local.py::TestPodmanDockerHostNormalisation::test_environ_not_mutated_for_podman_host` is unrelated (missing `docker` package on this venv; reproduces on `origin/dev` without these changes).

## Follow-up

A cube-harness PR will drop the 5 now-redundant per-cube `cleanup_stale()` calls. Will be opened as draft with `Depends-on: cube-standard/refactor/cleanup-stale-base-setup` until this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)