### PR TITLE
feat(benchmark,task): stamp benchmark prompt context onto TaskConfig

### DIFF
--- a/openspec/specs/benchmark/spec.md
+++ b/openspec/specs/benchmark/spec.md
@@ -47,7 +47,9 @@ Keep it short and generic: a generalist agent should remain competitive
 without it; the field exists so benchmarks with unusual conventions can
 opt into a level playing field for evaluations that report numbers with
 the hint applied. The framework only declares the slot — actual prompt
-assembly happens in the harness.
+assembly happens in the harness, which reads it from each emitted config's
+`benchmark_prompt_context.hint_prompt` (stamped by `get_task_configs()`; see
+below).
 
 `reset_isolation` is informational for harness users to reason about parallelism:
 - `SNAPSHOT` — VM reverts to savestate (~5s)
@@ -100,7 +102,8 @@ declared on `TaskMetadata.task_clarification` (see
 [task/spec.md](../task/spec.md)). Default `False` so a run reproduces the
 original benchmark wording untouched and stays comparable with baselines
 that ignored these clarifications. Harnesses interpret the flag during
-prompt assembly; the framework only carries the intent.
+prompt assembly; the framework only carries the intent — copied onto each
+emitted `TaskConfig.benchmark_prompt_context` by `get_task_configs()`.
 
 Per-task container needs are declared via `TaskMetadata.container_config`
 (`ContainerConfig`) and provisioned through the injected `InfraConfig` — see
@@ -131,7 +134,9 @@ happens.
 - `name` (property) — `self.benchmark_metadata.name`.
 - `get_task_configs()` → `Generator[TaskConfig]` — yields one
   `task_config_class` per task in `tasks()`, expanding via `seed_generator` if
-  set.
+  set. Stamps each emitted config with its `TaskMetadata` and a
+  `BenchmarkPromptContext` (`benchmark_hint_prompt` + `add_task_clarification`)
+  so the worker can assemble the agent prompt without the owning config.
 - `subset_from_list(tasks, benchmark_name_suffix="custom")` → `Self` (same
   subclass, new instance) with `task_ids` populated. Accepts ids or `TaskMetadata` objects.
   Duplicates deduped (first-wins order).

--- a/openspec/specs/task/spec.md
+++ b/openspec/specs/task/spec.md
@@ -47,7 +47,9 @@ agent then clicks submit. Storing the fix as metadata keeps the original
 benchmark wording intact and lets evaluations toggle the clarifications
 on or off without forking the benchmark. Leave `None` for tasks whose
 wording is unambiguous. The framework only declares the slot — actual
-prompt assembly happens in the harness.
+prompt assembly happens in the harness, which reads the toggle from the
+config's `benchmark_prompt_context.add_task_clarification` (stamped at spawn,
+see `TaskConfig` below).
 
 ### `TaskExecutionInfo` (serializable)
 ```python
@@ -211,6 +213,7 @@ class TaskConfig[TTMetadata: TaskMetadata](TypedBaseModel, ABC):
     seed: int | None = None
     tool_config: SerializeAsAny[ToolConfig] | None = None
     sub_bench_name: str | None = None            # composite routing hint (see below)
+    benchmark_prompt_context: BenchmarkPromptContext  # benchmark-level prompt context, stamped at spawn
 
     @property
     def task_id(self) -> str:
@@ -247,6 +250,16 @@ emitted config by `BenchmarkConfig.get_task_configs()` on the driver).
 `make()` uses `self.metadata` directly; no import of the owning
 `BenchmarkConfig` is needed on the worker. This is the single most important
 invariant of the layer: the serialization boundary is self-describing.
+
+**Benchmark-level prompt context.** `benchmark_prompt_context`
+(`BenchmarkPromptContext`) mirrors the two benchmark-level prompt fields onto
+the config at spawn so the boundary stays self-describing for prompt assembly
+too: `hint_prompt` (from `BenchmarkMetadata.benchmark_hint_prompt`) and
+`add_task_clarification` (from `BenchmarkConfig.add_task_clarification`). It is
+stamped by `get_task_configs()`; a `TaskConfig` constructed directly defaults
+to an empty context. The framework only carries these values — whether and how
+they reach the agent is the harness's decision (see
+[benchmark/spec.md](../benchmark/spec.md)).
 
 Subclasses that carry heavy install-time data (e.g. SWE-bench problem
 statements, OSWorld evaluator configs) declare a `TaskExecutionInfo`

--- a/src/cube/benchmark.py
+++ b/src/cube/benchmark.py
@@ -65,7 +65,7 @@ from cube import get_cache_dir
 from cube.core import TypedBaseModel, ValidatedConfig
 from cube.resource import InfraConfig, ResourceConfig
 from cube.seed import AbstractSeedGenerator
-from cube.task import RuntimeContext, Task, TaskConfig, TaskMetadata
+from cube.task import BenchmarkPromptContext, RuntimeContext, Task, TaskConfig, TaskMetadata
 from cube.tool import ToolConfig
 
 logger = logging.getLogger(__name__)
@@ -492,14 +492,20 @@ class BenchmarkConfig[TTMetadata: TaskMetadata](ValidatedConfig, ABC):
     def get_task_configs(self) -> Generator[TaskConfig, None, None]:
         """Yield one ``TaskConfig`` per task (expanded by seed_generator if set).
 
-        Stamps full ``TaskMetadata`` onto each emitted config so workers never
-        need to import the owning ``BenchmarkConfig`` class to resolve metadata.
+        Stamps full ``TaskMetadata`` and a ``BenchmarkPromptContext`` (the
+        benchmark hint prompt + clarification toggle) onto each emitted config
+        so workers never need to import the owning ``BenchmarkConfig`` class to
+        resolve metadata or assemble the agent prompt.
 
         Cubes with heavy execution data (problem statements, patches, …)
         populate ``Task.execution_info`` inside ``TaskConfig.make()`` by
         validating ``self.load_task_execution_info()`` against a typed
         ``TaskExecutionInfo`` subclass — no override of this method needed.
         """
+        prompt_context = BenchmarkPromptContext(
+            hint_prompt=self.benchmark_metadata.benchmark_hint_prompt,
+            add_task_clarification=self.add_task_clarification,
+        )
         for tm in self.tasks().values():
             if self.seed_generator is not None:
                 for seed in self.seed_generator(tm):
@@ -507,12 +513,14 @@ class BenchmarkConfig[TTMetadata: TaskMetadata](ValidatedConfig, ABC):
                         metadata=tm,
                         tool_config=self.tool_config,
                         seed=seed,
+                        benchmark_prompt_context=prompt_context,
                     )
             else:
                 yield self.task_config_class(
                     metadata=tm,
                     tool_config=self.tool_config,
                     seed=None,
+                    benchmark_prompt_context=prompt_context,
                 )
 
     # ──────────────────────────────────────────────────────────────────────────

--- a/src/cube/task.py
+++ b/src/cube/task.py
@@ -446,6 +446,36 @@ class Task(TypedBaseModel, Generic[TTMetadata, TTool], ABC):
             self._container = None
 
 
+class BenchmarkPromptContext(TypedBaseModel):
+    """Benchmark-level prompt context stamped onto each ``TaskConfig`` by
+    ``BenchmarkConfig.get_task_configs()``.
+
+    A worker only ever sees a ``TaskConfig`` (live ``Benchmark`` objects never
+    cross the process boundary), so the benchmark-level prompt fields are
+    copied here at spawn time. This lets a harness assemble the agent prompt
+    from the config alone, without importing the owning ``BenchmarkConfig``.
+    The framework only carries these values; the harness decides whether and
+    how to surface them (see benchmark/spec.md).
+    """
+
+    hint_prompt: str | None = Field(
+        default=None,
+        description=(
+            "Mirror of ``BenchmarkMetadata.benchmark_hint_prompt`` — a concise, "
+            "generic orientation hint a harness may prepend to the agent's "
+            "prompt for every task in this benchmark."
+        ),
+    )
+    add_task_clarification: bool = Field(
+        default=False,
+        description=(
+            "Mirror of ``BenchmarkConfig.add_task_clarification`` — when True, "
+            "harnesses should surface ``TaskMetadata.task_clarification`` "
+            "(when populated) alongside the task objective."
+        ),
+    )
+
+
 class TaskConfig[TTMetadata: TaskMetadata](ABC, TypedBaseModel):
     """Serializable task configuration — self-contained unit handed to workers.
 
@@ -500,6 +530,15 @@ class TaskConfig[TTMetadata: TaskMetadata](ABC, TypedBaseModel):
             "Names the sub-benchmark this task originated from; "
             "``CompositeBenchmark.spawn()`` uses it to route to the right sub-benchmark's "
             "runtime_context. None for standalone (non-composite) benchmarks."
+        ),
+    )
+    benchmark_prompt_context: BenchmarkPromptContext = Field(
+        default_factory=BenchmarkPromptContext,
+        description=(
+            "Benchmark-level prompt context (hint prompt + clarification toggle) "
+            "stamped by ``BenchmarkConfig.get_task_configs()``. Defaults to an "
+            "empty context, so a config constructed directly (outside the spawn "
+            "path) stays backward-compatible and surfaces no extra prompt text."
         ),
     )
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -294,6 +294,38 @@ def test_get_task_configs_stamps_metadata_on_each_config():
     assert configs["t4"].metadata == MyBenchmarkConfig.task_metadata["t4"]
 
 
+def test_get_task_configs_prompt_context_defaults_empty():
+    """Default benchmark: each config gets an empty prompt context (no hint, toggle off)."""
+    for cfg in MyBenchmarkConfig().get_task_configs():
+        assert cfg.benchmark_prompt_context.hint_prompt is None
+        assert cfg.benchmark_prompt_context.add_task_clarification is False
+
+
+def test_get_task_configs_stamps_prompt_context_and_round_trips():
+    """The benchmark hint prompt and clarification toggle are copied onto every
+    emitted config and survive a JSON round-trip across the worker boundary."""
+
+    class _HintedBenchmarkConfig(MyBenchmarkConfig):
+        benchmark_metadata = BenchmarkMetadata(
+            name="MyBenchmark",
+            version="2.0.0",
+            description="Test benchmark",
+            num_tasks=4,
+            benchmark_hint_prompt="Use the filter UI, not column clicks.",
+        )
+
+    configs = list(_HintedBenchmarkConfig(add_task_clarification=True).get_task_configs())
+    assert configs  # non-empty
+    for cfg in configs:
+        ctx = cfg.benchmark_prompt_context
+        assert ctx.hint_prompt == "Use the filter UI, not column clicks."
+        assert ctx.add_task_clarification is True
+
+    reloaded = _TaskConfig.model_validate_json(configs[0].model_dump_json())
+    assert reloaded.benchmark_prompt_context.hint_prompt == "Use the filter UI, not column clicks."
+    assert reloaded.benchmark_prompt_context.add_task_clarification is True
+
+
 def test_get_task_configs_honours_subset():
     cfg = MyBenchmarkConfig().subset_from_list(["t1", "t3"])
     configs = list(cfg.get_task_configs())


### PR DESCRIPTION
## What

Adds `BenchmarkPromptContext` (the benchmark **hint prompt** + the
**`add_task_clarification` toggle**) and stamps it onto every emitted
`TaskConfig` in `get_task_configs()`, mirroring how `TaskMetadata` is already
stamped.

## Why

A worker only ever sees a `TaskConfig` — live `Benchmark` objects never cross
the process boundary. The benchmark-level prompt slots merged earlier
(`BenchmarkMetadata.benchmark_hint_prompt`, `BenchmarkConfig.add_task_clarification`)
therefore can't reach a harness at run time today. Copying them onto the config
at spawn keeps the serialization boundary **self-describing for prompt assembly**:
a harness can prepend the benchmark hint and surface per-task clarifications from
the config alone, without importing the owning `BenchmarkConfig`.

The framework only *carries* these values — whether and how they reach the agent
stays the harness's decision (consumed in a follow-up cube-harness PR).

## Invariant / compatibility

- Defaults to an **empty context**, so a `TaskConfig` constructed directly
  (outside the spawn path) is unchanged and surfaces no extra prompt text.
- Composite benchmarks inherit each task's **originating sub-benchmark** context
  automatically via the existing `model_copy` in
  `CompositeBenchmarkConfig.get_task_configs()` — exactly right, since the hint
  and toggle belong to the originating benchmark, not the composite wrapper.

## Tests

`tests/test_benchmark.py`: default config → empty context on each emitted config;
populated hint + toggle-on → stamped on every config and survives a JSON
round-trip across the worker boundary. Specs updated (`task`, `benchmark`).

---

First of the hinter-use-case series; unblocks the cube-harness PR that consumes
these fields (clarification append at the episode boundary + `benchmark_hint_prompt`
→ system prompt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)