### PR TITLE
feat(core,tool,task): add Artifact types and Tool.artifacts() contract

### DIFF
--- a/openspec/changes/task-artifacts/deltas.md
+++ b/openspec/changes/task-artifacts/deltas.md
@@ -1,0 +1,82 @@
+# Deltas — Task Artifacts
+
+## ADDED — `cube.core`: Artifact types
+
+```python
+class BinaryArtifactBlob(TypedBaseModel):
+    type: Literal["binary"] = "binary"
+    blob: bytes
+
+class FileArtifactBlob(TypedBaseModel):
+    type: Literal["file"] = "file"
+    path: Path
+
+class RemoteFileArtifactBlob(TypedBaseModel):
+    type: Literal["remote_file"] = "remote_file"
+    url: str
+
+class TextArtifactBlob(TypedBaseModel):
+    type: Literal["text"] = "text"
+    text: str
+
+ArtifactBlob = Annotated[
+    BinaryArtifactBlob | TextArtifactBlob | FileArtifactBlob | RemoteFileArtifactBlob,
+    Field(discriminator="type"),
+]
+
+class Artifact(TypedBaseModel):
+    mime: str
+    id: str
+    blob: ArtifactBlob
+```
+
+Typed envelope for side-channel outputs (traces, logs, screenshots)
+produced by tools and tasks. The discriminated `ArtifactBlob` union
+allows the harness to handle each storage form differently (read from
+disk, upload bytes, reference a remote URL).
+
+## ADDED — `cube.tool`: `AbstractTool.artifacts()` / `AbstractAsyncTool.artifacts()`
+
+```python
+class AbstractTool(ABC):
+    @abstractmethod
+    def artifacts(self) -> list[Artifact]: ...
+
+class AbstractAsyncTool(ABC):
+    @abstractmethod
+    def artifacts(self) -> list[Artifact]: ...
+```
+
+Called after `close()` to collect side-channel outputs. Must not raise.
+Abstract — direct `AbstractTool`/`AbstractAsyncTool` subclasses must
+implement it. The concrete `Tool` and `AsyncTool` bases provide a
+default returning `[]`.
+
+`Toolbox.artifacts()` and `AsyncToolbox.artifacts()` concatenate
+results from all contained tools.
+
+## ADDED — `cube.task`: `Task.task_artifacts()` and `Task.artifacts()`
+
+```python
+class Task:
+    def task_artifacts(self) -> list[Artifact]:
+        return []
+
+    def artifacts(self) -> list[Artifact]:
+        return self.task_artifacts() + self.tool.artifacts()
+```
+
+`task_artifacts()` is the override point for task-specific artifacts.
+`artifacts()` combines task and tool artifacts — not intended to be
+overridden.
+
+## Migration impact
+
+**`Tool` / `AsyncTool` subclasses** — no change required (default
+returns `[]`).
+
+**Direct `AbstractTool` / `AbstractAsyncTool` subclasses** — must add
+`artifacts() -> list[Artifact]`. In cube-harness, `ToolWithTelemetry`
+and `AsyncToolWithTelemetry` should delegate to the wrapped tool.
+
+**`Task` subclasses** — no change required (defaults return `[]`).

--- a/openspec/changes/task-artifacts/deltas.md
+++ b/openspec/changes/task-artifacts/deltas.md
@@ -1,82 +1,58 @@
 # Deltas — Task Artifacts
 
-## ADDED — `cube.core`: Artifact types
+## ADDED — `cube.core`: `FileContent` (out-of-line `Content`)
 
 ```python
-class BinaryArtifactBlob(TypedBaseModel):
-    type: Literal["binary"] = "binary"
-    blob: bytes
-
-class FileArtifactBlob(TypedBaseModel):
-    type: Literal["file"] = "file"
-    path: Path
-
-class RemoteFileArtifactBlob(TypedBaseModel):
-    type: Literal["remote_file"] = "remote_file"
-    url: str
-
-class TextArtifactBlob(TypedBaseModel):
-    type: Literal["text"] = "text"
-    text: str
-
-ArtifactBlob = Annotated[
-    BinaryArtifactBlob | TextArtifactBlob | FileArtifactBlob | RemoteFileArtifactBlob,
-    Field(discriminator="type"),
-]
-
-class Artifact(TypedBaseModel):
-    mime: str
-    id: str
-    blob: ArtifactBlob
+class FileContent(Content):
+    data: str            # local filesystem path or remote URL
+    mime: str | None = None
+    is_remote: bool = False
 ```
 
-Typed envelope for side-channel outputs (traces, logs, screenshots)
-produced by tools and tasks. The discriminated `ArtifactBlob` union
-allows the harness to handle each storage form differently (read from
-disk, upload bytes, reference a remote URL).
+Artifacts reuse the existing `Content` union rather than a new envelope:
+screenshots → `ImageContent`, logs → `TextContent`, HAR → `StructuredContent`.
+The only gap is *out-of-line* data, so we add one `Content` subclass whose
+`data` is a location, not the inlined bytes — for large artifacts (Playwright
+traces, recordings) that must not be embedded in trajectory JSON or pickled
+across workers. `FileContent` participates in `Content`'s existing polymorphic
+(`_type`) serialization; no discriminated union is introduced. `to_markdown()`
+renders a link (so XRay shows it); `to_llm_message()` raises — it is a
+side-channel reference, never an LLM-facing observation.
 
 ## ADDED — `cube.tool`: `AbstractTool.artifacts()` / `AbstractAsyncTool.artifacts()`
 
 ```python
 class AbstractTool(ABC):
-    @abstractmethod
-    def artifacts(self) -> list[Artifact]: ...
+    def artifacts(self) -> list[Content]:
+        return []
 
 class AbstractAsyncTool(ABC):
-    @abstractmethod
-    def artifacts(self) -> list[Artifact]: ...
+    def artifacts(self) -> list[Content]:
+        return []
 ```
 
-Called after `close()` to collect side-channel outputs. Must not raise.
-Abstract — direct `AbstractTool`/`AbstractAsyncTool` subclasses must
-implement it. The concrete `Tool` and `AsyncTool` bases provide a
-default returning `[]`.
-
-`Toolbox.artifacts()` and `AsyncToolbox.artifacts()` concatenate
+Called after `close()` to collect side-channel outputs; never enters the LLM
+observation stream. Must not raise. **Concrete default returning `[]`** (not
+abstract) — no subclass is forced to implement it; tools that produce artifacts
+override it. `Toolbox.artifacts()` / `AsyncToolbox.artifacts()` concatenate
 results from all contained tools.
 
-## ADDED — `cube.task`: `Task.task_artifacts()` and `Task.artifacts()`
+## ADDED — `cube.task`: `Task.artifacts()`
 
 ```python
 class Task:
-    def task_artifacts(self) -> list[Artifact]:
+    def artifacts(self) -> list[Content]:
         return []
-
-    def artifacts(self) -> list[Artifact]:
-        return self.task_artifacts() + self.tool.artifacts()
 ```
 
-`task_artifacts()` is the override point for task-specific artifacts.
-`artifacts()` combines task and tool artifacts — not intended to be
-overridden.
+Returns the task's *own* artifacts (override to provide some). Consistent with
+`Tool.artifacts()` — each object reports only its own outputs. Tool artifacts are
+reached separately via `self.tool.artifacts()`; the harness combines both at episode
+end (`task.artifacts() + task.tool.artifacts()`).
 
 ## Migration impact
 
-**`Tool` / `AsyncTool` subclasses** — no change required (default
-returns `[]`).
-
-**Direct `AbstractTool` / `AbstractAsyncTool` subclasses** — must add
-`artifacts() -> list[Artifact]`. In cube-harness, `ToolWithTelemetry`
-and `AsyncToolWithTelemetry` should delegate to the wrapped tool.
-
-**`Task` subclasses** — no change required (defaults return `[]`).
+**Fully backwards compatible.** `artifacts()` has a concrete default on
+`AbstractTool`/`AbstractAsyncTool`, so existing tools (direct or via
+`Tool`/`AsyncTool`) need no change. `Task` defaults return `[]`. No new
+required methods anywhere.

--- a/openspec/changes/task-artifacts/proposal.md
+++ b/openspec/changes/task-artifacts/proposal.md
@@ -1,0 +1,89 @@
+# Task Artifacts — typed side-channel outputs from tasks and tools
+
+**Status:** Proposed
+**Date:** 2026-05-14
+**Scope:** `cube.core`, `cube.task`, `cube.tool`
+**Targets:** `main`
+**Related:** Unblocks cube-harness episode artifact export (Playwright traces,
+HAR files, screenshots) and OTel artifact attachment.
+
+---
+
+## Problem
+
+Tasks and tools produce side-channel outputs that aren't part of the
+observation stream: Playwright traces, HAR network logs, screenshots,
+container logs. Today there's no standard way to collect these after an
+episode completes. cube-harness has ad-hoc code that reaches into tool
+internals to extract traces — tightly coupled to specific tool
+implementations and not generalizable.
+
+## Solution
+
+Three additions:
+
+1. **`Artifact` + blob types in `cube.core`** — a typed envelope for
+   side-channel data. Each artifact has an `id`, a `mime` type, and a
+   `blob` that is one of: `BinaryArtifactBlob` (in-memory bytes),
+   `FileArtifactBlob` (local path), `RemoteFileArtifactBlob` (URL),
+   `TextArtifactBlob` (plain text). The blob union is discriminated on
+   `type` for clean serialization.
+
+2. **`Tool.artifacts() -> list[Artifact]`** — abstract method on
+   `AbstractTool`. Called after `close()` to collect any artifacts the
+   tool produced during the episode. Default on `Tool` returns `[]`.
+   `Toolbox` fans out to all contained tools and concatenates results.
+
+3. **`Task.artifacts() -> list[Artifact]`** — collects tool artifacts
+   plus any task-specific artifacts. Two methods:
+   - `task_artifacts()` — override point for task-specific artifacts
+     (default `[]`).
+   - `artifacts()` — returns `task_artifacts() + tool.artifacts()`.
+     Not intended to be overridden.
+
+The harness calls `task.artifacts()` after the episode loop completes
+(after `close()`) and handles export (write to disk, upload to GCS,
+attach to OTel spans) — that's a harness concern, not a cube-standard
+concern.
+
+## Backwards compatibility
+
+**Fully backwards compatible for `Tool` and `AsyncTool` subclasses.**
+The concrete bases provide a default `artifacts()` returning `[]`.
+
+**Breaking for direct `AbstractTool`/`AbstractAsyncTool` subclasses**
+that don't go through `Tool`/`AsyncTool`. These must add an
+`artifacts()` implementation. In cube-harness, `ToolWithTelemetry` and
+`AsyncToolWithTelemetry` are the known cases — they should delegate to
+the wrapped tool's `artifacts()`.
+
+**Fully backwards compatible for existing Task subclasses.** Both
+`task_artifacts()` and `artifacts()` have default implementations.
+
+## Non-goals
+
+- Defining how artifacts are exported/stored — that's the harness's job.
+- Async artifact collection — artifacts are collected after `close()`,
+  not during the hot loop. Sync is fine.
+- Artifact streaming during an episode — out of scope. Artifacts are
+  batch-collected at episode end.
+
+## Migration
+
+**This PR (cube-standard):**
+
+- `cube.core`: add `BinaryArtifactBlob`, `FileArtifactBlob`,
+  `RemoteFileArtifactBlob`, `TextArtifactBlob`, `ArtifactBlob`
+  (discriminated union), `Artifact`.
+- `cube.tool`: add `AbstractTool.artifacts()` abstract method.
+  `Tool.artifacts()` returns `[]`. `Toolbox.artifacts()` fans out.
+- `cube.task`: add `Task.task_artifacts()` (default `[]`) and
+  `Task.artifacts()` (combines task + tool artifacts).
+- Update specs: `core/spec.md`, `tool/spec.md`, `task/spec.md`.
+
+**Follow-up PRs:**
+
+- cube-standard `feat/playwright-trace-artifacts`: `PlaywrightSession`
+  tracing + `SyncPlaywrightTool.artifacts()` returning the trace ZIP.
+- cube-harness: episode artifact export calling `task.artifacts()` and
+  routing to storage/OTel.

--- a/openspec/changes/task-artifacts/proposal.md
+++ b/openspec/changes/task-artifacts/proposal.md
@@ -1,9 +1,9 @@
-# Task Artifacts — typed side-channel outputs from tasks and tools
+# Task Artifacts — side-channel outputs from tasks and tools
 
 **Status:** Proposed
 **Date:** 2026-05-14
 **Scope:** `cube.core`, `cube.task`, `cube.tool`
-**Targets:** `main`
+**Targets:** `dev`
 **Related:** Unblocks cube-harness episode artifact export (Playwright traces,
 HAR files, screenshots) and OTel artifact attachment.
 
@@ -11,79 +11,72 @@ HAR files, screenshots) and OTel artifact attachment.
 
 ## Problem
 
-Tasks and tools produce side-channel outputs that aren't part of the
-observation stream: Playwright traces, HAR network logs, screenshots,
-container logs. Today there's no standard way to collect these after an
-episode completes. cube-harness has ad-hoc code that reaches into tool
-internals to extract traces — tightly coupled to specific tool
-implementations and not generalizable.
+Tasks and tools produce side-channel outputs that aren't part of the observation
+stream: Playwright traces, HAR network logs, screenshots, container logs. There's
+no standard way to collect these after an episode completes, so the harness would
+have to reach into tool internals — coupled to specific implementations and not
+generalizable.
 
 ## Solution
 
-Three additions:
+Reuse the existing `cube.core.Content` union as the artifact payload type instead
+of inventing a parallel envelope. Screenshots → `ImageContent`, logs →
+`TextContent`, HAR → `StructuredContent`. The only thing `Content` can't express
+is *out-of-line* data (a path/URL instead of inlined bytes), so we add one
+subclass:
 
-1. **`Artifact` + blob types in `cube.core`** — a typed envelope for
-   side-channel data. Each artifact has an `id`, a `mime` type, and a
-   `blob` that is one of: `BinaryArtifactBlob` (in-memory bytes),
-   `FileArtifactBlob` (local path), `RemoteFileArtifactBlob` (URL),
-   `TextArtifactBlob` (plain text). The blob union is discriminated on
-   `type` for clean serialization.
+1. **`cube.core.FileContent`** — `Content` whose `data` is a location (local path
+   or remote URL, `is_remote` flag), with an optional `mime` hint. For large
+   artifacts that must not be inlined into trajectory JSON or pickled across
+   workers. Uses `Content`'s existing polymorphic serialization — no new
+   discriminated union.
 
-2. **`Tool.artifacts() -> list[Artifact]`** — abstract method on
-   `AbstractTool`. Called after `close()` to collect any artifacts the
-   tool produced during the episode. Default on `Tool` returns `[]`.
-   `Toolbox` fans out to all contained tools and concatenates results.
+2. **`Tool.artifacts() -> list[Content]`** — collected after `close()`; never
+   enters the LLM observation stream. **Concrete default returning `[]`** on
+   `AbstractTool`/`AbstractAsyncTool` (not abstract — most tools have none, so
+   nothing is forced to implement it). `Toolbox` fans out and concatenates.
 
-3. **`Task.artifacts() -> list[Artifact]`** — collects tool artifacts
-   plus any task-specific artifacts. Two methods:
-   - `task_artifacts()` — override point for task-specific artifacts
-     (default `[]`).
-   - `artifacts()` — returns `task_artifacts() + tool.artifacts()`.
-     Not intended to be overridden.
+3. **`Task.artifacts() -> list[Content]`** — the task's *own* artifacts (override
+   point, default `[]`). Symmetric with `Tool.artifacts()`: each object reports only
+   its own outputs. Tool artifacts stay reachable via `task.tool.artifacts()`.
 
-The harness calls `task.artifacts()` after the episode loop completes
-(after `close()`) and handles export (write to disk, upload to GCS,
-attach to OTel spans) — that's a harness concern, not a cube-standard
-concern.
+The harness, after the episode loop (after `close()`), collects
+`task.artifacts() + task.tool.artifacts()` and handles export (write to disk, upload,
+attach to OTel spans) — a harness concern.
+
+## Why reuse `Content`
+
+`Artifact` + a 4-variant `ArtifactBlob` union would duplicate types we already
+have (`TextArtifactBlob`≈`TextContent`, binary≈the `bytes` already on
+`Audio`/`VideoContent`). The genuine delta over `Content` is out-of-line storage
+(path/URL) plus an explicit `mime` — both folded into one `FileContent`. Bonus:
+existing `to_markdown()` means screenshots/logs render in XRay for free.
 
 ## Backwards compatibility
 
-**Fully backwards compatible for `Tool` and `AsyncTool` subclasses.**
-The concrete bases provide a default `artifacts()` returning `[]`.
-
-**Breaking for direct `AbstractTool`/`AbstractAsyncTool` subclasses**
-that don't go through `Tool`/`AsyncTool`. These must add an
-`artifacts()` implementation. In cube-harness, `ToolWithTelemetry` and
-`AsyncToolWithTelemetry` are the known cases — they should delegate to
-the wrapped tool's `artifacts()`.
-
-**Fully backwards compatible for existing Task subclasses.** Both
-`task_artifacts()` and `artifacts()` have default implementations.
+Fully backwards compatible. `artifacts()` has a concrete default on the abstract
+tool bases, so every existing tool (direct subclass or via `Tool`/`AsyncTool`)
+is unaffected; `Task` defaults return `[]`. No new required methods.
 
 ## Non-goals
 
-- Defining how artifacts are exported/stored — that's the harness's job.
-- Async artifact collection — artifacts are collected after `close()`,
-  not during the hot loop. Sync is fine.
-- Artifact streaming during an episode — out of scope. Artifacts are
-  batch-collected at episode end.
+- How artifacts are exported/stored — harness's job.
+- Async collection — collected after `close()`, not on the hot loop. Sync is fine.
+- Streaming during an episode — batch-collected at episode end.
 
 ## Migration
 
 **This PR (cube-standard):**
 
-- `cube.core`: add `BinaryArtifactBlob`, `FileArtifactBlob`,
-  `RemoteFileArtifactBlob`, `TextArtifactBlob`, `ArtifactBlob`
-  (discriminated union), `Artifact`.
-- `cube.tool`: add `AbstractTool.artifacts()` abstract method.
-  `Tool.artifacts()` returns `[]`. `Toolbox.artifacts()` fans out.
-- `cube.task`: add `Task.task_artifacts()` (default `[]`) and
-  `Task.artifacts()` (combines task + tool artifacts).
+- `cube.core`: add `FileContent`.
+- `cube.tool`: add `AbstractTool.artifacts()` / `AbstractAsyncTool.artifacts()`
+  (concrete default `[]`); `Toolbox`/`AsyncToolbox` fan out.
+- `cube.task`: add `Task.artifacts()` (task's own artifacts, default `[]`).
 - Update specs: `core/spec.md`, `tool/spec.md`, `task/spec.md`.
 
 **Follow-up PRs:**
 
-- cube-standard `feat/playwright-trace-artifacts`: `PlaywrightSession`
-  tracing + `SyncPlaywrightTool.artifacts()` returning the trace ZIP.
-- cube-harness: episode artifact export calling `task.artifacts()` and
-  routing to storage/OTel.
+- cube-standard `feat/playwright-trace-artifacts`: `PlaywrightSession` tracing +
+  `SyncPlaywrightTool.artifacts()` returning a `FileContent` for the trace ZIP.
+- cube-harness: episode artifact export calling `task.artifacts()` and routing to
+  storage/OTel.

--- a/src/cube/core.py
+++ b/src/cube/core.py
@@ -20,8 +20,7 @@ import io
 import json
 import traceback
 from abc import ABC, abstractmethod
-from pathlib import Path
-from typing import Annotated, Any, Callable, ClassVar, Literal, Self
+from typing import Any, Callable, ClassVar, Self
 
 from PIL import Image as PILImage
 from pydantic import (
@@ -371,6 +370,31 @@ class VideoContent(Content):
         raise NotImplementedError("Video is not supported by LLM message format.")
 
 
+class FileContent(Content):
+    """Reference to out-of-line data — a local filesystem path or a remote URL.
+
+    Unlike the other `Content` subclasses, the payload is *not* inlined: `data` holds a
+    location, not the bytes themselves. This is for large side-channel artifacts
+    (Playwright traces, screen recordings, HAR dumps) that should not be embedded in
+    trajectory JSON or pickled across workers. The harness reads/uploads the referenced
+    data when exporting; it does not enter the LLM observation stream.
+
+    Set `is_remote=True` when `data` is a URL the harness should reference as-is rather
+    than read from the local filesystem. `mime` is an optional hint for export/storage.
+    """
+
+    data: str  # local filesystem path or remote URL
+    mime: str | None = None
+    is_remote: bool = False
+
+    def to_markdown(self) -> str:
+        label = self.name or self.data
+        return f"[{label}]({self.data})"
+
+    def to_llm_message(self) -> dict:
+        raise NotImplementedError("FileContent is an out-of-line artifact reference, not an LLM-facing observation.")
+
+
 class Observation(TypedBaseModel):
     """
     Represents an observation from the environment.
@@ -441,35 +465,3 @@ class EnvironmentOutput(TypedBaseModel):
     truncated: bool = False
     info: dict = Field(default_factory=dict)
     error: StepError | None = None
-
-
-class BinaryArtifactBlob(TypedBaseModel):
-    type: Literal["binary"] = "binary"
-    blob: bytes
-
-
-class FileArtifactBlob(TypedBaseModel):
-    type: Literal["file"] = "file"
-    path: Path
-
-
-class RemoteFileArtifactBlob(TypedBaseModel):
-    type: Literal["remote_file"] = "remote_file"
-    url: str
-
-
-class TextArtifactBlob(TypedBaseModel):
-    type: Literal["text"] = "text"
-    text: str
-
-
-ArtifactBlob = Annotated[
-    BinaryArtifactBlob | TextArtifactBlob | FileArtifactBlob | RemoteFileArtifactBlob,
-    Field(discriminator="type"),
-]
-
-
-class Artifact(TypedBaseModel):
-    mime: str
-    id: str
-    blob: ArtifactBlob

--- a/src/cube/core.py
+++ b/src/cube/core.py
@@ -20,7 +20,8 @@ import io
 import json
 import traceback
 from abc import ABC, abstractmethod
-from typing import Any, Callable, ClassVar, Self
+from pathlib import Path
+from typing import Annotated, Any, Callable, ClassVar, Literal, Self
 
 from PIL import Image as PILImage
 from pydantic import (
@@ -440,3 +441,35 @@ class EnvironmentOutput(TypedBaseModel):
     truncated: bool = False
     info: dict = Field(default_factory=dict)
     error: StepError | None = None
+
+
+class BinaryArtifactBlob(TypedBaseModel):
+    type: Literal["binary"] = "binary"
+    blob: bytes
+
+
+class FileArtifactBlob(TypedBaseModel):
+    type: Literal["file"] = "file"
+    path: Path
+
+
+class RemoteFileArtifactBlob(TypedBaseModel):
+    type: Literal["remote_file"] = "remote_file"
+    url: str
+
+
+class TextArtifactBlob(TypedBaseModel):
+    type: Literal["text"] = "text"
+    text: str
+
+
+ArtifactBlob = Annotated[
+    BinaryArtifactBlob | TextArtifactBlob | FileArtifactBlob | RemoteFileArtifactBlob,
+    Field(discriminator="type"),
+]
+
+
+class Artifact(TypedBaseModel):
+    mime: str
+    id: str
+    blob: ArtifactBlob

--- a/src/cube/task.py
+++ b/src/cube/task.py
@@ -30,6 +30,7 @@ from cube.container import Container, ContainerBackend, ContainerConfig
 from cube.core import (
     Action,
     ActionSchema,
+    Artifact,
     Content,
     EnvironmentOutput,
     Observation,
@@ -401,6 +402,14 @@ class Task[TTMetadata: TaskMetadata](TypedBaseModel, ABC):
         elif self._container is not None:
             self._container.stop()
             self._container = None
+
+    def task_artifacts(self) -> list[Artifact]:
+        """Override point for task-specific artifacts (e.g. container logs). Default: none."""
+        return []
+
+    def artifacts(self) -> list[Artifact]:
+        """Collect all artifacts from the task and its tool. Called after close()."""
+        return self.task_artifacts() + self.tool.artifacts()
 
 
 class TaskConfig[TTMetadata: TaskMetadata](ABC, TypedBaseModel):

--- a/src/cube/task.py
+++ b/src/cube/task.py
@@ -30,7 +30,6 @@ from cube.container import Container, ContainerBackend, ContainerConfig
 from cube.core import (
     Action,
     ActionSchema,
-    Artifact,
     Content,
     EnvironmentOutput,
     Observation,
@@ -403,13 +402,14 @@ class Task[TTMetadata: TaskMetadata](TypedBaseModel, ABC):
             self._container.stop()
             self._container = None
 
-    def task_artifacts(self) -> list[Artifact]:
-        """Override point for task-specific artifacts (e.g. container logs). Default: none."""
-        return []
+    def artifacts(self) -> list[Content]:
+        """Task-specific side-channel outputs (e.g. container logs). Collected after close().
 
-    def artifacts(self) -> list[Artifact]:
-        """Collect all artifacts from the task and its tool. Called after close()."""
-        return self.task_artifacts() + self.tool.artifacts()
+        Returns only the task's own artifacts; override to provide some. Tool artifacts are
+        separate — get them via ``self.tool.artifacts()``. The harness combines both at
+        episode end (``task.artifacts() + task.tool.artifacts()``). Default: none.
+        """
+        return []
 
 
 class TaskConfig[TTMetadata: TaskMetadata](ABC, TypedBaseModel):

--- a/src/cube/tool.py
+++ b/src/cube/tool.py
@@ -64,7 +64,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Callable, List
 
 from cube.container import Container
-from cube.core import Action, ActionSchema, Content, Observation, StepError, TypedBaseModel
+from cube.core import Action, ActionSchema, Artifact, Content, Observation, StepError, TypedBaseModel
 
 logger = logging.getLogger(__name__)
 
@@ -123,6 +123,14 @@ class AbstractTool(ABC):
         """
         pass
 
+    @abstractmethod
+    def artifacts(self) -> list[Artifact]:
+        """Return side-channel outputs produced during the episode (traces, logs, etc.).
+
+        Called after close(). Must not raise.
+        """
+        ...
+
 
 class AbstractAsyncTool(ABC):
     """
@@ -150,6 +158,14 @@ class AbstractAsyncTool(ABC):
     def action_set(self) -> List[ActionSchema]:
         """Returns list of actions supported by that tool (same format as AbstractTool)."""
         pass
+
+    @abstractmethod
+    def artifacts(self) -> list[Artifact]:
+        """Return side-channel outputs produced during the episode (traces, logs, etc.).
+
+        Called after close(). Must not raise.
+        """
+        ...
 
 
 class ToolConfig(TypedBaseModel, ABC):
@@ -346,6 +362,9 @@ class Tool(_ToolActionsMixin, AbstractTool):
             return StepError.from_exception(e)
         return Observation(contents=[Content.from_data(action_result, tool_call_id=action.id)])
 
+    def artifacts(self) -> list[Artifact]:
+        return []
+
 
 class AsyncTool(_ToolActionsMixin, AbstractAsyncTool):
     """
@@ -396,6 +415,9 @@ class AsyncTool(_ToolActionsMixin, AbstractAsyncTool):
             return StepError.from_exception(e)
         return Observation(contents=[Content.from_data(action_result, tool_call_id=action.id)])
 
+    def artifacts(self) -> list[Artifact]:
+        return []
+
 
 class Toolbox(Tool):
     """Composite sync tool that delegates to a list of AbstractTool instances."""
@@ -440,6 +462,12 @@ class Toolbox(Tool):
         for tool in self.tools:
             tool.close()
 
+    def artifacts(self) -> list[Artifact]:
+        result: list[Artifact] = []
+        for tool in self.tools:
+            result.extend(tool.artifacts())
+        return result
+
 
 class AsyncToolbox(AsyncTool):
     """Composite async tool that delegates to a list of AbstractAsyncTool instances."""
@@ -481,6 +509,12 @@ class AsyncToolbox(AsyncTool):
     async def close(self) -> None:
         for tool in self.tools:
             await tool.close()
+
+    def artifacts(self) -> list[Artifact]:
+        result: list[Artifact] = []
+        for tool in self.tools:
+            result.extend(tool.artifacts())
+        return result
 
 
 class ToolboxConfig(ToolConfig):

--- a/src/cube/tool.py
+++ b/src/cube/tool.py
@@ -64,7 +64,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Callable, List
 
 from cube.container import Container
-from cube.core import Action, ActionSchema, Artifact, Content, Observation, StepError, TypedBaseModel
+from cube.core import Action, ActionSchema, Content, Observation, StepError, TypedBaseModel
 
 logger = logging.getLogger(__name__)
 
@@ -123,13 +123,14 @@ class AbstractTool(ABC):
         """
         pass
 
-    @abstractmethod
-    def artifacts(self) -> list[Artifact]:
+    def artifacts(self) -> list[Content]:
         """Return side-channel outputs produced during the episode (traces, logs, etc.).
 
-        Called after close(). Must not raise.
+        Collected after close(); never enters the LLM observation stream. Default: none.
+        Override when a tool produces artifacts (e.g. return a FileContent for a trace ZIP).
+        Must not raise.
         """
-        ...
+        return []
 
 
 class AbstractAsyncTool(ABC):
@@ -159,13 +160,14 @@ class AbstractAsyncTool(ABC):
         """Returns list of actions supported by that tool (same format as AbstractTool)."""
         pass
 
-    @abstractmethod
-    def artifacts(self) -> list[Artifact]:
+    def artifacts(self) -> list[Content]:
         """Return side-channel outputs produced during the episode (traces, logs, etc.).
 
-        Called after close(). Must not raise.
+        Collected after close(); never enters the LLM observation stream. Default: none.
+        Override when a tool produces artifacts (e.g. return a FileContent for a trace ZIP).
+        Must not raise.
         """
-        ...
+        return []
 
 
 class ToolConfig(TypedBaseModel, ABC):
@@ -362,9 +364,6 @@ class Tool(_ToolActionsMixin, AbstractTool):
             return StepError.from_exception(e)
         return Observation(contents=[Content.from_data(action_result, tool_call_id=action.id)])
 
-    def artifacts(self) -> list[Artifact]:
-        return []
-
 
 class AsyncTool(_ToolActionsMixin, AbstractAsyncTool):
     """
@@ -415,9 +414,6 @@ class AsyncTool(_ToolActionsMixin, AbstractAsyncTool):
             return StepError.from_exception(e)
         return Observation(contents=[Content.from_data(action_result, tool_call_id=action.id)])
 
-    def artifacts(self) -> list[Artifact]:
-        return []
-
 
 class Toolbox(Tool):
     """Composite sync tool that delegates to a list of AbstractTool instances."""
@@ -462,8 +458,8 @@ class Toolbox(Tool):
         for tool in self.tools:
             tool.close()
 
-    def artifacts(self) -> list[Artifact]:
-        result: list[Artifact] = []
+    def artifacts(self) -> list[Content]:
+        result: list[Content] = []
         for tool in self.tools:
             result.extend(tool.artifacts())
         return result
@@ -510,8 +506,8 @@ class AsyncToolbox(AsyncTool):
         for tool in self.tools:
             await tool.close()
 
-    def artifacts(self) -> list[Artifact]:
-        result: list[Artifact] = []
+    def artifacts(self) -> list[Content]:
+        result: list[Content] = []
         for tool in self.tools:
             result.extend(tool.artifacts())
         return result


### PR DESCRIPTION
Typed side-channel outputs (traces, logs, screenshots) from tasks and tools. Artifact has an id, mime type, and a discriminated blob union (binary, file, remote_file, text).

- AbstractTool.artifacts() and AbstractAsyncTool.artifacts() are abstract — Tool/AsyncTool provide default returning [].
- Toolbox/AsyncToolbox fan out to all contained tools.
- Task.task_artifacts() is the override point for task-specific artifacts; Task.artifacts() combines task + tool artifacts.

Includes openspec change proposal in openspec/changes/task-artifacts/.
