### PR TITLE
refactor(resource): drop on_incompatible 'skip' mode (raise/force only)

### DIFF
--- a/openspec/changes/task-permission-requirements/deltas.md
+++ b/openspec/changes/task-permission-requirements/deltas.md
@@ -31,7 +31,7 @@ Subclasses fold `requires` via `super().requirements()`:
 
 ```python
 class InfraConfig(...):
-    on_incompatible: Literal["raise", "skip", "force"] = "raise"
+    on_incompatible: Literal["raise", "force"] = "raise"
 ```
 
 `can_serve(resource)` (existing — `requirements() <= capabilities()`) is the per-resource
@@ -47,13 +47,14 @@ publish `container:root`; `Toolkit` does not (pins a non-root uid).
 benchmark's `resources`, then apply the policy:
 
 - `"raise"` — any incompatible resource → `IncompatibleInfraError` (pre-episode, no spend).
-- `"skip"` — narrow the task view to the compatible subset (`subset_from_list`); a shared
-  benchmark-scoped incompatible resource still raises.
 - `"force"` — skip the gate entirely.
+
+A silent `"skip"` mode is intentionally absent — silently dropping tasks is the failure
+mode this gate removes. A future `"per-task-raise"` (benchmark proceeds; each incompatible
+task raises at episode start, recorded terminally) is the planned successor.
 
 ## CONSUMED (cube-harness follow-up, not in this change)
 
-- **skip mode** episodes map to the existing terminal, non-retriable `INVALID_CONFIG`.
 - tbench2 (and other root-needing cubes) codegen stamps `requires={"container:root"}`.
 
 ## Migration

--- a/openspec/changes/task-permission-requirements/proposal.md
+++ b/openspec/changes/task-permission-requirements/proposal.md
@@ -28,12 +28,12 @@ unification a task's `container_config` **is** a `ResourceConfig`, so the existi
 2. **Declaration.** `ResourceConfig.requires: set[str]` (base field), folded into
    `requirements()` by each subclass via `super().requirements()`. A task declares
    `requires={"container:root"}`.
-3. **Policy.** `InfraConfig.on_incompatible: Literal["raise","skip","force"] = "raise"`.
+3. **Policy.** `InfraConfig.on_incompatible: Literal["raise","force"] = "raise"`.
 4. **Gate.** `BenchmarkConfig.make()` runs `can_serve` over each task's `container_config`
    and the benchmark's declared `resources` **before provisioning**:
-   `"raise"` → `IncompatibleInfraError` (pre-episode, no spend); `"skip"` → narrow the task
-   view to the compatible subset (harness records the dropped ones as the existing terminal,
-   non-retriable `INVALID_CONFIG`); `"force"` → run everything. Metadata-only and launch-free.
+   `"raise"` → `IncompatibleInfraError` (pre-episode, no spend) if any resource is
+   incompatible; `"force"` → run everything. Metadata-only and launch-free.
+   (A silent `"skip"` was deliberately not kept — see below.)
 
 ## Why this shape
 
@@ -46,5 +46,9 @@ unification a task's `container_config` **is** a `ResourceConfig`, so the existi
 ## Out of scope / follow-ups
 
 - **cube-harness:** tbench2 (and other root-needing cubes) codegen stamps
-  `requires={"container:root"}`; harness maps skip-mode tasks to `INVALID_CONFIG`.
+  `requires={"container:root"}`.
+- **Per-task-raise mode:** a future `"per-task-raise"` may let the benchmark proceed while
+  each incompatible task raises at episode start (recorded as a terminal per-task error). A
+  silent `"skip"` is intentionally absent — silently dropping tasks is the failure mode this
+  gate exists to remove.
 - **Meta-infra + composite resources:** a separate effort. This gate already supports it.

--- a/openspec/specs/benchmark/spec.md
+++ b/openspec/specs/benchmark/spec.md
@@ -191,11 +191,10 @@ JSON-encoded strings as well.
   gate** first (when `infra` is set and `infra.on_incompatible != "force"`):
   `can_serve` is checked over every task's `container_config` and the benchmark's
   declared `resources`, applying `infra.on_incompatible` (`"raise"` →
-  `IncompatibleInfraError` before any provisioning; `"skip"` → task view narrowed to
-  the compatible subset; an incompatible benchmark-scoped resource always raises). This
-  is metadata-only and launch-free, so it stays cheap. Then, for every resource whose
+  `IncompatibleInfraError` before any provisioning if any resource is incompatible).
+  This is metadata-only and launch-free, so it stays cheap. Then, for every resource whose
   `infra.provision_status(resource) != "ready"`, call `infra.provision(resource)`
-  (idempotent), instantiate `type(cfg).benchmark_class(config=cfg, infra=infra)`, call
+  (idempotent), instantiate `type(self).benchmark_class(config=self, infra=infra)`, call
   `benchmark.setup()`, and return the live `Benchmark`. `infra` is forwarded to the
   runtime constructor so subclasses can reach it via `self._infra` from `_setup()`. When
   `infra` is None the gate is skipped (and, if `resources` is non-empty, provisioning is

--- a/openspec/specs/resource/spec.md
+++ b/openspec/specs/resource/spec.md
@@ -76,7 +76,7 @@ class VolumeSpec(TypedBaseModel):
 class InfraConfig(TypedBaseModel, ABC):
     default_ttl_seconds: int | None = 86400          # 1 day; overrides resource TTL
     image_name_suffix: str = ""                       # e.g. "-test" to isolate CI
-    on_incompatible: Literal["raise", "skip", "force"] = "raise"  # capability-gate policy
+    on_incompatible: Literal["raise", "force"] = "raise"  # capability-gate policy
 
     @abstractmethod
     def fingerprint(self) -> str                     # "aws:us-east-2", "azure:westus2", "local"
@@ -139,10 +139,12 @@ Checked at `make()` by running `can_serve` over each task's `container_config` a
 benchmark's `resources`:
 - `"raise"` (default) — abort with `IncompatibleInfraError` if **any** resource is
   incompatible. No provisioning, no episodes, no spend.
-- `"skip"` — run only the compatible tasks (the task view is narrowed); the harness records
-  the dropped ones terminally (`INVALID_CONFIG`). An incompatible *benchmark-scoped* resource
-  is shared and still raises.
 - `"force"` — attempt everything anyway (escape hatch to probe a stale requirement).
+
+Future: a per-task mode (`"per-task-raise"`) may let the benchmark proceed while each
+incompatible task raises at episode start — recording them as terminal per-task errors
+rather than dropping them. A silent `"skip"` is intentionally absent: silently dropping
+tasks is the failure mode this gate exists to remove.
 
 ## Cleanup Methods Reference
 

--- a/scripts/smoke/capability_gate_smoke.py
+++ b/scripts/smoke/capability_gate_smoke.py
@@ -12,8 +12,7 @@ Part A — handshake against the REAL `LocalInfraConfig.capabilities()` (no daem
 Part B — `BenchmarkConfig.make()` gate end-to-end with real local infra capabilities
   (install() no-op'd — orthogonal system-dep step we are not testing):
     * a non-root infra (real local minus `container:root`, mirroring EAI Toolkit) →
-      `on_incompatible="raise"` aborts with `IncompatibleInfraError`; `"skip"` drops only
-      the root task; `"force"` keeps everything.
+      `on_incompatible="raise"` aborts with `IncompatibleInfraError`; `"force"` keeps everything.
     * a root-capable infra serves both tasks.
 
 Part C — capability TRUTH (docker daemon required, else SKIP): launch a container on local
@@ -123,16 +122,8 @@ def check_gate() -> None:
     log.info("  [B] raise -> IncompatibleInfraError on non-root infra OK")
 
     if not has_docker:
-        log.info("  [B] no docker binary — skipping skip/force/positive cases (plain task needs docker)")
+        log.info("  [B] no docker binary — skipping force/positive cases (plain task needs docker)")
         return
-
-    # skip: drop only the incompatible (root) task.
-    bench = _GateBenchConfig().make(_NonRootLocal(on_incompatible="skip"))
-    try:
-        assert set(bench.config.tasks()) == {"plain"}, set(bench.config.tasks())
-    finally:
-        bench.close()
-    log.info("  [B] skip -> {plain} kept, {root} dropped OK")
 
     # force: keep everything.
     bench = _GateBenchConfig().make(_NonRootLocal(on_incompatible="force"))

--- a/src/cube/benchmark.py
+++ b/src/cube/benchmark.py
@@ -733,24 +733,23 @@ class BenchmarkConfig[TTMetadata: TaskMetadata](ValidatedConfig, ABC):
         for per-task container launches can do so from ``_setup()`` without
         overriding ``make``.
         """
-        # 0. Capability gate (fail-fast, before any install / provisioning or episode).
-        cfg: Self = self
+        # 0. Capability gate: fail fast before any install / provisioning or episode.
         if infra is not None and infra.on_incompatible != "force":
-            cfg = self._gate_infra_compatibility(infra)
+            self._gate_infra_compatibility(infra)
 
         if infra is not None:
             infra.install()
 
-        if cfg.resources:
+        if self.resources:
             if infra is None:
                 logger.debug(
                     "%s.make() called without infra but %d resource(s) are declared; "
                     "skipping provisioning (task-scoped resources will be launched per-task).",
-                    type(cfg).__name__,
-                    len(cfg.resources),
+                    type(self).__name__,
+                    len(self.resources),
                 )
             else:
-                for resource in cfg.resources:
+                for resource in self.resources:
                     status = infra.provision_status(resource)
                     if status == "ready":
                         logger.info("Resource %s already provisioned on %s", resource.name, infra.fingerprint())
@@ -758,19 +757,16 @@ class BenchmarkConfig[TTMetadata: TaskMetadata](ValidatedConfig, ABC):
                     logger.info("Provisioning resource %s on %s...", resource.name, infra.fingerprint())
                     infra.provision(resource)
 
-        benchmark = type(cfg).benchmark_class(config=cfg, infra=infra)
+        benchmark = type(self).benchmark_class(config=self, infra=infra)
         benchmark.setup()
         return benchmark
 
-    def _gate_infra_compatibility(self, infra: InfraConfig) -> Self:
-        """Run ``infra.can_serve`` over every resource this benchmark needs and apply
-        ``infra.on_incompatible``. Returns ``self`` (or, in ``"skip"`` mode, a task-narrowed
-        copy); raises ``IncompatibleInfraError`` in ``"raise"`` mode. Metadata-only and
-        launch-free, so it stays cheap even for large benchmarks. Never called for
-        ``on_incompatible == "force"``.
+    def _gate_infra_compatibility(self, infra: InfraConfig) -> None:
+        """Raise ``IncompatibleInfraError`` if ``infra`` cannot serve every resource this
+        benchmark needs — each task's container plus the benchmark's declared resources.
+        Metadata-only and launch-free, so it stays cheap even for large benchmarks. Only
+        called when ``infra.on_incompatible == "raise"`` (``"force"`` skips the gate).
         """
-        # Benchmark-scoped resources are shared by every task → an incompatible one is
-        # always fatal (it cannot be skipped), regardless of the policy.
         bad_shared = [r for r in self.resources if not infra.can_serve(r)]
         incompatible = {
             tid: sorted(tm.container_config.requirements())
@@ -778,29 +774,16 @@ class BenchmarkConfig[TTMetadata: TaskMetadata](ValidatedConfig, ABC):
             if tm.container_config is not None and not infra.can_serve(tm.container_config)
         }
         if not bad_shared and not incompatible:
-            return self
+            return
 
-        if bad_shared or infra.on_incompatible == "raise":
-            detail = {r.name: sorted(r.requirements()) for r in bad_shared}
-            detail.update(dict(list(incompatible.items())[:5]))
-            more = "" if len(incompatible) <= 5 else f" (+{len(incompatible) - 5} more tasks)"
-            raise IncompatibleInfraError(
-                f"{type(infra).__name__} (capabilities={sorted(infra.capabilities())}) cannot "
-                f"serve {len(bad_shared) + len(incompatible)} resource(s) of benchmark "
-                f"{self.benchmark_metadata.name!r}: {detail}{more}"
-            )
-
-        # skip mode: drop the incompatible tasks, keep the compatible subset.
-        keep = [tid for tid in self.tasks() if tid not in incompatible]
-        logger.warning(
-            "on_incompatible='skip': %s cannot serve %d/%d task(s) of %r; skipping %s",
-            type(infra).__name__,
-            len(incompatible),
-            len(self.tasks()),
-            self.benchmark_metadata.name,
-            sorted(incompatible),
+        detail = {r.name: sorted(r.requirements()) for r in bad_shared}
+        detail.update(dict(list(incompatible.items())[:5]))
+        more = "" if len(incompatible) <= 5 else f" (+{len(incompatible) - 5} more tasks)"
+        raise IncompatibleInfraError(
+            f"{type(infra).__name__} (capabilities={sorted(infra.capabilities())}) cannot "
+            f"serve {len(bad_shared) + len(incompatible)} resource(s) of benchmark "
+            f"{self.benchmark_metadata.name!r}: {detail}{more}"
         )
-        return self.subset_from_list(keep)
 
 
 class Benchmark[TBenchConfig: BenchmarkConfig](ABC):

--- a/src/cube/resource.py
+++ b/src/cube/resource.py
@@ -420,7 +420,7 @@ class ResourceHandle(ABC):
 
 # ── InfraConfig ───────────────────────────────────────────────────────────────
 
-OnIncompatible = Literal["raise", "skip", "force"]
+OnIncompatible = Literal["raise", "force"]
 
 
 class InfraConfig(ValidatedConfig, ABC):
@@ -474,11 +474,13 @@ class InfraConfig(ValidatedConfig, ABC):
 
     - ``"raise"`` (default) — abort with ``IncompatibleInfraError`` if ANY resource is
       incompatible. No provisioning, no episodes, no spend.
-    - ``"skip"`` — run only the compatible tasks; incompatible ones are dropped from the
-      task view (the harness records them terminally). An incompatible *benchmark-scoped*
-      resource still raises — it is shared and cannot be skipped.
     - ``"force"`` — attempt everything anyway; the escape hatch to probe whether a stale
-      requirement still holds."""
+      requirement still holds.
+
+    Future: a per-task mode (``"per-task-raise"``) will let the benchmark proceed while each
+    incompatible task raises at episode start, so the incompatible tasks are recorded as
+    terminal per-task errors rather than vanishing. (A silent ``"skip"`` was deliberately
+    not kept — silently dropping tasks is the failure mode this gate exists to remove.)"""
 
     # ── Lifecycle ─────────────────────────────────────────────────────────────
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -735,7 +735,7 @@ def test_setup_cleanup_stale_called_before_subclass_setup() -> None:
         bench.close()
 
 
-# ── make() capability gate: on_incompatible raise / skip / force (RFC #191) ────
+# ── make() capability gate: on_incompatible raise / force ─────────────────────
 
 
 class _GateInfra(InfraConfig):
@@ -792,15 +792,6 @@ def test_make_raise_aborts_when_a_task_is_incompatible() -> None:
     infra = _GateInfra(caps=["docker"], on_incompatible="raise")  # no container:root
     with pytest.raises(IncompatibleInfraError, match="cannot serve"):
         _GateBenchConfig().make(infra=infra)
-
-
-def test_make_skip_drops_only_the_incompatible_tasks() -> None:
-    infra = _GateInfra(caps=["docker"], on_incompatible="skip")
-    bench = _GateBenchConfig().make(infra=infra)
-    try:
-        assert set(bench.config.tasks()) == {"plain"}
-    finally:
-        bench.close()
 
 
 def test_make_force_keeps_every_task() -> None:


### PR DESCRIPTION
## What

Drop the `"skip"` mode from `InfraConfig.on_incompatible` — keep `"raise"` (default) and `"force"`.

## Why

The capability gate (#191) shipped a `"skip"` mode that **silently dropped** incompatible tasks by narrowing the benchmark's task view. That's exactly the silent-failure class the gate exists to *remove*: dropped tasks left **no result record** (the `INVALID_CONFIG` mapping that would have surfaced them was never built), so a run could quietly evaluate a subset and look complete.

`"raise"` (abort the whole run, explicit) and `"force"` (explicit escape hatch) cover the real needs. `OnIncompatible` stays a `Literal`, so the *intended* successor slots in later without a silent drop:

> **per-task-raise** (future) — the benchmark proceeds, but each *incompatible* task raises at episode start, so it's recorded as a terminal per-task error rather than vanishing.

## Change

- `OnIncompatible = Literal["raise", "force"]`.
- `_gate_infra_compatibility` is now raise-or-return (no `subset_from_list` narrowing); `make()` drops the `cfg` branch and uses `self` directly.
- Removed the skip unit test + the skip case in `capability_gate_smoke.py`.
- Updated the living `resource/`+`benchmark/` specs and the change proposal/deltas (the deferred `INVALID_CONFIG` follow-up is gone; replaced by the per-task-raise note).

## Verification

Full suite green; `make lint` clean. `capability_gate_smoke.py` green on colima — `raise` aborts, `force` keeps all, root-capable infra serves, and the launched container still asserts `id -u == 0`.

Net diff: **−27 lines** (8 files), simpler gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
