### PR TITLE
refactor(resource): unify single-container config — ContainerConfig becomes a ResourceConfig in cube.resource

### DIFF
--- a/examples/toy_benchmark/counter.py
+++ b/examples/toy_benchmark/counter.py
@@ -11,10 +11,10 @@ from collections.abc import Generator
 from typing import Any, ClassVar, Dict, Literal, Tuple
 
 from cube.benchmark import Benchmark, BenchmarkConfig, BenchmarkMetadata, RuntimeContext
-from cube.container import Container, ContainerConfig
+from cube.container import Container
 from cube.core import Action, ActionSchema, Observation
 from cube.infra_local import LocalInfraConfig
-from cube.resource import InfraConfig
+from cube.resource import ContainerConfig, InfraConfig
 from cube.task import Task, TaskConfig, TaskMetadata
 from cube.tool import Tool, ToolConfig, tool_action
 

--- a/scripts/smoke/container_config_smoke.py
+++ b/scripts/smoke/container_config_smoke.py
@@ -1,19 +1,14 @@
 #!/usr/bin/env python3
-"""Smoke: ContainerConfig folded into the ResourceConfig family (Phase 1 unify).
+"""Smoke: ``ContainerConfig`` serialization across committed metadata + end-to-end launch.
 
-Background
-==========
-``ContainerConfig`` used to be a standalone ``TypedBaseModel``; the orphan
-``DockerImageConfig`` was a parallel single-image ``ResourceConfig`` (defined, never
-launched by any infra). The unification made ``ContainerConfig`` a ``ResourceConfig``
-— so it joins the capability handshake (``requirements()`` / ``InfraConfig.can_serve``)
-— deleted ``DockerImageConfig``, and moved ``ContainerConfig`` to ``cube.resource``
-(re-exported from ``cube.container`` for back-compat).
-
-The risk surface is **serialization**: already-committed ``task_metadata.json`` entries
-carry ``"_type": "cube.container.ContainerConfig"`` and were serialized *before* both
-the move and the now-inherited (required on ``ResourceConfig``) ``name`` field. They
-must still deserialize — via the re-export, defaulting ``name`` — without regeneration.
+``ContainerConfig`` is a ``ResourceConfig`` living in ``cube.resource`` (re-exported
+from ``cube.container`` for back-compat), so it shares the capability handshake
+(``requirements()`` / ``InfraConfig.can_serve``). The fragile surface is
+**serialization**: thousands of committed ``task_metadata.json`` entries embed a
+``ContainerConfig`` and must keep deserializing across schema/location changes —
+including legacy ``"_type": "cube.container.ContainerConfig"`` blobs (resolved via the
+re-export) and ones serialized before ``ContainerConfig`` inherited the required
+``name`` field. This smoke guards that, plus the local-docker launch path.
 
 What it does
 ============
@@ -41,9 +36,9 @@ How to read the output
 
 Run from the cube-standard repo root::
 
-    uv run scripts/smoke/container_config_unify.py
-    uv run scripts/smoke/container_config_unify.py --cube-harness /path/to/cube-harness
-    uv run scripts/smoke/container_config_unify.py --no-launch
+    uv run scripts/smoke/container_config_smoke.py
+    uv run scripts/smoke/container_config_smoke.py --cube-harness /path/to/cube-harness
+    uv run scripts/smoke/container_config_smoke.py --no-launch
 """
 
 from __future__ import annotations
@@ -64,7 +59,7 @@ from cube.task_infra import launch_task_container
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 log = logging.getLogger("cc-unify-smoke")
 
-NAME = "container_config_unify"
+NAME = "container_config_smoke"
 CURRENT_TYPE = "cube.resource.ContainerConfig"  # canonical home after the move
 LEGACY_TYPE = "cube.container.ContainerConfig"  # pre-move; still resolves via the re-export shim
 LAUNCH_IMAGE = "python:3.12-slim"

--- a/scripts/smoke/container_config_unify.py
+++ b/scripts/smoke/container_config_unify.py
@@ -5,27 +5,28 @@ Background
 ==========
 ``ContainerConfig`` used to be a standalone ``TypedBaseModel``; the orphan
 ``DockerImageConfig`` was a parallel single-image ``ResourceConfig`` (defined, never
-launched by any infra). Phase 1 made ``ContainerConfig`` a ``ResourceConfig`` — so it
-joins the capability handshake (``requirements()`` / ``InfraConfig.can_serve``) — and
-deleted ``DockerImageConfig``.
+launched by any infra). The unification made ``ContainerConfig`` a ``ResourceConfig``
+— so it joins the capability handshake (``requirements()`` / ``InfraConfig.can_serve``)
+— deleted ``DockerImageConfig``, and moved ``ContainerConfig`` to ``cube.resource``
+(re-exported from ``cube.container`` for back-compat).
 
-The risk surface is **serialization**: thousands of already-committed
-``task_metadata.json`` entries carry ``"_type": "cube.container.ContainerConfig"`` and
-were serialized *before* the now-inherited (and required on ``ResourceConfig``)
-``name`` field existed. They must still deserialize without regeneration.
+The risk surface is **serialization**: already-committed ``task_metadata.json`` entries
+carry ``"_type": "cube.container.ContainerConfig"`` and were serialized *before* both
+the move and the now-inherited (required on ``ResourceConfig``) ``name`` field. They
+must still deserialize — via the re-export, defaulting ``name`` — without regeneration.
 
 What it does
 ============
 Part A — serialization (always runs, no docker):
   1. Invariants — ``ContainerConfig`` is-a ``ResourceConfig``; ``requirements() == {"docker"}``
      (``+ "gpu:nvidia"`` when ``gpu=True``); a docker-capable infra ``can_serve`` it, a
-     non-docker one does not; the ``_type`` tag stays ``cube.container.ContainerConfig``.
-  2. Legacy round-trip — a dict with no ``name`` and the legacy ``_type`` deserializes
-     via ``ResourceConfig.model_validate`` into a ``ContainerConfig(name="")``.
-  3. Real-data sweep — every ``cube.container.ContainerConfig`` blob in the sibling
-     cube-harness cubes' ``task_metadata.json`` must deserialize as a ``ContainerConfig``
-     with ``docker`` in ``requirements()`` (swebench-verified/-live, terminalbench2 ≈ 2.5k
-     blobs). Skipped (with a note) if cube-harness is not found.
+     non-docker one does not; fresh configs serialize as ``cube.resource.ContainerConfig``.
+  2. Legacy round-trip — a dict with no ``name`` and the legacy ``cube.container`` ``_type``
+     deserializes via ``ResourceConfig.model_validate`` into a ``ContainerConfig(name="")``.
+  3. Real-data sweep — every ContainerConfig blob (legacy ``cube.container`` or current
+     ``cube.resource`` ``_type``) in the sibling cube-harness cubes' ``task_metadata.json``
+     must deserialize as a ``ContainerConfig`` with ``docker`` in ``requirements()``
+     (swebench-verified/-live, terminalbench2 ≈ 2.5k blobs). Skipped if cube-harness absent.
 
 Part B — launch (docker required, else noted as skipped):
   Provision + launch ``python:3.12-slim`` via ``launch_task_container`` on
@@ -56,16 +57,16 @@ from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
-from cube.container import ContainerConfig
 from cube.infra_local import LocalInfraConfig
-from cube.resource import ResourceConfig
+from cube.resource import ContainerConfig, ResourceConfig
 from cube.task_infra import launch_task_container
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 log = logging.getLogger("cc-unify-smoke")
 
 NAME = "container_config_unify"
-LEGACY_TYPE = "cube.container.ContainerConfig"
+CURRENT_TYPE = "cube.resource.ContainerConfig"  # canonical home after the move
+LEGACY_TYPE = "cube.container.ContainerConfig"  # pre-move; still resolves via the re-export shim
 LAUNCH_IMAGE = "python:3.12-slim"
 
 
@@ -79,9 +80,9 @@ def banner(status: str, reason: str = "") -> int:
 
 
 def _iter_container_blobs(node: Any) -> Iterator[dict]:
-    """Yield every dict whose ``_type`` is the legacy ContainerConfig tag."""
+    """Yield every dict whose ``_type`` is a ContainerConfig tag (legacy or current)."""
     if isinstance(node, dict):
-        if node.get("_type") == LEGACY_TYPE:
+        if node.get("_type") in (LEGACY_TYPE, CURRENT_TYPE):
             yield node
         for v in node.values():
             yield from _iter_container_blobs(v)
@@ -98,7 +99,7 @@ def check_invariants() -> None:
     assert cc.requirements() == {"docker"}, cc.requirements()
     assert ContainerConfig(image="x", gpu=True).requirements() == {"docker", "gpu:nvidia"}
     assert cc.scope == "task", cc.scope
-    assert cc.model_dump()["_type"] == LEGACY_TYPE, "the _type tag must stay stable"
+    assert cc.model_dump()["_type"] == CURRENT_TYPE, "fresh configs serialize with the canonical _type"
     # can_serve is exactly set-inclusion of requirements() in capabilities():
     assert cc.requirements().issubset({"docker", "network:egress"}), "docker-shaped caps must serve it"
     assert not cc.requirements().issubset({"kvm"}), "a kvm-only infra must NOT serve it"

--- a/scripts/smoke/container_config_unify.py
+++ b/scripts/smoke/container_config_unify.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Smoke: ContainerConfig folded into the ResourceConfig family (Phase 1 unify).
+
+Background
+==========
+``ContainerConfig`` used to be a standalone ``TypedBaseModel``; the orphan
+``DockerImageConfig`` was a parallel single-image ``ResourceConfig`` (defined, never
+launched by any infra). Phase 1 made ``ContainerConfig`` a ``ResourceConfig`` — so it
+joins the capability handshake (``requirements()`` / ``InfraConfig.can_serve``) — and
+deleted ``DockerImageConfig``.
+
+The risk surface is **serialization**: thousands of already-committed
+``task_metadata.json`` entries carry ``"_type": "cube.container.ContainerConfig"`` and
+were serialized *before* the now-inherited (and required on ``ResourceConfig``)
+``name`` field existed. They must still deserialize without regeneration.
+
+What it does
+============
+Part A — serialization (always runs, no docker):
+  1. Invariants — ``ContainerConfig`` is-a ``ResourceConfig``; ``requirements() == {"docker"}``
+     (``+ "gpu:nvidia"`` when ``gpu=True``); a docker-capable infra ``can_serve`` it, a
+     non-docker one does not; the ``_type`` tag stays ``cube.container.ContainerConfig``.
+  2. Legacy round-trip — a dict with no ``name`` and the legacy ``_type`` deserializes
+     via ``ResourceConfig.model_validate`` into a ``ContainerConfig(name="")``.
+  3. Real-data sweep — every ``cube.container.ContainerConfig`` blob in the sibling
+     cube-harness cubes' ``task_metadata.json`` must deserialize as a ``ContainerConfig``
+     with ``docker`` in ``requirements()`` (swebench-verified/-live, terminalbench2 ≈ 2.5k
+     blobs). Skipped (with a note) if cube-harness is not found.
+
+Part B — launch (docker required, else noted as skipped):
+  Provision + launch ``python:3.12-slim`` via ``launch_task_container`` on
+  ``LocalInfraConfig``, ``exec`` an echo, assert, then ``close`` — proving the task
+  bridge that consumes ``ContainerConfig`` fields still works end-to-end.
+
+How to read the output
+======================
+- **SMOKE OK**   — every executed check passed.
+- **SMOKE FAIL** — an invariant, a real serialized blob, or the launch failed.
+- **SMOKE SKIP** — nothing was runnable (Part A is always runnable, so this is unexpected).
+
+Run from the cube-standard repo root::
+
+    uv run scripts/smoke/container_config_unify.py
+    uv run scripts/smoke/container_config_unify.py --cube-harness /path/to/cube-harness
+    uv run scripts/smoke/container_config_unify.py --no-launch
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import subprocess
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+from cube.container import ContainerConfig
+from cube.infra_local import LocalInfraConfig
+from cube.resource import ResourceConfig
+from cube.task_infra import launch_task_container
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+log = logging.getLogger("cc-unify-smoke")
+
+NAME = "container_config_unify"
+LEGACY_TYPE = "cube.container.ContainerConfig"
+LAUNCH_IMAGE = "python:3.12-slim"
+
+
+def banner(status: str, reason: str = "") -> int:
+    """Print the standard SMOKE banner; return the conventional exit code."""
+    line = f"SMOKE {status}: {NAME}"
+    if reason:
+        line += f" — {reason}"
+    print(line)
+    return {"OK": 0, "FAIL": 1, "SKIP": 2}[status]
+
+
+def _iter_container_blobs(node: Any) -> Iterator[dict]:
+    """Yield every dict whose ``_type`` is the legacy ContainerConfig tag."""
+    if isinstance(node, dict):
+        if node.get("_type") == LEGACY_TYPE:
+            yield node
+        for v in node.values():
+            yield from _iter_container_blobs(v)
+    elif isinstance(node, list):
+        for v in node:
+            yield from _iter_container_blobs(v)
+
+
+def check_invariants() -> None:
+    """Part A.1 — type/capability invariants."""
+    assert issubclass(ContainerConfig, ResourceConfig), "ContainerConfig must be a ResourceConfig"
+    cc = ContainerConfig(image=LAUNCH_IMAGE)
+    assert isinstance(cc, ResourceConfig)
+    assert cc.requirements() == {"docker"}, cc.requirements()
+    assert ContainerConfig(image="x", gpu=True).requirements() == {"docker", "gpu:nvidia"}
+    assert cc.scope == "task", cc.scope
+    assert cc.model_dump()["_type"] == LEGACY_TYPE, "the _type tag must stay stable"
+    # can_serve is exactly set-inclusion of requirements() in capabilities():
+    assert cc.requirements().issubset({"docker", "network:egress"}), "docker-shaped caps must serve it"
+    assert not cc.requirements().issubset({"kvm"}), "a kvm-only infra must NOT serve it"
+    log.info("  [A.1] invariants OK (is-a ResourceConfig, requirements, _type stable, capability inclusion)")
+
+
+def check_legacy_roundtrip() -> None:
+    """Part A.2 — a name-less legacy blob still deserializes."""
+    legacy = {
+        "_type": LEGACY_TYPE,
+        "image": LAUNCH_IMAGE,
+        "ram_gb": 1.0,
+        "cpu_cores": 1.0,
+        "gpu": False,
+        "disk_gb": 10.0,
+        "ports": None,
+    }
+    obj = ResourceConfig.model_validate(legacy)
+    assert isinstance(obj, ContainerConfig), type(obj)
+    assert obj.name == "", repr(obj.name)
+    assert obj.image == LAUNCH_IMAGE
+    assert obj.requirements() == {"docker"}
+    log.info("  [A.2] legacy (name-less) blob deserializes -> ContainerConfig(name='')")
+
+
+def sweep_real_metadata(cube_harness: Path | None) -> tuple[int, int]:
+    """Part A.3 — validate every real ContainerConfig blob. Returns (n_blobs, n_files)."""
+    if cube_harness is None or not cube_harness.exists():
+        log.info("  [A.3] cube-harness not found — real-data sweep skipped (synthetic checks cover the logic)")
+        return (0, 0)
+    files = [f for f in cube_harness.glob("cubes/*/src/*/task_metadata.json") if ".venv" not in f.parts]
+    n_blobs = 0
+    for f in files:
+        data = json.loads(f.read_text())
+        blobs = list(_iter_container_blobs(data))
+        for blob in blobs:
+            obj = ResourceConfig.model_validate(blob)
+            assert isinstance(obj, ContainerConfig), f"{f.name}: {type(obj)}"
+            assert "docker" in obj.requirements(), f"{f.name}: {obj.requirements()}"
+        if blobs:
+            log.info("  [A.3] %4d blobs OK  %s", len(blobs), f.relative_to(cube_harness))
+        n_blobs += len(blobs)
+    log.info("  [A.3] real-data sweep OK — %d ContainerConfig blobs across %d files", n_blobs, len(files))
+    return (n_blobs, len(files))
+
+
+def _docker_daemon_ok() -> bool:
+    """True only if the docker *daemon* responds — capabilities() checks just the binary."""
+    try:
+        return subprocess.run(["docker", "info"], capture_output=True, timeout=20).returncode == 0
+    except Exception:  # noqa: BLE001 — any failure means the daemon is unusable
+        return False
+
+
+def check_launch() -> tuple[bool, str]:
+    """Part B — real container launch via the task bridge. Returns (ran, detail)."""
+    infra = LocalInfraConfig(enable_kvm=False)
+    if "docker" not in infra.capabilities():
+        return (False, "no docker binary on this host — launch skipped")
+    if not _docker_daemon_ok():
+        return (False, "docker binary present but daemon unreachable — launch skipped")
+    log.info("  [B] launching %s via launch_task_container ...", LAUNCH_IMAGE)
+    handle, container = launch_task_container(
+        {"infra": infra},
+        name="cc-unify-smoke",
+        image=LAUNCH_IMAGE,
+        ram_gb=1.0,
+        cpu_cores=1.0,
+    )
+    try:
+        token = "hello-cube-unify"
+        res = container.exec(f"echo {token}")
+        assert res.exit_code == 0, f"exit_code={res.exit_code} stderr={res.stderr!r}"
+        assert token in res.stdout, f"stdout={res.stdout!r}"
+    finally:
+        handle.close()
+    log.info("  [B] launch + exec + close OK")
+    return (True, "launched python:3.12-slim, exec echo, closed")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    default_harness = Path(__file__).resolve().parents[2].parent / "cube-harness"
+    ap.add_argument(
+        "--cube-harness",
+        type=Path,
+        default=default_harness,
+        help=f"Path to cube-harness for the real-data sweep (default: {default_harness}).",
+    )
+    ap.add_argument("--no-launch", action="store_true", help="Skip Part B (the docker launch).")
+    args = ap.parse_args()
+
+    try:
+        log.info("Part A — serialization")
+        check_invariants()
+        check_legacy_roundtrip()
+        n_blobs, n_files = sweep_real_metadata(args.cube_harness)
+
+        launch_ran, launch_detail = (False, "skipped (--no-launch)")
+        if not args.no_launch:
+            log.info("Part B — launch")
+            launch_ran, launch_detail = check_launch()
+        log.info("  [B] %s", launch_detail)
+    except AssertionError as exc:
+        return banner("FAIL", f"check failed: {exc}")
+    except Exception as exc:  # noqa: BLE001 — smoke surfaces any failure as FAIL
+        log.exception("unexpected error")
+        return banner("FAIL", f"{type(exc).__name__}: {exc}")
+
+    summary = f"serialization OK ({n_blobs} real blobs / {n_files} files); launch {'OK' if launch_ran else 'skipped'}"
+    return banner("OK", summary)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/cube/__init__.py
+++ b/src/cube/__init__.py
@@ -23,7 +23,6 @@ __all__ = ["__version__", "get_cache_dir"]
 from cube.infra_local import LocalInfraConfig  # noqa: E402
 from cube.provision_store import ProvisionStore  # noqa: E402
 from cube.resource import (  # noqa: E402
-    DockerImageConfig,
     DockerServiceConfig,
     InfraConfig,
     ResourceConfig,
@@ -38,7 +37,6 @@ __all__ += [
     "ResourceConfig",
     "VMResourceConfig",
     "DockerServiceConfig",
-    "DockerImageConfig",
     "VolumeSpec",
     "InfraConfig",
     "ResourceHandle",

--- a/src/cube/container.py
+++ b/src/cube/container.py
@@ -20,8 +20,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, Dict
 
-from cube.core import TypedBaseModel
-from cube.resource import ResourceHandle
+from cube.resource import ResourceConfig, ResourceHandle
 
 logger = logging.getLogger(__name__)
 
@@ -178,21 +177,34 @@ def port_from_url(url: str) -> int:
 # ── Task container requirements ──────────────────────────────────────────────
 
 
-class ContainerConfig(TypedBaseModel):
-    """Serializable description of *what* container a task needs.
+class ContainerConfig(ResourceConfig):
+    """Serializable description of *what* single-container resource a task needs.
 
-    Declared on ``TaskMetadata.container_config`` and consumed by the
-    ``InfraConfig`` path in ``Task.model_post_init`` (via
+    A ``ResourceConfig`` (one Docker image, ``scope="task"``), so it shares the
+    capability handshake — ``requirements()`` / ``InfraConfig.can_serve`` — with
+    every other resource. Declared on ``TaskMetadata.container_config`` and consumed
+    by the ``InfraConfig`` path in ``Task.model_post_init`` (via
     ``cube.task_infra.launch_task_container``).  *How* the container is
     provisioned is owned by the injected ``InfraConfig`` (see ``cube.resource``).
     """
 
+    # ResourceConfig.name is required; task containers are keyed by the task id at
+    # launch (launch_task_container(name=task.metadata.id, ...)), so the field is
+    # unused here and defaults to "" — which keeps legacy metadata (serialized
+    # before ContainerConfig carried a name) loadable without regeneration.
+    name: str = ""
     image: str
     ram_gb: float = 4.0
     cpu_cores: float = 2.0
     gpu: bool = False
     disk_gb: float = 10.0
     ports: list[int] | None = None
+
+    def requirements(self) -> set[str]:
+        reqs = {"docker"}
+        if self.gpu:
+            reqs.add("gpu:nvidia")
+        return reqs
 
 
 # === auto-fix notes ===  (spec: openspec/specs/auto-fix/spec.md)

--- a/src/cube/container.py
+++ b/src/cube/container.py
@@ -5,12 +5,11 @@ directly — no wrapper indirection.  Subclasses carry the handle bookkeeping
 (run_id / resource / infra / created_at / expires_at) alongside their driver-
 specific state.
 
-``ContainerConfig`` below is the serializable description of *what* container a
-task needs (``TaskMetadata.container_config``).  It is consumed by the
-``InfraConfig`` path in ``Task.model_post_init`` (via
-``cube.task_infra.launch_task_container``) — it is **not** deprecated.  The old
-``ContainerBackend`` factory has been removed; provisioning is now done
-exclusively through ``InfraConfig`` (see ``cube.resource``).
+``ContainerConfig`` (the serializable description of *what* container a task needs,
+``TaskMetadata.container_config``) is a ``ResourceConfig`` and now lives in
+``cube.resource`` alongside the other resource configs; it is re-exported from this
+module for backward compatibility.  The old ``ContainerBackend`` factory has been
+removed; provisioning is now done exclusively through ``InfraConfig``.
 """
 
 from __future__ import annotations
@@ -20,7 +19,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, Dict
 
-from cube.resource import ResourceConfig, ResourceHandle
+from cube.resource import ResourceHandle
 
 logger = logging.getLogger(__name__)
 
@@ -177,34 +176,10 @@ def port_from_url(url: str) -> int:
 # ── Task container requirements ──────────────────────────────────────────────
 
 
-class ContainerConfig(ResourceConfig):
-    """Serializable description of *what* single-container resource a task needs.
-
-    A ``ResourceConfig`` (one Docker image, ``scope="task"``), so it shares the
-    capability handshake — ``requirements()`` / ``InfraConfig.can_serve`` — with
-    every other resource. Declared on ``TaskMetadata.container_config`` and consumed
-    by the ``InfraConfig`` path in ``Task.model_post_init`` (via
-    ``cube.task_infra.launch_task_container``).  *How* the container is
-    provisioned is owned by the injected ``InfraConfig`` (see ``cube.resource``).
-    """
-
-    # ResourceConfig.name is required; task containers are keyed by the task id at
-    # launch (launch_task_container(name=task.metadata.id, ...)), so the field is
-    # unused here and defaults to "" — which keeps legacy metadata (serialized
-    # before ContainerConfig carried a name) loadable without regeneration.
-    name: str = ""
-    image: str
-    ram_gb: float = 4.0
-    cpu_cores: float = 2.0
-    gpu: bool = False
-    disk_gb: float = 10.0
-    ports: list[int] | None = None
-
-    def requirements(self) -> set[str]:
-        reqs = {"docker"}
-        if self.gpu:
-            reqs.add("gpu:nvidia")
-        return reqs
+# ``ContainerConfig`` now lives in ``cube.resource`` (it is a ``ResourceConfig``).
+# Re-exported here so that ``_type: cube.container.ContainerConfig`` strings — serialized
+# before the move — still resolve on deserialize (importlib + getattr on this module).
+from cube.resource import ContainerConfig  # noqa: E402,F401
 
 
 # === auto-fix notes ===  (spec: openspec/specs/auto-fix/spec.md)

--- a/src/cube/resource.py
+++ b/src/cube/resource.py
@@ -254,6 +254,38 @@ class DockerServiceConfig(ResourceConfig):
         return {"docker"}
 
 
+class ContainerConfig(ResourceConfig):
+    """Serializable description of *what* single-container resource a task needs.
+
+    A ``ResourceConfig`` (one Docker image, ``scope="task"``), so it shares the
+    capability handshake — ``requirements()`` / ``InfraConfig.can_serve`` — with
+    every other resource. Declared on ``TaskMetadata.container_config`` and consumed
+    by the ``InfraConfig`` path in ``Task.model_post_init`` (via
+    ``cube.task_infra.launch_task_container``).  *How* the container is
+    provisioned is owned by the injected ``InfraConfig`` (see below).
+
+    Re-exported from ``cube.container`` for backward compatibility (its original home).
+    """
+
+    # ResourceConfig.name is required; task containers are keyed by the task id at
+    # launch (launch_task_container(name=task.metadata.id, ...)), so the field is
+    # unused here and defaults to "" — which keeps legacy metadata (serialized
+    # before ContainerConfig carried a name) loadable without regeneration.
+    name: str = ""
+    image: str
+    ram_gb: float = 4.0
+    cpu_cores: float = 2.0
+    gpu: bool = False
+    disk_gb: float = 10.0
+    ports: list[int] | None = None
+
+    def requirements(self) -> set[str]:
+        reqs = {"docker"}
+        if self.gpu:
+            reqs.add("gpu:nvidia")
+        return reqs
+
+
 # ── ResourceHandle ────────────────────────────────────────────────────────────
 
 

--- a/src/cube/resource.py
+++ b/src/cube/resource.py
@@ -254,28 +254,6 @@ class DockerServiceConfig(ResourceConfig):
         return {"docker"}
 
 
-class DockerImageConfig(ResourceConfig):
-    """Single Docker image per task (SWE-bench, MLE-bench, CTF...).
-
-    Resource requirements (ram_gb, cpu_cores, disk_gb, ports) are read by
-    DockerInfraConfig.launch() to configure the container. gpu=True maps to
-    the "gpu:nvidia" capability requirement token via requirements().
-    """
-
-    image: str
-    ram_gb: float = 4.0
-    cpu_cores: float = 2.0
-    disk_gb: float = 10.0
-    gpu: bool = False
-    ports: list[int] | None = None
-
-    def requirements(self) -> set[str]:
-        reqs = {"docker"}
-        if self.gpu:
-            reqs.add("gpu:nvidia")
-        return reqs
-
-
 # ── ResourceHandle ────────────────────────────────────────────────────────────
 
 

--- a/src/cube/task.py
+++ b/src/cube/task.py
@@ -27,7 +27,7 @@ from pydantic import ConfigDict, Field, PrivateAttr, SerializeAsAny
 from typing_extensions import TypeVar
 
 from cube import get_cache_dir
-from cube.container import Container, ContainerConfig
+from cube.container import Container
 from cube.core import (
     Action,
     ActionSchema,
@@ -38,7 +38,7 @@ from cube.core import (
     StructuredContent,
     TypedBaseModel,
 )
-from cube.resource import ResourceHandle
+from cube.resource import ContainerConfig, ResourceHandle
 from cube.tool import AbstractTool, ToolConfig
 
 # Type parameters for ``Task``. ``TTMetadata`` narrows ``self.metadata``; ``TTool``

--- a/tests/test_resource_lifecycle.py
+++ b/tests/test_resource_lifecycle.py
@@ -14,9 +14,9 @@ from pathlib import Path
 
 import pytest
 
-from cube.container import ContainerConfig
 from cube.provision_store import ProvisionStore
 from cube.resource import (
+    ContainerConfig,
     DockerServiceConfig,
     InfraConfig,
     ResourceConfig,
@@ -204,14 +204,21 @@ class TestContainerConfigUnification:
         assert _StubInfra(name="x", caps=["docker"]).can_serve(cc) is True
         assert _StubInfra(name="x", caps=["kvm"]).can_serve(cc) is False
 
-    def test_type_tag_stays_on_cube_container_path(self) -> None:
-        # _type must remain cube.container.ContainerConfig so the thousands of
-        # already-serialized task_metadata.json entries keep resolving.
-        assert ContainerConfig(image="img").model_dump()["_type"] == "cube.container.ContainerConfig"
+    def test_type_tag_is_cube_resource_path(self) -> None:
+        # Canonical home after the move is cube.resource.
+        assert ContainerConfig(image="img").model_dump()["_type"] == "cube.resource.ContainerConfig"
+
+    def test_legacy_cube_container_import_is_same_class(self) -> None:
+        # Back-compat re-export: the old import path resolves to the same class object,
+        # so `_type: cube.container.ContainerConfig` blobs still deserialize via it.
+        from cube.container import ContainerConfig as LegacyContainerConfig
+
+        assert LegacyContainerConfig is ContainerConfig
 
     def test_legacy_metadata_without_name_deserializes(self) -> None:
-        # Entry serialized before ContainerConfig inherited the (required) name
-        # field — must still load, defaulting name to "".
+        # Entry serialized before the move AND before the (now-required, inherited)
+        # name field — both the legacy cube.container _type and the missing name must
+        # still load, defaulting name to "". Exercises the re-export shim.
         legacy = {
             "_type": "cube.container.ContainerConfig",
             "image": "python:3.12-slim",

--- a/tests/test_resource_lifecycle.py
+++ b/tests/test_resource_lifecycle.py
@@ -14,9 +14,9 @@ from pathlib import Path
 
 import pytest
 
+from cube.container import ContainerConfig
 from cube.provision_store import ProvisionStore
 from cube.resource import (
-    DockerImageConfig,
     DockerServiceConfig,
     InfraConfig,
     ResourceConfig,
@@ -167,8 +167,8 @@ class TestResourceConfig:
         r = DockerServiceConfig(name="webarena", compose_url="http://example.com/compose.yml")
         assert r.requirements() == {"docker"}
 
-    def test_docker_image_requires_docker(self) -> None:
-        r = DockerImageConfig(name="swebench", image="swebench/swe-bench:latest")
+    def test_container_config_requires_docker(self) -> None:
+        r = ContainerConfig(name="swebench", image="swebench/swe-bench:latest")
         assert r.requirements() == {"docker"}
 
     def test_default_ttl_is_one_hour(self) -> None:
@@ -178,6 +178,61 @@ class TestResourceConfig:
     def test_scope_defaults_to_task(self) -> None:
         r = VMResourceConfig(name="vm")
         assert r.scope == "task"
+
+
+# ── ContainerConfig is a ResourceConfig (unification) ─────────────────────────
+
+
+class TestContainerConfigUnification:
+    """ContainerConfig was folded into the ResourceConfig family (it absorbed the
+    deleted DockerImageConfig). These guard the capability handshake and the
+    backward-compatible deserialization of metadata serialized before the change."""
+
+    def test_is_a_resource_config(self) -> None:
+        assert issubclass(ContainerConfig, ResourceConfig)
+        assert isinstance(ContainerConfig(image="img"), ResourceConfig)
+
+    def test_requirements_adds_gpu_token(self) -> None:
+        assert ContainerConfig(image="img").requirements() == {"docker"}
+        assert ContainerConfig(image="img", gpu=True).requirements() == {"docker", "gpu:nvidia"}
+
+    def test_scope_defaults_to_task(self) -> None:
+        assert ContainerConfig(image="img").scope == "task"
+
+    def test_can_serve_against_capabilities(self) -> None:
+        cc = ContainerConfig(image="img")
+        assert _StubInfra(name="x", caps=["docker"]).can_serve(cc) is True
+        assert _StubInfra(name="x", caps=["kvm"]).can_serve(cc) is False
+
+    def test_type_tag_stays_on_cube_container_path(self) -> None:
+        # _type must remain cube.container.ContainerConfig so the thousands of
+        # already-serialized task_metadata.json entries keep resolving.
+        assert ContainerConfig(image="img").model_dump()["_type"] == "cube.container.ContainerConfig"
+
+    def test_legacy_metadata_without_name_deserializes(self) -> None:
+        # Entry serialized before ContainerConfig inherited the (required) name
+        # field — must still load, defaulting name to "".
+        legacy = {
+            "_type": "cube.container.ContainerConfig",
+            "image": "python:3.12-slim",
+            "ram_gb": 1.0,
+            "cpu_cores": 1.0,
+            "gpu": False,
+            "disk_gb": 10.0,
+            "ports": None,
+        }
+        obj = ResourceConfig.model_validate(legacy)
+        assert isinstance(obj, ContainerConfig)
+        assert obj.name == ""
+        assert obj.image == "python:3.12-slim"
+        assert obj.requirements() == {"docker"}
+
+    def test_polymorphic_roundtrip_through_resource_config(self) -> None:
+        cc = ContainerConfig(image="img", ram_gb=2.0, gpu=True, ports=[8080])
+        reloaded = ResourceConfig.model_validate(cc.model_dump())
+        assert isinstance(reloaded, ContainerConfig)
+        assert reloaded == cc
+        assert reloaded.requirements() == {"docker", "gpu:nvidia"}
 
 
 # ── InfraConfig base: register / provision_status / can_serve ─────────────────


### PR DESCRIPTION
## What

Unify the single-container resource config: make `ContainerConfig` a `ResourceConfig`, delete the orphan `DockerImageConfig`, and **relocate `ContainerConfig` to `cube.resource`** (its canonical home, next to `VMResourceConfig`/`DockerServiceConfig`) with a back-compat re-export from `cube.container`.

## Why

Two field-identical single-container configs existed:

- `ContainerConfig` (standalone `TypedBaseModel`, in `cube.container`) — what tasks actually declare (`TaskMetadata.container_config`); used by swebench-verified, swebench-live, terminalbench2.
- `DockerImageConfig` (a `ResourceConfig`, in `cube.resource`) — **orphan**: no infra ever launches it (every `launch()` dispatches only on `DockerServiceConfig`/`VMResourceConfig`), referenced only by its own def + one test.

Because `ContainerConfig` wasn't a `ResourceConfig`, task containers couldn't use the existing capability handshake (`requirements()` / `InfraConfig.can_serve`) — they paralleled it. Now there's one tree, one home.

## Change

- `class ContainerConfig(ResourceConfig)` in `cube.resource`, `requirements()` → `{"docker"}` (`+ "gpu:nvidia"` when `gpu=True`) — exactly the deleted `DockerImageConfig`'s contract.
- Deleted `DockerImageConfig` + its export.
- `cube.container` re-exports `ContainerConfig` for back-compat; in-repo importers (`cube.task`, counter-cube) use the canonical `cube.resource` path.

## Backward-compatible — zero regeneration, order-independent

- The inherited, **required** `ResourceConfig.name` is **overridden to default `""`** — task containers are keyed by the task id at launch (`launch_task_container`), so name-less legacy blobs still deserialize.
- The **re-export** keeps `_type: cube.container.ContainerConfig` resolving (importlib + `getattr` on `cube.container`), so the ~2,500 already-serialized `task_metadata.json` entries load unchanged. Fresh configs serialize as `cube.resource.ContainerConfig`.
- A companion cube-harness change normalizes the committed `_type` strings to `cube.resource.ContainerConfig`, but the re-export means **the two PRs are independent of merge order**.

The launch bridge (`launch_task_container` → `DockerServiceConfig`) is **untouched** — it consumes raw fields, not a `ContainerConfig`, so provisioning behavior cannot change.

## Verification

- **Unit** — `tests/test_resource_lifecycle.py::TestContainerConfigUnification`: is-a `ResourceConfig`, `requirements()`/`can_serve`, canonical `_type` = `cube.resource.ContainerConfig`, **legacy `cube.container` re-export is the same class**, name-less legacy deserialization, polymorphic round-trip. Full suite: **646 passed, 1 skipped**. `make lint` clean.
- **Smoke** — `scripts/smoke/container_config_unify.py` deserializes **all 2,484 real `ContainerConfig` blobs** across the cube-harness cubes (still on the legacy `_type`, via the re-export) and launches `python:3.12-slim` end-to-end through the task bridge (verified on colima; SKIPs cleanly where no docker daemon).

## Notes

Sets up RFC #191 (task permission requirements): with `requirements()` now on `ContainerConfig`, the permission gate becomes "add the `container:root` token + `on_incompatible` policy + the setup loop" on top of the existing `can_serve`, rather than a parallel mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
