### PR TITLE
docs(openspec): RFC for outcome-aware Observation (reward, done)

### DIFF
--- a/openspec/changes/outcome-aware-observation/deltas.md
+++ b/openspec/changes/outcome-aware-observation/deltas.md
@@ -1,0 +1,82 @@
+# Deltas — Outcome-aware Observation
+
+Applies to `openspec/specs/core/spec.md`.
+
+## MODIFIED — `core/spec.md`: `Observation` gains optional `reward` and `done` fields
+
+```python
+class Observation(TypedBaseModel):
+    contents: list[Content] = []
+    reward: float | None = None     # NEW — additive, optional
+    done: bool | None = None        # NEW — additive, optional
+
+    @classmethod def from_text(cls, text: str) -> Observation
+    def to_llm_messages(self) -> list[dict]
+    def to_markdown(self) -> str
+    def __add__(self, other: Observation) -> Observation
+```
+
+Both fields default `None`. Semantics:
+
+- `reward: float | None` — the reward emitted by the **prior** environment step, if
+  the consumer (typically a runner like `Episode`) chose to forward it. `None` when
+  no prior step exists (e.g., immediately after `Task.reset()`).
+- `done: bool | None` — whether the **prior** step terminated the episode. `None` when
+  no prior step exists.
+
+Cubes are not required to populate these — the fields exist for runners that want to
+let an agent observe outcomes between steps. `EnvironmentOutput.reward` and `.done`
+remain the env-side authoritative source.
+
+## Invariants (additions)
+
+- `reward` and `done` default `None`; existing code paths that construct `Observation`
+  without setting them are unaffected.
+- `__add__` (concat two Observations) does not merge `reward`/`done` — the operator
+  appends `contents` only. Callers that need the fields preserved must construct the
+  result explicitly. (Rationale: `__add__` is intentionally for content accumulation;
+  outcome fields are per-step, not aggregable.)
+- `to_llm_messages()` and `to_markdown()` ignore `reward` and `done` — the rendering
+  surface is unchanged. Outcome fields are agent-facing metadata, not LLM-payload.
+
+## Not changed
+
+- `Observation.contents` field and rendering helpers (`to_llm_messages`,
+  `to_markdown`, `from_text`, `__add__` content-merging behaviour).
+- `EnvironmentOutput.reward` / `.done` / `.truncated` — env-side authoritative source;
+  `Observation`'s new fields are a separate, additive surface for agent-facing
+  forwarding.
+- `Task.reset()` and `Task.step()` signatures.
+- `StepError`, `Content` and subclasses, `ActionSchema`, `ActionConfig`,
+  `TypedBaseModel`.
+
+## CONSUMED (cube-harness follow-up, not in this change)
+
+- cube-harness `Episode` populates `obs.reward` / `obs.done` from the prior
+  `env_output` when calling `agent.step()`. (See cube-harness
+  `openspec/changes/multi-episode-rollouts/`.)
+- cube-harness `Agent` gets a `finalize(terminal_obs: Observation)` hook that receives
+  the terminal observation with these fields populated — the one observation the agent
+  never sees via `step()`. (Same change folder.)
+
+## Migration
+
+Fully backward-compatible:
+
+- Existing `Observation(contents=[...])` constructions continue to work; `reward` and
+  `done` default to `None`.
+- Existing serialized `Observation` JSON / Pydantic dumps deserialize unchanged —
+  Pydantic's `model_validate` ignores missing fields when they have defaults.
+- Existing agents (any agent that reads `Observation.contents` but not
+  `Observation.reward` / `.done`) are byte-identical in behavior.
+- No cube changes required. Cubes choosing to populate the fields when constructing
+  their own Observations (rare — typically the runner does this) can do so at their
+  leisure.
+
+## Why not deprecate `EnvironmentOutput.reward` / `.done`
+
+`EnvironmentOutput` is the env-side return type of `Task.step()` — it's how the env
+communicates outcomes to the framework. It stays. The new `Observation` fields are
+the agent-side mirror — set by whatever drives the agent (typically the runner)
+*from* `EnvironmentOutput` *for* the agent's next `step()` call. The two types play
+complementary roles, not redundant ones.

--- a/openspec/changes/outcome-aware-observation/proposal.md
+++ b/openspec/changes/outcome-aware-observation/proposal.md
@@ -1,0 +1,116 @@
+# Outcome-aware Observation: optional `reward` and `done` fields
+
+**Status:** DRAFT
+**Date:** 2026-05-29
+**Author:** Oleksiy Ostapenko
+**Scope:** `cube.core` (`Observation`).
+**Targets:** `dev`
+**Related:** cube-harness `openspec/changes/multi-episode-rollouts/` (renamed in spirit
+to "outcome-aware agents") — the downstream consumer that motivates this change. The
+cube-harness side cannot proceed without these fields.
+
+## Problem
+
+Agents in cube-harness receive only `Observation` from `Episode`. They never see the
+env's `reward` or `done` flags — both live on `EnvironmentOutput`, which is consumed
+framework-side for trajectory recording and loop termination, then discarded before
+the next `agent.step()`. This blocks any agent that wants to react to outcomes:
+
+- **Meta-RL** methods that adapt across episodes via reflection (LaMer — arxiv 2512.16848)
+  need to know "did the prior step end an episode" and "what was the reward."
+- **Online learning / retry-on-failure** — an agent about to submit a final answer could
+  re-try a different strategy if the prior step's reward was low.
+- **Reward-shaped behaviour** — agents whose policy depends on observed reward signals
+  (exploration bonuses, fail-fast heuristics).
+- **Outcome-aware logging** — agents that want to record their own per-task metrics
+  alongside their state.
+
+Today there's no clean way for an agent to access either signal without breaking the
+existing `Agent.step(obs: Observation) -> AgentOutput` contract (which every existing
+agent depends on) or leaking env-internal types into agent code.
+
+## Design
+
+Add two optional fields to `Observation`:
+
+```python
+class Observation(TypedBaseModel):
+    contents: list[Content] = []
+    reward: float | None = None     # NEW — additive, optional
+    done: bool | None = None        # NEW — additive, optional
+```
+
+Both default `None`. Existing Observations and existing agents are byte-identical in
+behaviour — the fields are only populated by downstream consumers (cube-harness's
+`Episode`) when they want to pass per-step outcome context to the agent.
+
+`Episode` (cube-harness) populates these from the **prior** `env_output` when calling
+`agent.step()`:
+
+```
+step k:
+    obs_for_agent = Observation(
+        contents=env_output.obs.contents,
+        reward=env_output.reward,    # ← from prior task.step()
+        done=env_output.done,        # ← from prior task.step()
+    )
+    agent.step(obs_for_agent)
+```
+
+`EnvironmentOutput.reward` / `.done` remain authoritative (env-side, what the env
+emits). `Observation.reward` / `.done` are the agent-side mirror — what the agent
+gets to see, set by whatever drives the agent.
+
+## Why this shape
+
+- **Additive optional fields with `None` defaults.** Existing code is unaffected;
+  agents that don't read these stay byte-identical. The constitution's Pillar I
+  exception for additive backward-compatible changes applies — no breaking change.
+- **On `Observation`, not `step()`'s signature.** Putting them on the observation
+  keeps `Agent.step(obs) -> AgentOutput` intact (every existing agent's contract
+  unchanged). The alternative (`step(obs, reward, done)` or `step(env_output)`) breaks
+  every existing agent. Bigger blast radius, no upside.
+- **`reward: float | None` and `done: bool | None`** distinguish "no prior step" (None;
+  e.g. first call after `reset()`) from "prior step gave reward 0 / done False"
+  (0.0 / False). Same shape gym-style envs hint at via "first" observations.
+- **`Observation` is the right layer.** It's the agent's view of the world; reward and
+  done are part of that view. `EnvironmentOutput` continues to be the env-side
+  authoritative record (framework consumes it for trajectory persistence) — the two
+  layers play complementary roles, not redundant ones.
+- **Doesn't force cubes to populate.** Cubes can keep emitting bare `EnvironmentOutput`
+  as today. Only consumers that want to forward reward/done into the agent's view
+  (cube-harness's Episode) do the work of construction.
+
+## Why not now: alternatives rejected
+
+- **Pass `EnvironmentOutput` to `step()`.** Bigger change — every existing agent's
+  step signature breaks. The fields-on-Observation approach is strictly additive.
+- **Pass reward/done as separate kwargs to `step()`.** Same issue: signature change.
+  Also puts the "agent's outcome awareness" surface in two places (the kwargs and the
+  obs) instead of one.
+- **Carry reward/done in `Observation.contents` as special `Content` items.** Couples
+  outcome-awareness to content rendering (would these show up in `to_markdown()` /
+  `to_llm_messages()`? probably no, which then begs why they're in `contents`).
+  Cleaner as typed fields.
+- **Add a new `AgentObservation` subclass.** Multiplies types without benefit — agents
+  would have to know which subclass to expect; existing code's `Observation` typing
+  would lose coverage of the new fields. Plain additive fields on the existing class
+  is the minimal-disruption approach.
+
+## Out of scope / follow-ups
+
+- **Consumers populating the fields.** This change adds the fields; cube-harness
+  `Episode` populating them is downstream work (in cube-harness, not here).
+- **`Task.reset()` semantics.** Reset returns an initial obs; the convention is that
+  `reward=None, done=None` there (no prior step). The reset signature itself doesn't
+  need changing; consumers that pass the initial obs to an agent just leave the fields
+  at their `None` defaults.
+- **`Observation.truncated`.** `EnvironmentOutput` has `truncated` (max-steps signal,
+  distinct from env-driven `done`). Could be mirrored on `Observation` if a use case
+  arises — deferred until then.
+- **Cubes that want to expose richer reward shape (vector reward, multi-objective).**
+  The `reward: float | None` here matches `EnvironmentOutput.reward`'s shape. Richer
+  reward types are a separate design conversation; not blocked by this change.
+- **`Agent.finalize()` hook in cube-harness.** Downstream change in cube-harness — uses
+  the same primitives this change unlocks. Documented in
+  `cube-harness/openspec/changes/multi-episode-rollouts/`.


### PR DESCRIPTION
This is spec only for now.
Proposes adding two additive optional fields to cube.core.Observation:
- reward: float | None = None
- done: bool | None = None

Both default None. Existing Observations and existing agents are byte- identical in behaviour. The fields are the agent-side mirror of EnvironmentOutput.reward / .done, populated by runners (typically cube-harness Episode) when they want to forward outcome context into the agent's next step() call.

Motivating downstream consumer: cube-harness's outcome-aware-agents design (openspec/changes/multi-episode-rollouts/ in the cube-harness repo), which uses these fields to enable meta-RL methods, online learning, retry-on-failure, and other reward-shaped agent behaviour without breaking Agent.step()'s existing contract.

This change is additive and backward-compatible per the openspec methodology's additive-change exception. The downstream cube-harness change is gated on this RFC landing.

## Related Issues
* PR numbers [#460](https://github.com/The-AI-Alliance/cube-harness/pull/460) on cube-harness
