### PR TITLE
feat(benchmark): load prompt overlay (hint + clarifications) from a sidecar module

### DIFF
--- a/docs/authoring-a-cube.markdown
+++ b/docs/authoring-a-cube.markdown
@@ -98,44 +98,54 @@ Every debug task must hit `reward == 1.0`. If one doesn't, either the debug acti
 
 ## Prompt hints and per-task clarifications
 
-Two optional metadata fields let benchmark authors steer how harnesses
-present tasks to the agent without rewriting the benchmark itself. Both
-are framework slots: `cube-standard` only declares them and ships them
-across the serialization boundary. Whether and how to surface them is the
-harness's call.
+A benchmark may *organize* two optional, agent-facing prompt strings to steer
+how harnesses present it — without rewriting the benchmark itself. The
+benchmark only stores them; `cube-standard` loads them and a harness folds them
+into the agent config at experiment-design time.
 
-**`BenchmarkMetadata.benchmark_hint_prompt`** — one concise paragraph the
-harness may prepend to every task in this benchmark. Use it when the
-benchmark has conventions a first-time reader would miss but that aren't
-specific to any single task: a high-level workflow, the shape of a
-verifier, a recurring ambiguity in the wording. Keep it short and
-generic. A generalist agent should remain competitive without it; the
-field exists so evaluations that opt in can report a number on a level
-playing field, not so authors can engineer prompts for any one model.
-Default: `None`.
-
-**`TaskMetadata.task_clarification`** — an optional short string a
-harness may append to the task objective, gated by
-`BenchmarkConfig.add_task_clarification`. Use it for individual brittle
-tasks whose original wording omits a step a reasonable LLM would not
-infer. Canonical example: a miniwob task whose objective reads "set
-slider to 32 and string value to 'foo'" but whose verifier only rewards
-if the agent then clicks submit — a competent LLM would not click submit
-unprompted, and that is not really the LLM's fault. Adding
-`task_clarification="After setting the values, click submit."` keeps the
-original benchmark wording intact while letting evaluations toggle the
-fix on. Populated over time by the `/auto-cube` workflow as it detects
-brittle tasks; left `None` for tasks whose wording is unambiguous.
-
-**`BenchmarkConfig.add_task_clarification`** — instance-level switch on
-the config. Default `False` so a run reproduces the original benchmark
-wording untouched and stays comparable with baselines that ignored these
-clarifications. Set `True` on the config when you want the run to apply
-all populated `task_clarification` strings.
+Both live in an optional **`benchmark_clarifications.py` sidecar next to the
+benchmark's module** (mirroring the `task_metadata` "files next to the module"
+convention), exposing two module-level names:
 
 ```python
-cfg = MyBenchmarkConfig(add_task_clarification=True)
+# my_cube/benchmark_clarifications.py
+BENCHMARK_HINT = "Submit your final answer with final_step."
+
+_SLIDER_TASKS = ["slider-1", "slider-2", "slider-3"]
+TASK_CLARIFICATION = {tid: "After setting the values, click submit." for tid in _SLIDER_TASKS}
 ```
+
+**`BENCHMARK_HINT`** — one concise paragraph for conventions a first-time reader
+would miss but that aren't specific to any single task: a high-level workflow,
+the shape of a verifier, a recurring ambiguity. Keep it short and generic — a
+generalist agent should remain competitive without it; it exists so opt-in
+evaluations report on a level playing field, not so authors engineer prompts
+for one model.
+
+**`TASK_CLARIFICATION`** — a `{task_id: text}` dict for individually brittle
+tasks whose original wording omits a step a reasonable LLM would not infer.
+Canonical example: a miniwob task whose objective reads "set slider to 32 and
+string value to 'foo'" but whose verifier only rewards if the agent then clicks
+submit — a competent LLM would not click submit unprompted, and that is not
+really the LLM's fault. Because it's a `.py`, one clarification can be reused
+across many task ids (above) — that reuse is a deliberate **regularizer**,
+pushing clarifications to generalize rather than overfit per task.
+
+A harness loads both via `BenchmarkConfig.load_benchmark_clarifications()`
+(returns `(benchmark_hint, task_clarification)`; empty when no sidecar exists),
+then folds them into the agent config at experiment-design time — e.g.:
+
+```python
+overlay = MyBenchmarkConfig.load_benchmark_clarifications()
+agent = GennyConfig(
+    benchmark_hint_prompt=overlay.benchmark_hint,
+    task_clarification=overlay.task_clarification,  # pass {} to run without clarifications
+    ...,
+)
+```
+
+Applying the overlay is the recipe's explicit choice — to run a clean baseline,
+simply don't pass it. There is no separate on/off flag.
 
 Because both fields are metadata, third-party harnesses see them through
 the same serialization the rest of `TaskMetadata` / `BenchmarkMetadata`

--- a/openspec/specs/benchmark/spec.md
+++ b/openspec/specs/benchmark/spec.md
@@ -33,21 +33,11 @@ class BenchmarkMetadata(TypedBaseModel):
     tags: list[str] = []
     reset_isolation: ResetIsolation | None = None  # snapshot/restart/app_level/new_instance
     named_subsets: dict[str, tuple[str, str]] = {} # name → (glob_key, glob_pattern)
-    benchmark_hint_prompt: str | None = None       # optional benchmark-wide prompt hint
 ```
 
 Cube authors needing additional benchmark-level fields subclass
 `BenchmarkMetadata` with named typed fields. The base class accepts only
 the framework-defined fields above.
-
-`benchmark_hint_prompt` is a concise, generic hint a harness may prepend
-to the agent's prompt for any task in this benchmark — e.g. a short
-workflow summary or a clarification of conventions shared across tasks.
-Keep it short and generic: a generalist agent should remain competitive
-without it; the field exists so benchmarks with unusual conventions can
-opt into a level playing field for evaluations that report numbers with
-the hint applied. The framework only declares the slot — actual prompt
-assembly happens in the harness.
 
 `reset_isolation` is informational for harness users to reason about parallelism:
 - `SNAPSHOT` — VM reverts to savestate (~5s)
@@ -92,15 +82,33 @@ task_ids: list[str] | None = None          # None = all; populated by subset_fro
 resources: list[ResourceConfig] = []       # resource dependencies (L2/L3)
 tool_config: ToolConfig | None             # applied to every task by the default get_task_configs(); override get_task_configs() for per-task variation
 seed_generator: AbstractSeedGenerator | None # yields seeds per TaskMetadata
-add_task_clarification: bool = False       # surface TaskMetadata.task_clarification to the agent
 ```
 
-`add_task_clarification` opts a run into the per-task clarifications
-declared on `TaskMetadata.task_clarification` (see
-[task/spec.md](../task/spec.md)). Default `False` so a run reproduces the
-original benchmark wording untouched and stays comparable with baselines
-that ignored these clarifications. Harnesses interpret the flag during
-prompt assembly; the framework only carries the intent.
+### Prompt overlay (`load_benchmark_clarifications`)
+
+A benchmark may *organize* two optional, agent-facing prompt strings without
+acting on them itself:
+
+- a benchmark-wide **hint** (orientation for a generalist agent), and
+- a **`{task_id: clarification}`** dict for individually under-specified tasks.
+
+These live in an optional `benchmark_clarifications.py` sidecar **next to the
+benchmark's module** (the same "files next to the module" convention used for
+`task_metadata`), exposing `BENCHMARK_HINT: str | None` and
+`TASK_CLARIFICATION: dict[str, str]`. A `.py` (not a data file) lets one
+clarification be reused across many task ids — that reuse is a deliberate
+**regularizer**, pushing clarifications to generalize rather than overfit.
+
+```python
+@classmethod
+def load_benchmark_clarifications(cls) -> BenchmarkClarifications:
+    # (benchmark_hint, task_clarification); empty when no sidecar exists.
+```
+
+The framework only loads and returns these — nothing is delivered to the agent
+automatically. A harness reads them at experiment-design time and folds them
+into the agent config (e.g. `GennyConfig.benchmark_hint_prompt` /
+`task_clarification`).
 
 Per-task container needs are declared via `TaskMetadata.container_config`
 (`ContainerConfig`) and provisioned through the injected `InfraConfig` — see

--- a/openspec/specs/task/spec.md
+++ b/openspec/specs/task/spec.md
@@ -19,7 +19,6 @@ class TaskMetadata(TypedBaseModel):
     abstract_description: str = ""             # for search/filtering only — NOT the objective
     recommended_max_steps: int | None = None   # harness hint, not enforced
     container_config: ContainerConfig | None = None
-    task_clarification: str | None = None      # optional opt-in clarification (see below)
 ```
 
 `TaskMetadata` is the lightweight, eager-loaded view of a task: it ships in
@@ -36,18 +35,12 @@ scripts, …) lives on a `TaskExecutionInfo` subclass surfaced via
 The actual task objective is surfaced in the first `Observation` returned by `reset()`.
 `abstract_description` is for tooling (search, subsetting), never to be shown to the agent.
 
-`task_clarification` is an optional short string a harness may append to
-the task objective **only when** the owning
-`BenchmarkConfig.add_task_clarification` is `True` (see
-[benchmark/spec.md](../benchmark/spec.md)). Populated over time for
-brittle tasks whose original wording omits a step a reasonable LLM would
-not infer — for instance a miniwob task whose objective reads "set slider
-to 32 and string value to 'foo'" but whose verifier only rewards if the
-agent then clicks submit. Storing the fix as metadata keeps the original
-benchmark wording intact and lets evaluations toggle the clarifications
-on or off without forking the benchmark. Leave `None` for tasks whose
-wording is unambiguous. The framework only declares the slot — actual
-prompt assembly happens in the harness.
+Per-task **clarifications** for brittle tasks (whose original wording omits a
+step a reasonable LLM would not infer) are not stored on `TaskMetadata`. They
+live in the benchmark's prompt overlay — a `{task_id: text}` dict loaded by
+`BenchmarkConfig.load_benchmark_clarifications()` (see
+[benchmark/spec.md](../benchmark/spec.md)). This keeps the original benchmark
+wording intact and lets one clarification be reused across many tasks.
 
 ### `TaskExecutionInfo` (serializable)
 ```python

--- a/src/cube/benchmark.py
+++ b/src/cube/benchmark.py
@@ -52,6 +52,7 @@ import csv
 import enum
 import fnmatch
 import importlib.resources
+import importlib.util
 import json
 import logging
 import subprocess
@@ -59,7 +60,7 @@ import sys
 from abc import ABC, abstractmethod
 from collections import Counter
 from pathlib import Path
-from typing import Any, ClassVar, Generator, Mapping, Self, Sequence, cast
+from typing import Any, ClassVar, Generator, Mapping, NamedTuple, Self, Sequence, cast
 
 from pydantic import Field, SerializeAsAny
 
@@ -129,16 +130,46 @@ class BenchmarkMetadata(TypedBaseModel):
             "Example: {'train_only': ('split', 'train')}"
         ),
     )
-    benchmark_hint_prompt: str | None = Field(
-        default=None,
-        description=(
-            "Optional concise hint a harness may prepend to the agent's prompt to "
-            "orient it on this benchmark — e.g. a one-paragraph workflow or a "
-            "clarification of conventions that apply to every task. Keep it short "
-            "and as generic as possible: a generalist agent should remain "
-            "competitive without it. The framework does not deliver this string "
-            "to the agent itself; harnesses decide whether and how to surface it."
-        ),
+
+
+#: Sidecar module (next to the benchmark module) that carries the optional prompt
+#: overlay — a benchmark-wide ``BENCHMARK_HINT`` string and a ``TASK_CLARIFICATION``
+#: ``{task_id: text}`` dict. A ``.py`` (rather than data file) lets one clarification
+#: be reused across many task ids, which keeps clarifications general — a regularizer.
+_CLARIFICATIONS_MODULE = "benchmark_clarifications"
+
+
+class BenchmarkClarifications(NamedTuple):
+    """Optional prompt overlay loaded from a benchmark's sidecar module.
+
+    The framework only loads and carries these; nothing is delivered to the
+    agent automatically. A harness reads them at experiment-design time and
+    folds them into the agent config (e.g. ``GennyConfig.benchmark_hint_prompt``
+    / ``task_clarification``).
+    """
+
+    benchmark_hint: str | None = None
+    task_clarification: dict[str, str] = {}  # noqa: RUF012 — NamedTuple default, never mutated
+
+
+def _load_benchmark_clarifications(package: str | None) -> BenchmarkClarifications:
+    """Load the ``benchmark_clarifications`` sidecar from ``package``.
+
+    Returns an empty overlay when ``package`` is falsy or has no sidecar. Import
+    errors *inside* an existing sidecar propagate — only absence is silent.
+    """
+    if not package:
+        return BenchmarkClarifications()
+    module_name = f"{package}.{_CLARIFICATIONS_MODULE}"
+    try:
+        if importlib.util.find_spec(module_name) is None:
+            return BenchmarkClarifications()
+    except ModuleNotFoundError:
+        return BenchmarkClarifications()
+    module = importlib.import_module(module_name)
+    return BenchmarkClarifications(
+        benchmark_hint=getattr(module, "BENCHMARK_HINT", None),
+        task_clarification=dict(getattr(module, "TASK_CLARIFICATION", {}) or {}),
     )
 
 
@@ -218,17 +249,6 @@ class BenchmarkConfig[TTMetadata: TaskMetadata](ValidatedConfig, ABC):
         default=None,
         description="Optional seed generator yielding per-task seeds during get_task_configs().",
     )
-    add_task_clarification: bool = Field(
-        default=False,
-        description=(
-            "When True, harnesses should surface ``TaskMetadata.task_clarification`` "
-            "(when populated) alongside the task objective so the agent sees the "
-            "added wording. Defaults to False so a run reproduces the original "
-            "benchmark wording untouched; flip on to evaluate with curated "
-            "per-task clarifications applied. The framework only declares the "
-            "intent — actual prompt assembly happens in the harness."
-        ),
-    )
 
     # ──────────────────────────────────────────────────────────────────────────
     # File-loading helpers
@@ -307,6 +327,46 @@ class BenchmarkConfig[TTMetadata: TaskMetadata](ValidatedConfig, ABC):
                     data["recommended_max_steps"] = int(data["recommended_max_steps"])
                 tasks.append(TaskMetadata.model_validate(data))
         return {t.id: t for t in tasks}
+
+    @classmethod
+    def load_benchmark_clarifications(cls) -> BenchmarkClarifications:
+        """Load this benchmark's optional prompt overlay from its sidecar module.
+
+        Reads a ``benchmark_clarifications.py`` next to the benchmark's module
+        (the same "files next to the module" convention used for
+        ``task_metadata``), exposing ``BENCHMARK_HINT: str | None`` and
+        ``TASK_CLARIFICATION: dict[str, str]``; returns an empty overlay when no
+        sidecar exists. The benchmark only *organizes* these strings — nothing
+        is applied automatically. A harness reads them at experiment-design time
+        and folds them into the agent config (e.g.
+        ``GennyConfig.benchmark_hint_prompt`` / ``task_clarification``); to run a
+        clean baseline it simply does not.
+
+        Purpose and when to use each:
+
+        ``BENCHMARK_HINT`` — one concise paragraph orienting a generalist agent
+        on conventions a first-time reader would miss but that are not specific
+        to any single task: a high-level workflow, the shape of the verifier, a
+        recurring ambiguity in the wording. Keep it short and generic — a
+        generalist agent should remain competitive without it. It exists so
+        evaluations that opt in can report a number on a level playing field,
+        not so authors can engineer prompts for one model.
+
+        ``TASK_CLARIFICATION`` — per-task fixes for individually brittle tasks
+        whose original wording omits a step a reasonable LLM would not infer.
+        Canonical example: a miniwob task whose objective reads "set slider to 32
+        and string value to 'foo'" but whose verifier only rewards if the agent
+        then clicks submit — a competent LLM would not click submit unprompted,
+        and that is not really the LLM's fault. Mapping that task id to "After
+        setting the values, click submit." keeps the original benchmark wording
+        intact while letting an evaluation opt the fix in. Because the overlay is
+        a ``.py``, one clarification can be reused across many task ids — that
+        reuse is a deliberate regularizer, pushing clarifications to generalize
+        rather than overfit. Leave a task out when its wording is unambiguous;
+        the dict grows over time as the auto-cube workflow detects brittle tasks.
+        """
+        package = cls.__module__.rpartition(".")[0]
+        return _load_benchmark_clarifications(package)
 
     # ──────────────────────────────────────────────────────────────────────────
     # Subclass validation / file auto-load

--- a/src/cube/task.py
+++ b/src/cube/task.py
@@ -93,7 +93,6 @@ class TaskMetadata(TypedBaseModel):
         abstract_description (str): Broad description of the task for searching and filtering only. The task objective is part of the first Observation returned by task.reset(). (default: "")
         recommended_max_steps (int | None): Recommended maximum number of steps to help harness prevent infinite running agents. Not a hard limit, the task can still run longer if needed. (default: None)
         container_config (ContainerConfig | None): Optional container configuration for this task (default: None, meaning no container needed).
-        task_clarification (str | None): Optional short clarification a harness may append to the task objective when ``BenchmarkConfig.add_task_clarification`` is True (default: None).
     """
 
     id: str = Field(..., description="Unique task identifier")
@@ -109,19 +108,6 @@ class TaskMetadata(TypedBaseModel):
     container_config: ContainerConfig | None = Field(
         default=None,
         description="Optional container configuration for this task (defaults to None, meaning no container needed).",
-    )
-    task_clarification: str | None = Field(
-        default=None,
-        description=(
-            "Optional short clarification a harness may append to the task "
-            "objective when the owning ``BenchmarkConfig.add_task_clarification`` "
-            "is True. Intended for brittle tasks whose original wording omits a "
-            "step a reasonable LLM would not infer (e.g. an instruction that does "
-            "not say to click submit when the verifier requires submit to be "
-            "clicked). Populated over time as auto-cube agents detect these "
-            "cases; left None for tasks whose wording is unambiguous. Stored as "
-            "metadata so the original benchmark wording stays untouched."
-        ),
     )
 
 

--- a/tests/clarif_fixture/benchmark_clarifications.py
+++ b/tests/clarif_fixture/benchmark_clarifications.py
@@ -1,0 +1,9 @@
+"""Sidecar prompt overlay used by tests for ``load_benchmark_clarifications``.
+
+Demonstrates reusing one clarification across several task ids (the regularizer).
+"""
+
+BENCHMARK_HINT = "Submit your final answer with final_step."
+
+_SLIDER_TASKS = ["slider-1", "slider-2", "slider-3"]
+TASK_CLARIFICATION = {tid: "After setting the values, click Submit." for tid in _SLIDER_TASKS}

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -7,7 +7,13 @@ from typing import Literal
 
 import pytest
 
-from cube.benchmark import Benchmark, BenchmarkConfig, BenchmarkMetadata
+from cube.benchmark import (
+    Benchmark,
+    BenchmarkClarifications,
+    BenchmarkConfig,
+    BenchmarkMetadata,
+    _load_benchmark_clarifications,
+)
 from cube.core import Observation
 from cube.seed import AbstractSeedGenerator
 from cube.task import Task, TaskConfig, TaskMetadata
@@ -92,28 +98,29 @@ def test_benchmark_metadata_defaults():
         requirements={},
         named_subsets={},
         reset_isolation=None,
-        benchmark_hint_prompt=None,
     )
 
 
-def test_benchmark_metadata_hint_prompt_round_trips():
-    bm = BenchmarkMetadata(
-        name="foo",
-        version="1.0",
-        description="bar",
-        benchmark_hint_prompt="Submit your final answer with final_step.",
-    )
-    reloaded = BenchmarkMetadata.model_validate_json(bm.model_dump_json())
-    assert reloaded.benchmark_hint_prompt == "Submit your final answer with final_step."
+def test_load_benchmark_clarifications_from_sidecar():
+    """A benchmark whose package ships ``benchmark_clarifications.py`` loads both
+    the benchmark hint and the per-task clarification dict from it."""
+    overlay = _load_benchmark_clarifications("tests.clarif_fixture")
+    assert overlay.benchmark_hint == "Submit your final answer with final_step."
+    assert overlay.task_clarification["slider-2"] == "After setting the values, click Submit."
+    assert len(overlay.task_clarification) == 3
 
 
-def test_benchmark_config_add_task_clarification_defaults_false():
-    cfg = MyBenchmarkConfig()
-    assert cfg.add_task_clarification is False
-    enabled = MyBenchmarkConfig(add_task_clarification=True)
-    assert enabled.add_task_clarification is True
-    reloaded = MyBenchmarkConfig.model_validate_json(enabled.model_dump_json())
-    assert reloaded.add_task_clarification is True
+def test_load_benchmark_clarifications_absent_returns_empty():
+    overlay = _load_benchmark_clarifications("tests")  # no sidecar next to the tests package
+    assert overlay == BenchmarkClarifications()
+    assert overlay.benchmark_hint is None
+    assert overlay.task_clarification == {}
+
+
+def test_benchmark_config_load_clarifications_empty_by_default():
+    """The classmethod resolves the sidecar from the config's own module; the test
+    benchmark has none, so it returns an empty overlay."""
+    assert MyBenchmarkConfig.load_benchmark_clarifications() == BenchmarkClarifications()
 
 
 # ── __init_subclass__ validation ──────────────────────────────────────────────

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -101,7 +101,6 @@ _TASK_META_1 = {
     "abstract_description": "",
     "recommended_max_steps": None,
     "container_config": None,
-    "task_clarification": None,
 }
 
 _TASK_META_2 = {**_TASK_META_1, "id": "task-2"}
@@ -177,7 +176,6 @@ def test_benchmark_info(bench_client):
         "tags": [],
         "reset_isolation": None,
         "named_subsets": {},
-        "benchmark_hint_prompt": None,
     }
 
 

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -54,14 +54,7 @@ def test_task_metadata_defaults():
         abstract_description="",
         recommended_max_steps=None,
         container_config=None,
-        task_clarification=None,
     )
-
-
-def test_task_metadata_clarification_round_trips():
-    tm = TaskMetadata(id="my-task", task_clarification="After setting values, click submit.")
-    reloaded = TaskMetadata.model_validate_json(tm.model_dump_json())
-    assert reloaded.task_clarification == "After setting values, click submit."
 
 
 # --- Task.reset ---


### PR DESCRIPTION
## What

Replaces the per-field prompt slots added in 5bb0327 — **`BenchmarkMetadata.benchmark_hint_prompt`**, **`TaskMetadata.task_clarification`**, and **`BenchmarkConfig.add_task_clarification`** — with a single per-benchmark **sidecar module**, `benchmark_clarifications.py`, next to the benchmark's module (mirroring the existing `task_metadata` "files next to the module" convention). It exposes:

```python
BENCHMARK_HINT = "..."                       # benchmark-wide orientation (str | None)
TASK_CLARIFICATION = {task_id: "...", ...}   # per-task clarifications
```

loaded by:

```python
BenchmarkConfig.load_benchmark_clarifications() -> BenchmarkClarifications(benchmark_hint, task_clarification)
# empty overlay when no sidecar exists
```

## Why a `.py`, not metadata fields

- **Reuse / regularization**: a `.py` lets one clarification map onto many task ids (a comprehension over a task group), which pushes clarifications to *generalize* rather than overfit per task.
- **One place to grow**: the whole overlay lives in a single module the auto-cube hinter can append to.
- **Clean layering**: the benchmark only *organizes* these strings — it never acts on them. A harness reads them at experiment-design time and folds them into the agent config (e.g. `GennyConfig.benchmark_hint_prompt` / `task_clarification`). Nothing on `TaskConfig`/`EpisodeConfig`; no automatic delivery.

## Why no `add_task_clarification` flag

Applying the overlay is the **recipe's explicit choice**: pass `task_clarification=overlay.task_clarification` into the agent config, or pass `{}` for a clean baseline. A separate on/off boolean is redundant under "Python is the configuration", so it's removed.

The `load_benchmark_clarifications` docstring documents the **purpose of each string and when to use it** (benchmark-wide orientation vs. per-task fixes for brittle wording — e.g. the miniwob slider/submit case), carrying over the guidance that previously lived on the removed fields.

## Behavior / safety

- No sidecar → empty overlay (`(None, {})`). Absence is silent; an **import error inside an existing sidecar propagates** (not swallowed).
- Removing the three optional fields is safe: no benchmark set them, and the harness consumes the overlay via the agent config, not via these fields.

## Tests

`tests/clarif_fixture/` ships a sample sidecar (incl. the reuse-across-tasks pattern). `tests/test_benchmark.py` covers: load from sidecar, absent → empty, and the classmethod resolving from a config's own module. Specs (`benchmark`, `task`) and `docs/authoring-a-cube.markdown` updated. Full `tests/` green (only the unrelated missing-`docker` optional-dep test fails in this env).

## Companion

cube-harness #432 adds `GennyConfig.benchmark_hint_prompt` (the fold into the system message). A recipe wires both at design time: `GennyConfig(benchmark_hint_prompt=ov.benchmark_hint, task_clarification=ov.task_clarification)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)