### PR TITLE
fix(toolkit): experiment-scoped run_id via CUBE_RUN_ID (toolkit half of #206)

### DIFF
--- a/cube-resources/cube-infra-toolkit/scripts/smoke/experiment_scoped_reap.py
+++ b/cube-resources/cube-infra-toolkit/scripts/smoke/experiment_scoped_reap.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Smoke: CUBE_RUN_ID scopes the reaping tag to a run, so cleanup(run_id) reaps the
+whole run — and only that run (auto-fix #206).
+
+Launches 3 jobs: two with `CUBE_RUN_ID=run_a`, one with `CUBE_RUN_ID=run_b`, then
+calls `cleanup(run_a)`. Asserts:
+  1. both run_a jobs are reaped (cleanup(run_id) reaps the WHOLE run, not one job);
+  2. the run_b job is untouched (identity-scoped — no cross-run/cross-session kill).
+
+This is the toolkit half of #206; the cube-harness half exports CUBE_RUN_ID per
+experiment and reaps on exit / via a heartbeat startup GC.
+
+SKIP if `eai` is absent / not authed (safe in any CI).
+
+Run from cube-standard repo root with the toolkit venv:
+    EAI_PROFILE=yul101 .venv/bin/python \
+      cube-resources/cube-infra-toolkit/scripts/smoke/experiment_scoped_reap.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import time
+import uuid
+
+from cube_infra_toolkit.toolkit import ToolkitInfraConfig
+
+from cube.resource import DockerServiceConfig
+
+_NAME = "experiment_scoped_reap"
+_ACTIVE = {"queued", "queuing", "running"}
+
+
+def banner(status: str, reason: str = "") -> int:
+    print(f"\nSMOKE {status}: {_NAME}" + (f" — {reason}" if reason else ""))
+    return {"OK": 0, "FAIL": 1, "SKIP": 2}[status]
+
+
+def _state(eai: str, profile: str, job_id: str) -> str:
+    r = subprocess.run(
+        [eai, "--profile", profile, "job", "get", job_id, "--fields", "state", "--format", "json"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    for ln in r.stdout.splitlines():
+        ln = ln.strip()
+        if ln:
+            try:
+                return str(json.loads(ln).get("state", "")).lower()
+            except json.JSONDecodeError:
+                continue
+    return ""
+
+
+def _released(eai: str, profile: str, job_id: str, *, deadline_s: int = 30) -> bool:
+    end = time.monotonic() + deadline_s
+    while time.monotonic() < end:
+        st = _state(eai, profile, job_id)
+        if st and st not in _ACTIVE:
+            return True
+        time.sleep(2)
+    return False
+
+
+def main() -> int:
+    eai_path = "eai" if shutil.which("eai") else os.path.expanduser("~/bin/eai")
+    if shutil.which("eai") is None and not os.path.exists(eai_path):
+        return banner("SKIP", "eai CLI not found")
+    profile = os.environ.get("EAI_PROFILE", "yul101")
+
+    run_a = f"smoke-206-{uuid.uuid4().hex[:8]}"
+    run_b = f"smoke-206-{uuid.uuid4().hex[:8]}"
+    infra = ToolkitInfraConfig(profile=profile, eai_path=eai_path, cube_data=None, default_ttl_seconds=600)
+    resource = DockerServiceConfig(name="cube-smoke-206", scope="task", docker_images=["python:3.12-slim"])
+    infra.provision(resource)
+
+    handles = []
+    try:
+        os.environ["CUBE_RUN_ID"] = run_a
+        a1 = infra.launch(resource)
+        a2 = infra.launch(resource)
+        os.environ["CUBE_RUN_ID"] = run_b
+        b1 = infra.launch(resource)
+        handles = [a1, a2, b1]
+
+        # Reap only run_a.
+        infra.cleanup(run_a)
+
+        if not (_released(eai_path, profile, a1.id) and _released(eai_path, profile, a2.id)):
+            return banner("FAIL", f"cleanup({run_a}) did not reap BOTH its jobs ({a1.id[:8]}, {a2.id[:8]})")
+        if _state(eai_path, profile, b1.id) not in _ACTIVE:
+            return banner("FAIL", f"cleanup({run_a}) wrongly killed run_b's job {b1.id[:8]} — not identity-scoped")
+        return banner("OK", f"cleanup(run_a) reaped both run_a jobs; run_b job {b1.id[:8]} untouched")
+    except Exception as exc:  # noqa: BLE001
+        return banner("FAIL", f"{type(exc).__name__}: {exc}")
+    finally:
+        os.environ.pop("CUBE_RUN_ID", None)
+        for h in handles:
+            try:
+                h.close()
+            except Exception:  # noqa: BLE001, S110
+                pass
+        # Belt-and-suspenders: reap both smoke runs no matter what.
+        for rid in (run_a, run_b):
+            try:
+                infra.cleanup(rid)
+            except Exception:  # noqa: BLE001, S110
+                pass
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cube-resources/cube-infra-toolkit/src/cube_infra_toolkit/toolkit.py
+++ b/cube-resources/cube-infra-toolkit/src/cube_infra_toolkit/toolkit.py
@@ -160,7 +160,13 @@ class ToolkitInfraConfig(InfraConfig):
         # can be baked into job tags — a job whose client is hard-killed
         # mid-launch is then still reapable (by tag) and cluster-bounded
         # (by --max-run-time), instead of orphaning to the 48h default.
-        run_id = str(uuid.uuid4())
+        # auto-fix(206)↓ CUBE_RUN_ID (exported by the harness per experiment) scopes the
+        # reaping tag to the whole run, so infra.cleanup(run_id) — and a liveness-based
+        # startup GC (cube-harness) — can reap EVERY job an experiment launched once its
+        # client dies (Ray OOM-crash / laptop sleep), not just one job. Falls back to a
+        # per-job uuid (prior behavior) when unset, so non-harness callers are unaffected.
+        run_id = os.environ.get("CUBE_RUN_ID") or str(uuid.uuid4())
+        # /auto-fix(206)
         effective_ttl = (
             self.default_ttl_seconds if self.default_ttl_seconds is not None else resource.default_ttl_seconds
         )
@@ -678,3 +684,19 @@ def _publish_cube_bundle(full_name: str, eai_path: str, profile: str | None) -> 
 #              stale mode asserts cleanup_stale() reaps a dropped-handle
 #              run by tag + sweeps orphan port-forward procs.
 #              + tests/test_toolkit_cleanup.py (incl. reaper unit tests).
+# auto-fix-note(206) {class=L1 issue=206 hash=PENDING ctx=eai-toolkit/yul101/darwin-arm64/cube-standard@c72dfeb}
+#   symptoms:  abnormal client exit (Ray OOM-crash / laptop sleep) orphaned every
+#              in-flight eai job ~24h: launch() minted a per-JOB run_id, so cleanup(run_id)
+#              could only reap one job, and the only group reaper (cleanup_stale by
+#              _MANAGED_TAG) is cross-session-destructive. A time-based local guard for
+#              the same class was tried + reverted (cube-harness #445/#458): 141/300
+#              false-cancels — any fixed elapsed-time threshold conflates dead-vs-busy.
+#   invariant: cleanup(run_id) reaps EVERY resource a single run launched. Reaping is
+#              identity-based (whose run + is that run alive), never time-on-task.
+#   why:       run_id now reads CUBE_RUN_ID (harness exports it per experiment) →
+#              experiment-scoped tag; cleanup(run_id) already reaps by tag. Additive +
+#              backward-compatible (per-job uuid fallback when unset). Pairs with the
+#              cube-harness driver-side reaper + heartbeat startup GC.
+#   tested:    scripts/smoke/experiment_scoped_reap.py (2 jobs, shared CUBE_RUN_ID →
+#              cleanup(run_id) reaps both; distinct ids → reaps only its own).
+#   hash=PENDING: stamped by scripts/auto_fix_lint.py (Tier-1) on first run.

--- a/openspec/specs/resource/spec.md
+++ b/openspec/specs/resource/spec.md
@@ -155,6 +155,18 @@ tasks is the failure mode this gate exists to remove.
 | `infra.cleanup_stale(max_age)` | L2/L3 | Called automatically by `Benchmark.setup()` (the "harness startup" hook); harnesses may also call it explicitly on lifecycle exit as a defense-in-depth sweep | GCs TTL-expired resources across all runs |
 | `infra.unprovision(resource)` | L1 | Manual (retire / switch region) | Removes provisioned image + store entry |
 
+**Experiment-scoped `run_id` (`CUBE_RUN_ID`).** For `cleanup(run_id)` to reap a
+whole run's resources in one call, every resource a run launches must share one
+`run_id`. A harness signals this by exporting **`CUBE_RUN_ID`** (a stable per-experiment
+id) into the environment before launching; tag-based backends adopt it as the
+`run_id` tag (falling back to a fresh per-resource id when unset, so non-harness
+callers are unaffected — env-resolved like credentials, never an `InfraConfig` field).
+This is what lets a harness reap **identity-based, not time-based**: on a clean exit it
+calls `cleanup(run_id)`; for a hard-killed/slept client it runs a startup GC that calls
+`cleanup(run_id)` for each run its local heartbeat records prove dead (stale/terminal) —
+never cancelling a still-heartbeating run, and never touching another session's `run_id`.
+The server-side TTL (`cleanup_stale` / `--max-run-time`) remains the last-resort backstop.
+
 ## Recommended Harness Lifecycle
 
 ```python


### PR DESCRIPTION
# Fix Report — experiment-scoped `run_id` (toolkit half of #206)

**Class**: L1 (additive, backward-compatible) · **Anchor**: design-debt **#206**
**Context fingerprint**: `eai-toolkit/yul101/uid-13011/cube-standard@dev`
**Pairs with**: cube-harness driver-side reaper PR (the consumer that exports `CUBE_RUN_ID` and reaps on exit / via a heartbeat startup-GC). **Closes #206 once both land.**

## Invariant
`infra.cleanup(run_id)` must reap **every** resource a single run launched — so a run's jobs can be reaped as a unit when its client dies. Reaping must be **identity-based** (whose run), never time-on-task (the reverted #445/#458 lesson: any fixed elapsed-time threshold conflates dead-vs-busy → 141/300 false-cancels).

## Root cause
`launch()` minted a fresh **per-job** `uuid4` for the `cube_run_id` tag. So `cleanup(run_id)` matched one job, and the only group reaper (`cleanup_stale` by `_MANAGED_TAG`) is **cross-session-destructive**. Abnormal client exit (Ray OOM-crash / laptop sleep) → in-flight jobs orphan to the 24h `--max-run-time`.

## Fix
`run_id = os.environ.get("CUBE_RUN_ID") or str(uuid.uuid4())`. The harness exports `CUBE_RUN_ID` (a stable per-experiment id) before launching, so all of a run's jobs share one tag and `cleanup(run_id)` reaps the run. Env-resolved like credentials (never an `InfraConfig` field, per the resource contract). `resource/spec.md` documents the knob + the identity/liveness reaping pattern.

## Blast radius
- `cube-resources/cube-infra-toolkit/.../toolkit.py` — one line in `launch()` + a comment/footnote. `cleanup(run_id)` / `list_active(run_id)` already match by tag → unchanged, now operate per-run.
- **Backward-compatible:** `CUBE_RUN_ID` unset ⇒ per-job uuid (prior behavior) ⇒ non-harness callers unaffected.
- Other backends (daytona/aws/azure/modal) can adopt the same env read as a follow-up; not required here.

## Adversarial
*Could a shared run_id over-reap?* `cleanup(run_id)` only touches jobs tagged with **that** id, on the **current** infra — never another session's run, never another backend's jobs. Verified by the smoke's run_b isolation check.

## Test
- Smoke `scripts/smoke/experiment_scoped_reap.py` (validated, toolkit yul101): `cleanup(run_a)` reaps both `run_a` jobs; `run_b` job untouched.
- `tests/test_toolkit_cleanup.py` 13/13 (incl. `test_list_active_filters_by_run_id`).
