### PR TITLE
docs(openspec): guide proposals to be concise

### DIFF
--- a/.claude/commands/update-openspec.md
+++ b/.claude/commands/update-openspec.md
@@ -35,12 +35,15 @@ Focus on layers relevant to the current change, or all layers for a full audit.
 
 ## Decision rule
 
-**Minor drift** (1–3 spec lines, no contract change): edit the spec directly.
+**Default: edit the spec directly** and describe the change in the PR. Additive,
+backward-compatible drift (a new method, a new optional field, a corrected invariant)
+needs no proposal folder — just keep the living spec accurate.
 
-**Substantive drift** (new capability, breaking change, or multiple invariants affected):
-create `openspec/changes/<name>/` with `proposal.md` + `deltas.md` (ADDED / MODIFIED / REMOVED
-sections in target-state language) before editing the spec. This signals to the team that
-a real contract change is in flight.
+**Open a `changes/<name>/` folder only for breaking or multi-invariant contract
+changes** — a changed/removed signature, a new required field, behavior the team needs
+to see before code lands. It carries `proposal.md` + `deltas.md` (ADDED / MODIFIED /
+REMOVED, target-state language). Keep the proposal proportional to the change and
+skimmable — see `openspec/README.md` § "Writing a proposal".
 
 ## Output
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ issue. Flag, don't hard-block. Methodology (Fix Report, L0–L3, lint):
 1. **Find the relevant spec** — which layer? Start there.
 2. **Read the spec's "Invariants" and "Gotchas" sections** — these are the traps.
 3. **Check for an active change** in `openspec/changes/` — someone may already be working on this.
-4. **For substantive changes to a spec's contract**, write a delta spec in `openspec/changes/<name>/deltas.md` first (ADDED / MODIFIED / REMOVED requirements) before coding.
+4. **For breaking or multi-invariant contract changes**, open `openspec/changes/<name>/` (`proposal.md` + `deltas.md`) before coding; additive changes just edit the spec. Keep proposals concise — see [openspec/README.md](openspec/README.md) § "Writing a proposal".
 5. **For completed changes**, move the folder to `openspec/changes/archive/YYYY-MM-DD-<name>/` and apply deltas to the main spec.
 
 ## Package layout

--- a/openspec/README.md
+++ b/openspec/README.md
@@ -47,7 +47,7 @@ removes a method — create a delta spec in `openspec/changes/<name>/`:
 
 ```
 openspec/changes/my-change/
-├── proposal.md    # one-page: problem, proposed change, alternatives
+├── proposal.md    # problem, change, alternatives — see "Writing a proposal" below
 └── deltas.md      # structured diff against the current spec
 ```
 
@@ -56,6 +56,30 @@ before code lands. Post a link in the team channel when you open the PR.
 
 When the change merges, move the folder to `openspec/changes/archive/YYYY-MM-DD-<name>/`
 and apply the deltas to the main spec.
+
+---
+
+## Writing a proposal
+
+`proposal.md` is point-in-time — written before the change, not maintained afterward.
+No version header, no "aligned with implementation" changelog; once merged, the spec
+carries the contract.
+
+Length scales with complexity — there is no fixed cap. Favor skimmable structure over prose:
+
+- **Keep** schemas, signatures, and code blocks. A signature or a JSON schema skims
+  faster than the paragraph that would describe it.
+- **Show each thing once.** Don't pair a state diagram *and* a prose table of the same
+  transitions, or a coverage matrix *and* a paragraph per test — keep the representation
+  that reads best, delete the other.
+- **Rationale is the decision plus one line of why,** not an essay defending it.
+- **Leave working scaffolding out of the commit** — "resolved questions" logs and
+  exhaustive test matrices belong in the PR thread or the test files; a short *Testing*
+  note is enough.
+
+Sections: **Problem** (what breaks today) · **Proposed solution** (the contract, via
+schemas/signatures) · **Alternatives** (bullets). Add *Scope* / *Testing* only when they
+carry real weight.
 
 ---
 


### PR DESCRIPTION
## Problem

Change proposals in `openspec/changes/*/proposal.md` have been ballooning to 500–700 lines (`core-extensions` 688, `trajectory-judge` 644, `episode-status` 573) — while `openspec/README.md` claims a proposal is "one-page". That contract is asserted but never enforced.

The verbosity isn't in the structure. Schemas, signatures, and code blocks skim fast and earn their space. The bloat is **prose and redundancy**: the same state machine shown three ways (status table + mermaid diagram + prose transition table), a coverage matrix *and* a paragraph per test, "resolved questions" logs, and `Version 0.4 — aligned with implementation` changelogs that turn a point-in-time artifact into a living doc duplicating the spec.

## Change

Docs-only, three surfaces:

- **`openspec/README.md`** — new **"Writing a proposal"** section: keep schemas/signatures/code blocks, show each thing once, rationale = decision + one line, leave working scaffolding (resolved-questions logs, exhaustive test matrices) in the PR/test files. Length scales with complexity — no fixed cap.
- **`.claude/commands/update-openspec.md`** — loosen the decision rule: additive, backward-compatible drift edits the spec directly; reserve the `changes/` folder for breaking or multi-invariant contract changes.
- **`CLAUDE.md`** — dedupe the workflow step to point at the canonical README instead of restating the mechanics.

No spec contracts change; no existing proposals are rewritten here.

## Note

This is the pilot repo. The matching `/update-openspec` change and the `constitution.md` RFC-process trim (drop optional `design.md`/`tasks.md`) land separately in cube-harness if this direction looks right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
