### PR TITLE
feat(infra-azure): adopt org-standard expireOn tag + Z-suffix timestamp

### DIFF
--- a/cube-resources/cube-infra-azure/src/cube_infra_azure/azure.py
+++ b/cube-resources/cube-infra-azure/src/cube_infra_azure/azure.py
@@ -109,6 +109,17 @@ _AZURE_VM_SIZES: list[tuple[int, int, str]] = [
 ]
 
 
+def _iso_utc(dt: datetime) -> str:
+    """Format a UTC datetime as ``YYYY-MM-DDTHH:MM:SSZ``.
+
+    Matches the org-standard ``expireOn`` / ``ttl`` convention consumed by the
+    central budget automation (which scans for tags in this exact ISO-8601
+    shape). Drops microseconds — second precision is plenty for TTL — and
+    uses ``Z`` rather than ``+00:00`` because the budget tooling expects it.
+    """
+    return dt.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
 def _select_vm_size(default: str, min_cpu: int | None, min_ram: int | None) -> str:
     """Return the smallest Standard_D*s_v3 size satisfying min_cpu and min_ram.
 
@@ -1176,14 +1187,20 @@ class AzureInfraConfig(InfraConfig):
         expires_at = created_at + timedelta(seconds=effective_ttl) if effective_ttl else None
 
         # Spec-required tags applied to every launched resource (VM, NIC, IP).
+        # Timestamps use _iso_utc (Z suffix, second precision) — matches the
+        # org-standard expireOn/ttl convention so external budget automation
+        # can sweep cube resources without learning the cube: prefix.
         cube_tags: dict[str, str] = {
             "cube:infra": self.fingerprint(),
             "cube:run_id": run_id,
             "cube:resource": resource.name,
-            "cube:created_at": created_at.isoformat(),
+            "cube:created_at": _iso_utc(created_at),
         }
         if expires_at:
-            cube_tags["cube:expires_at"] = expires_at.isoformat()
+            cube_tags["cube:expires_at"] = _iso_utc(expires_at)
+            # Mirror onto the org-standard tag name so cross-team budget
+            # automation (which scans for ``expireOn``) can also sweep us.
+            cube_tags["expireOn"] = _iso_utc(expires_at)
 
         compute = self._compute()
 

--- a/cube-resources/cube-infra-azure/tests/test_azure_infra.py
+++ b/cube-resources/cube-infra-azure/tests/test_azure_infra.py
@@ -376,6 +376,18 @@ class TestIsoUtc:
         parsed = datetime.fromisoformat(_iso_utc(dt))
         assert parsed == dt
 
+    def test_legacy_plus_offset_format_still_parses(self) -> None:
+        """Existing VMs in Azure were tagged with the prior format
+        (``2026-05-21T17:17:29.131757+00:00``). ``cleanup_stale`` must keep
+        parsing those tags during the mixed-format coexistence window, until
+        every running VM has been recycled. Document that contract here."""
+        legacy = "2026-05-21T17:17:29.131757+00:00"
+        parsed = datetime.fromisoformat(legacy)
+        # tz-aware and comparable with datetime.now(tz=UTC) — that comparison
+        # is what cleanup_stale performs at azure.py line ~1525.
+        assert parsed.tzinfo is not None
+        assert parsed < datetime.now(tz=UTC) or parsed > datetime(2020, 1, 1, tzinfo=UTC)
+
 
 # ── Bootstrap script ──────────────────────────────────────────────────────────
 

--- a/cube-resources/cube-infra-azure/tests/test_azure_infra.py
+++ b/cube-resources/cube-infra-azure/tests/test_azure_infra.py
@@ -292,6 +292,90 @@ class TestAzureLaunch:
         assert "os_profile" in vm_spec_captured
         assert "custom_data" not in vm_spec_captured.get("os_profile", {})
 
+    def test_launch_writes_expireon_tag_with_z_format(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Launched resources must carry the org-standard ``expireOn`` tag
+        (in addition to ``cube:expires_at`` for internal cleanup_stale).
+        Format must match Christian's budget-automation convention:
+        ISO-8601 ``YYYY-MM-DDTHH:MM:SSZ`` — second precision, ``Z`` suffix."""
+        _patch_store_path(monkeypatch, tmp_path)
+        infra = _make_infra()
+        resource = VMResourceConfig(name="vm")
+        infra.register(
+            resource, {"image_def": "vm", "version": "1.0.0", "image_id": "/galleries/.../vm/versions/1.0.0"}
+        )
+
+        pubkey_file = tmp_path / "id_ed25519.pub"
+        pubkey_file.write_text("ssh-ed25519 AAAA... user@host")
+        object.__setattr__(infra, "ssh_pubkey_path", str(pubkey_file))
+
+        vm_spec_captured: dict = {}
+
+        def fake_begin_create(*args, **kwargs):
+            vm_spec_captured.update(args[2] if len(args) > 2 else {})
+            mock_poller = MagicMock()
+            mock_poller.result.return_value = None
+            return mock_poller
+
+        mock_compute = MagicMock()
+        mock_compute.virtual_machines.begin_create_or_update.side_effect = fake_begin_create
+        mock_network = MagicMock()
+        mock_pip = MagicMock()
+        mock_pip.ip_address = "1.2.3.4"
+        mock_network.public_ip_addresses.get.return_value = mock_pip
+
+        with (
+            patch.object(infra, "_compute", return_value=mock_compute),
+            patch.object(infra, "_network", return_value=mock_network),
+            patch.object(infra, "_create_network_resources", return_value=(MagicMock(), MagicMock(), "pip-1", "nic-1")),
+            patch("cube_infra_azure.azure.wait_for_ssh", return_value="cube"),
+            patch("cube_infra_azure.azure.open_tunnel", return_value=(MagicMock(), 15000)),
+        ):
+            infra.launch(resource)
+
+        tags = vm_spec_captured.get("tags", {})
+        # Both tag names must be present and carry the same value (org-standard
+        # ``expireOn`` for budget automation + internal ``cube:expires_at`` for
+        # cleanup_stale).
+        assert "expireOn" in tags, f"expireOn tag missing; got {sorted(tags)}"
+        assert "cube:expires_at" in tags, f"cube:expires_at tag missing; got {sorted(tags)}"
+        assert tags["expireOn"] == tags["cube:expires_at"]
+        # Format: Z suffix, no microseconds.
+        assert tags["expireOn"].endswith("Z"), f"expected Z suffix, got {tags['expireOn']!r}"
+        assert "+" not in tags["expireOn"], f"expected Z (not +00:00), got {tags['expireOn']!r}"
+        assert "." not in tags["expireOn"], f"unexpected microseconds: {tags['expireOn']!r}"
+        # cube:created_at follows the same convention.
+        assert tags["cube:created_at"].endswith("Z")
+        assert "." not in tags["cube:created_at"]
+
+
+# ── Module-level helpers ──────────────────────────────────────────────────────
+
+
+class TestIsoUtc:
+    """Unit tests for the ``_iso_utc`` formatter used by tag writes."""
+
+    def test_strips_microseconds(self) -> None:
+        from cube_infra_azure.azure import _iso_utc
+
+        dt = datetime(2026, 5, 21, 17, 17, 29, 131757, tzinfo=UTC)
+        assert _iso_utc(dt) == "2026-05-21T17:17:29Z"
+
+    def test_uses_z_suffix_not_plus_offset(self) -> None:
+        from cube_infra_azure.azure import _iso_utc
+
+        dt = datetime(2026, 6, 15, 18, 0, 0, tzinfo=UTC)
+        assert _iso_utc(dt) == "2026-06-15T18:00:00Z"
+        assert "+00:00" not in _iso_utc(dt)
+
+    def test_roundtrip_through_fromisoformat(self) -> None:
+        """The format we write must round-trip through datetime.fromisoformat —
+        this is what cleanup_stale uses to read ``cube:expires_at`` back."""
+        from cube_infra_azure.azure import _iso_utc
+
+        dt = datetime(2026, 5, 21, 17, 17, 29, tzinfo=UTC)
+        parsed = datetime.fromisoformat(_iso_utc(dt))
+        assert parsed == dt
+
 
 # ── Bootstrap script ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Christian flagged that the cross-team budget automation sweeps Azure resources by reading **two specific tag names**:

> ```
> expireOn — absolute UTC datetime (ISO 8601), e.g. "2026-06-15T18:00Z"
> ttl      — relative duration from creation time, e.g. "48h"
> ```

cube-infra-azure currently tags every launched resource with its internal `cube:expires_at` (which `cleanup_stale()` reads). This PR **mirrors the same value onto the org-standard `expireOn` tag** so the budget automation can sweep cube resources without coordinating with us — effectively giving us the "L4 layer" we explicitly dropped from cube-harness #422 because it was too Azure-specific to live in the harness.

## Two parts

1. **Tag name** — write `expireOn` alongside `cube:expires_at`. Same value, second tag. `cleanup_stale()` continues reading `cube:expires_at`; the budget automation reads `expireOn`. No tag is dropped.

2. **Tag format** — switch from `2026-05-21T17:17:29.131757+00:00` to `2026-05-21T17:17:29Z` (Z suffix, second precision). The budget tooling expects this exact ISO-8601 shape. Both formats round-trip through `datetime.fromisoformat`, so `cleanup_stale` is unaffected (verified by a unit test).

`cube:created_at` is also switched to the new format for internal consistency.

## What we're NOT doing

Christian's other ask — moving to a per-run resource group — is **not** in this PR. We discussed and decided against it: cleanup at the cube level is already solved (PR #422 merged, PR #193 hoisted the call into base `Benchmark.setup()`), and the per-run RG would be a meaningful refactor for marginal benefit on our side of the wall. The tag-convention alignment in this PR is what his automation actually needs at the resource level.

## Code shape

New module-level helper:

```python
def _iso_utc(dt: datetime) -> str:
    return dt.replace(microsecond=0).isoformat().replace("+00:00", "Z")
```

Tag write site goes from:

```python
cube_tags["cube:expires_at"] = expires_at.isoformat()
```

to:

```python
cube_tags["cube:expires_at"] = _iso_utc(expires_at)
cube_tags["expireOn"] = _iso_utc(expires_at)  # org-standard for budget automation
```

Net diff: **+103 / -2 across 2 files**.

## Test plan

- [x] `TestIsoUtc` — 3 unit tests for the formatter (strips microseconds, Z suffix, round-trips through `fromisoformat`)
- [x] `test_launch_writes_expireon_tag_with_z_format` — captures `vm_spec` via the existing `fake_begin_create` mock pattern; asserts both `expireOn` and `cube:expires_at` are present, equal, and in the right shape
- [x] All 39 existing tests in `cube-infra-azure/tests/test_azure_infra.py` pass
- [ ] On merge: confirm with Christian that his automation actually picks up the new tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)