### PR TITLE
fix(container): relocate_if_readonly force= for root-owned subdirs

### DIFF
--- a/src/cube/container.py
+++ b/src/cube/container.py
@@ -123,6 +123,7 @@ def relocate_if_readonly(
     new_wd: str,
     *,
     extra_setup: str | None = None,
+    force: bool = False,
 ) -> str:
     """Copy *working_dir* to *new_wd* if it isn't writable by the runtime user.
 
@@ -130,6 +131,15 @@ def relocate_if_readonly(
     *new_wd* after the copy).  Cubes that need additional setup after the copy
     (e.g. ``git config safe.directory``) can pass the commands as *extra_setup*
     — they are appended to the ``cp -a`` invocation with ``&&``.
+
+    The default probe (``test -w working_dir``) only checks the **top** dir. A
+    writable top dir can still hold root-owned, non-writable *subdirectories*
+    (some upstream Docker images bake them in) that a non-root runtime user
+    can neither write nor reparent in place — the caller knows this from its own
+    deeper writability check and passes ``force=True`` to relocate unconditionally
+    to a fully runtime-user-owned copy (``cp -a`` creates everything owned by the
+    runtime user). Tests run from *new_wd* import the relocated copy because
+    ``python -m pytest`` puts the cwd first on ``sys.path``.
 
     Typical usage in a cube's ``_build_tool()``::
 
@@ -141,9 +151,13 @@ def relocate_if_readonly(
             container=self._container
         )
     """
-    probe = container.exec(f"test -w {working_dir} && echo W || echo R", timeout=30)
-    if "W" in probe.stdout:
-        return working_dir
+    # auto-fix(205)↓ force= skips the top-dir probe so a caller can relocate even
+    # when `test -w {working_dir}` passes — it misses root-owned non-writable subdirs.
+    if not force:
+        probe = container.exec(f"test -w {working_dir} && echo W || echo R", timeout=30)
+        if "W" in probe.stdout:
+            return working_dir
+    # /auto-fix(205)
     logger.info("%s not writable by runtime user — copying to %s", working_dir, new_wd)
     cmd = f"cp -a {working_dir} {new_wd}"
     if extra_setup:
@@ -193,4 +207,14 @@ from cube.resource import ContainerConfig  # noqa: E402,F401
 #   why:       check result.exit_code; raise the module's domain exception
 #              (ContainerExecError), consistent with its error hierarchy.
 #   tested:    tests/test_container.py relocate cases.
+#   hash=PENDING: stamped by scripts/auto_fix_lint.py (Tier-1) on first run.
+# auto-fix-note(205) {class=L1 issue=205 hash=PENDING ctx=toolkit/uid-13011/swebench-verified/cube-standard@a9d98a7}
+#   symptoms:  non-root runtime (EAI toolkit uid 13011) — `test -w /testbed` passes
+#              but a root-owned subdir (psf/requests' /testbed/requests/) is
+#              non-writable, so relocate never fired and patches hit Permission denied.
+#   invariant: relocate_if_readonly yields a FULLY writable working dir; force= lets
+#              a caller that detected nested non-writable paths relocate regardless.
+#   why:       force= is additive (default False = prior probe behavior); only the
+#              caller knows its tree must be fully writable (it patches every file).
+#   tested:    cube-harness #443 — psf/requests gold patch 0/6 -> 6/6 on toolkit.
 #   hash=PENDING: stamped by scripts/auto_fix_lint.py (Tier-1) on first run.


### PR DESCRIPTION
# Fix Report — `relocate_if_readonly(..., force=)`

**Class**: L1 (shared layer, additive/backward-compatible) · **Anchor**: this PR
**Context fingerprint**: `toolkit/yul101/uid-13011/cube-standard@dev`
**Pairs with**: cube-harness `auto-fix/swebench-nonroot-subdir` (the caller that needs it)

## Invariant violated
`relocate_if_readonly` must yield a working directory the runtime user can
**fully** write — including nested files and subdirectories — not merely a
directory whose *top* node is writable.

## Root cause
The probe is `test -w {working_dir}` — it only checks the top directory. A
writable top dir can still contain **root-owned, non-writable subdirectories**
that a non-root runtime user (EAI toolkit pins uid 13011) can neither write nor
reparent in place (you can't `rm`/recreate entries inside a dir you don't own).
The function then returns the original path and the caller's later writes fail
with `Permission denied`. The caller can detect this with its own deeper
writability check, but had no way to *ask* for a relocate when the top dir
happened to be writable.

## Why this fix / why this layer
- `relocate_if_readonly` owns the "give me a writable working dir" contract, so
  the knob belongs here.
- `force=False` default → **no behavior change** for any existing caller; the
  probe shortcut is unchanged unless `force=True`.
- `cp -a` as the runtime user creates a copy fully owned by that user, which is
  exactly the escape hatch a non-root runtime needs.

## Blast radius
`git grep relocate_if_readonly origin/dev`:
- `src/cube/container.py:136` (docstring example) — unchanged.
- `cubes/swebench-verified-cube/.../task.py:173` — the new opt-in caller (paired PR).
- `cubes/swebench-live-cube/.../task.py:173` — same latent bug; not opted-in here (follow-up).
- `cubes/terminalbench2-cube/.../task.py` — read-only-mount case; `force` defaults False → unchanged.

## Adversarial: the opposite user
A caller that *relies* on `relocate_if_readonly` NOT relocating when the top dir
is writable. Ruled out: `force` defaults to `False`, so the probe path is
byte-for-byte the prior behavior; only an explicit `force=True` opts in.

## Test
- Existing `tests/test_container.py` relocate cases (writable→keep, readonly→copy,
  cp-fails→raise) are unaffected (`force` defaults False).
- New behavior witness (paired cube-harness PR): with `force=True`,
  `psf__requests-1142` gold patch goes 0.0→1.0 on toolkit (uid 13011).
