### PR TITLE
feat(benchmark,task): add agent prompt hint + per-task clarification fields

### DIFF
--- a/docs/authoring-a-cube.markdown
+++ b/docs/authoring-a-cube.markdown
@@ -96,6 +96,51 @@ Every debug task must hit `reward == 1.0`. If one doesn't, either the debug acti
 
 `/review-cube` installs your package, runs pytest, runs `cube test`, audits against cube-standard invariants, and produces a Blocking / Suggestions report. Resolve everything in the Blocking section before submitting. Registry CI catches the same issues later, but locally is faster and less public.
 
+## Prompt hints and per-task clarifications
+
+Two optional metadata fields let benchmark authors steer how harnesses
+present tasks to the agent without rewriting the benchmark itself. Both
+are framework slots: `cube-standard` only declares them and ships them
+across the serialization boundary. Whether and how to surface them is the
+harness's call.
+
+**`BenchmarkMetadata.benchmark_hint_prompt`** — one concise paragraph the
+harness may prepend to every task in this benchmark. Use it when the
+benchmark has conventions a first-time reader would miss but that aren't
+specific to any single task: a high-level workflow, the shape of a
+verifier, a recurring ambiguity in the wording. Keep it short and
+generic. A generalist agent should remain competitive without it; the
+field exists so evaluations that opt in can report a number on a level
+playing field, not so authors can engineer prompts for any one model.
+Default: `None`.
+
+**`TaskMetadata.task_clarification`** — an optional short string a
+harness may append to the task objective, gated by
+`BenchmarkConfig.add_task_clarification`. Use it for individual brittle
+tasks whose original wording omits a step a reasonable LLM would not
+infer. Canonical example: a miniwob task whose objective reads "set
+slider to 32 and string value to 'foo'" but whose verifier only rewards
+if the agent then clicks submit — a competent LLM would not click submit
+unprompted, and that is not really the LLM's fault. Adding
+`task_clarification="After setting the values, click submit."` keeps the
+original benchmark wording intact while letting evaluations toggle the
+fix on. Populated over time by the `/auto-cube` workflow as it detects
+brittle tasks; left `None` for tasks whose wording is unambiguous.
+
+**`BenchmarkConfig.add_task_clarification`** — instance-level switch on
+the config. Default `False` so a run reproduces the original benchmark
+wording untouched and stays comparable with baselines that ignored these
+clarifications. Set `True` on the config when you want the run to apply
+all populated `task_clarification` strings.
+
+```python
+cfg = MyBenchmarkConfig(add_task_clarification=True)
+```
+
+Because both fields are metadata, third-party harnesses see them through
+the same serialization the rest of `TaskMetadata` / `BenchmarkMetadata`
+uses — no extra plumbing on the cube side.
+
 ## Iterate (real LLMs find what the debug suite can't)
 
 `cube test` validates with the **Debug** agent — deterministic action sequences, no LLM. Real LLMs find a different class of issue: infra flakes, scaffold bugs, tasks that are *technically* solvable but practically impossible, scoring that's too strict or too lenient, hidden environmental assumptions, and sometimes problems in the benchmark itself (ambiguous prompts, broken ground truth, contaminated training data leaking into the task description).

--- a/openspec/specs/benchmark/spec.md
+++ b/openspec/specs/benchmark/spec.md
@@ -33,11 +33,21 @@ class BenchmarkMetadata(TypedBaseModel):
     tags: list[str] = []
     reset_isolation: ResetIsolation | None = None  # snapshot/restart/app_level/new_instance
     named_subsets: dict[str, tuple[str, str]] = {} # name → (glob_key, glob_pattern)
+    benchmark_hint_prompt: str | None = None       # optional benchmark-wide prompt hint
 ```
 
 Cube authors needing additional benchmark-level fields subclass
 `BenchmarkMetadata` with named typed fields. The base class accepts only
 the framework-defined fields above.
+
+`benchmark_hint_prompt` is a concise, generic hint a harness may prepend
+to the agent's prompt for any task in this benchmark — e.g. a short
+workflow summary or a clarification of conventions shared across tasks.
+Keep it short and generic: a generalist agent should remain competitive
+without it; the field exists so benchmarks with unusual conventions can
+opt into a level playing field for evaluations that report numbers with
+the hint applied. The framework only declares the slot — actual prompt
+assembly happens in the harness.
 
 `reset_isolation` is informational for harness users to reason about parallelism:
 - `SNAPSHOT` — VM reverts to savestate (~5s)
@@ -82,7 +92,15 @@ task_ids: list[str] | None = None          # None = all; populated by subset_fro
 resources: list[ResourceConfig] = []       # resource dependencies (L2/L3)
 tool_config: ToolConfig | None             # applied to every task by the default get_task_configs(); override get_task_configs() for per-task variation
 seed_generator: AbstractSeedGenerator | None # yields seeds per TaskMetadata
+add_task_clarification: bool = False       # surface TaskMetadata.task_clarification to the agent
 ```
+
+`add_task_clarification` opts a run into the per-task clarifications
+declared on `TaskMetadata.task_clarification` (see
+[task/spec.md](../task/spec.md)). Default `False` so a run reproduces the
+original benchmark wording untouched and stays comparable with baselines
+that ignored these clarifications. Harnesses interpret the flag during
+prompt assembly; the framework only carries the intent.
 
 Per-task container needs are declared via `TaskMetadata.container_config`
 (`ContainerConfig`) and provisioned through the injected `InfraConfig` — see

--- a/openspec/specs/task/spec.md
+++ b/openspec/specs/task/spec.md
@@ -19,6 +19,7 @@ class TaskMetadata(TypedBaseModel):
     abstract_description: str = ""             # for search/filtering only — NOT the objective
     recommended_max_steps: int | None = None   # harness hint, not enforced
     container_config: ContainerConfig | None = None
+    task_clarification: str | None = None      # optional opt-in clarification (see below)
 ```
 
 `TaskMetadata` is the lightweight, eager-loaded view of a task: it ships in
@@ -34,6 +35,19 @@ scripts, …) lives on a `TaskExecutionInfo` subclass surfaced via
 
 The actual task objective is surfaced in the first `Observation` returned by `reset()`.
 `abstract_description` is for tooling (search, subsetting), never to be shown to the agent.
+
+`task_clarification` is an optional short string a harness may append to
+the task objective **only when** the owning
+`BenchmarkConfig.add_task_clarification` is `True` (see
+[benchmark/spec.md](../benchmark/spec.md)). Populated over time for
+brittle tasks whose original wording omits a step a reasonable LLM would
+not infer — for instance a miniwob task whose objective reads "set slider
+to 32 and string value to 'foo'" but whose verifier only rewards if the
+agent then clicks submit. Storing the fix as metadata keeps the original
+benchmark wording intact and lets evaluations toggle the clarifications
+on or off without forking the benchmark. Leave `None` for tasks whose
+wording is unambiguous. The framework only declares the slot — actual
+prompt assembly happens in the harness.
 
 ### `TaskExecutionInfo` (serializable)
 ```python

--- a/src/cube/benchmark.py
+++ b/src/cube/benchmark.py
@@ -127,6 +127,17 @@ class BenchmarkMetadata(TypedBaseModel):
             "Example: {'train_only': ('split', 'train')}"
         ),
     )
+    benchmark_hint_prompt: str | None = Field(
+        default=None,
+        description=(
+            "Optional concise hint a harness may prepend to the agent's prompt to "
+            "orient it on this benchmark — e.g. a one-paragraph workflow or a "
+            "clarification of conventions that apply to every task. Keep it short "
+            "and as generic as possible: a generalist agent should remain "
+            "competitive without it. The framework does not deliver this string "
+            "to the agent itself; harnesses decide whether and how to surface it."
+        ),
+    )
 
 
 class BenchmarkConfig[TTMetadata: TaskMetadata](ValidatedConfig, ABC):
@@ -204,6 +215,17 @@ class BenchmarkConfig[TTMetadata: TaskMetadata](ValidatedConfig, ABC):
     seed_generator: SerializeAsAny[AbstractSeedGenerator] | None = Field(
         default=None,
         description="Optional seed generator yielding per-task seeds during get_task_configs().",
+    )
+    add_task_clarification: bool = Field(
+        default=False,
+        description=(
+            "When True, harnesses should surface ``TaskMetadata.task_clarification`` "
+            "(when populated) alongside the task objective so the agent sees the "
+            "added wording. Defaults to False so a run reproduces the original "
+            "benchmark wording untouched; flip on to evaluate with curated "
+            "per-task clarifications applied. The framework only declares the "
+            "intent — actual prompt assembly happens in the harness."
+        ),
     )
 
     # ──────────────────────────────────────────────────────────────────────────

--- a/src/cube/task.py
+++ b/src/cube/task.py
@@ -93,6 +93,7 @@ class TaskMetadata(TypedBaseModel):
         abstract_description (str): Broad description of the task for searching and filtering only. The task objective is part of the first Observation returned by task.reset(). (default: "")
         recommended_max_steps (int | None): Recommended maximum number of steps to help harness prevent infinite running agents. Not a hard limit, the task can still run longer if needed. (default: None)
         container_config (ContainerConfig | None): Optional container configuration for this task (default: None, meaning no container needed).
+        task_clarification (str | None): Optional short clarification a harness may append to the task objective when ``BenchmarkConfig.add_task_clarification`` is True (default: None).
     """
 
     id: str = Field(..., description="Unique task identifier")
@@ -108,6 +109,19 @@ class TaskMetadata(TypedBaseModel):
     container_config: ContainerConfig | None = Field(
         default=None,
         description="Optional container configuration for this task (defaults to None, meaning no container needed).",
+    )
+    task_clarification: str | None = Field(
+        default=None,
+        description=(
+            "Optional short clarification a harness may append to the task "
+            "objective when the owning ``BenchmarkConfig.add_task_clarification`` "
+            "is True. Intended for brittle tasks whose original wording omits a "
+            "step a reasonable LLM would not infer (e.g. an instruction that does "
+            "not say to click submit when the verifier requires submit to be "
+            "clicked). Populated over time as auto-cube agents detect these "
+            "cases; left None for tasks whose wording is unambiguous. Stored as "
+            "metadata so the original benchmark wording stays untouched."
+        ),
     )
 
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -92,7 +92,28 @@ def test_benchmark_metadata_defaults():
         requirements={},
         named_subsets={},
         reset_isolation=None,
+        benchmark_hint_prompt=None,
     )
+
+
+def test_benchmark_metadata_hint_prompt_round_trips():
+    bm = BenchmarkMetadata(
+        name="foo",
+        version="1.0",
+        description="bar",
+        benchmark_hint_prompt="Submit your final answer with final_step.",
+    )
+    reloaded = BenchmarkMetadata.model_validate_json(bm.model_dump_json())
+    assert reloaded.benchmark_hint_prompt == "Submit your final answer with final_step."
+
+
+def test_benchmark_config_add_task_clarification_defaults_false():
+    cfg = MyBenchmarkConfig()
+    assert cfg.add_task_clarification is False
+    enabled = MyBenchmarkConfig(add_task_clarification=True)
+    assert enabled.add_task_clarification is True
+    reloaded = MyBenchmarkConfig.model_validate_json(enabled.model_dump_json())
+    assert reloaded.add_task_clarification is True
 
 
 # ── __init_subclass__ validation ──────────────────────────────────────────────

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -101,6 +101,7 @@ _TASK_META_1 = {
     "abstract_description": "",
     "recommended_max_steps": None,
     "container_config": None,
+    "task_clarification": None,
 }
 
 _TASK_META_2 = {**_TASK_META_1, "id": "task-2"}
@@ -176,6 +177,7 @@ def test_benchmark_info(bench_client):
         "tags": [],
         "reset_isolation": None,
         "named_subsets": {},
+        "benchmark_hint_prompt": None,
     }
 
 

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -54,7 +54,14 @@ def test_task_metadata_defaults():
         abstract_description="",
         recommended_max_steps=None,
         container_config=None,
+        task_clarification=None,
     )
+
+
+def test_task_metadata_clarification_round_trips():
+    tm = TaskMetadata(id="my-task", task_clarification="After setting values, click submit.")
+    reloaded = TaskMetadata.model_validate_json(tm.model_dump_json())
+    assert reloaded.task_clarification == "After setting values, click submit."
 
 
 # --- Task.reset ---


### PR DESCRIPTION
## Summary

Adds three optional metadata slots so harnesses can present benchmarks more fairly without rewriting them. cube-standard only declares the slots and ships them across the serialization boundary — actual prompt assembly remains the harness's job.

- **`BenchmarkMetadata.benchmark_hint_prompt: str | None = None`** — concise, generic hint the harness may prepend to every task in a benchmark (e.g. a short workflow or shared convention). Keep it short: a generalist agent should remain competitive without it.
- **`TaskMetadata.task_clarification: str | None = None`** — optional short clarification for individual brittle tasks whose wording omits a step a reasonable LLM would not infer (e.g. a miniwob objective that says "set slider to 32 and string value to 'foo'" but whose verifier only rewards if submit is clicked). Populated over time by the `/auto-cube` workflow.
- **`BenchmarkConfig.add_task_clarification: bool = False`** — instance-level opt-in switch. Defaults to `False` so runs reproduce the original benchmark wording and stay comparable with prior baselines.

Specs updated in `openspec/specs/{benchmark,task}/spec.md`. New "Prompt hints and per-task clarifications" section in `docs/authoring-a-cube.markdown` explains the rationale and when to populate each field.

## Test plan

- [x] `make lint` clean
- [x] `make test` — full unit suite passes (427/427; the 1 pre-existing `test_infra_local` failure is an unrelated missing-`docker`-module env issue on this machine)
- [x] New unit tests cover defaults and JSON round-trips for both metadata fields and the new `BenchmarkConfig` flag
- [x] Updated `test_server.py` expected dumps to include the new keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)