### PR TITLE
feat: align registry-submission UX with cube-registry Phase 1 auto-merge

### DIFF
--- a/.claude/skills/new-cube/SKILL.md
+++ b/.claude/skills/new-cube/SKILL.md
@@ -123,7 +123,24 @@ Per layer:
   - `max_concurrent_tasks`
   - `parallelization_mode`
 - Patch placeholders into the YAML. Show the completed file.
+- **Pre-flight via `/review-cube ./<cube-dir>`** (recommended) — catches cube-code issues + previews what the registry's LLM semantic review will check.
 - Confirm, then run `cube registry add --submit` (forks + PRs via `gh`).
+
+**Post-submission — what happens on the PR:** registry CI runs three hard
+gates (ownership-check, quick-compliance, an LLM semantic review) plus an
+informational pre-merge slow-check. On all hard gates green and a
+path-isolated diff under `entries/<id>.yaml`, the PR auto-merges.
+Common reasons the LLM review returns `CONCERN` (which routes the PR to
+maintainer review instead):
+
+- Package not yet on PyPI → empty PyPI page can't verify `description_matches_package` or `wrapper_license_plausible`.
+- The linked repo's top-level README doesn't cover the cube subdirectory.
+- `authors[].github` handles aren't visible in the cube subdirectory's git history.
+- `id` near-duplicates an existing entry, or `name`/`description` reads like impersonation of a famous benchmark.
+
+If you anticipate any of these — most commonly "not on PyPI yet" — flag it
+to the user; the PR will still open and get a thorough LLM review, but a
+maintainer will need to manually merge after seeing the verdict.
 
 ### 8. Recipe (optional — ask)
 Offer to draft a harness recipe modeled on `cube-harness/recipes/hello_miniwob.py`. The user runs it themselves.

--- a/.claude/skills/new-cube/references/registry.md
+++ b/.claude/skills/new-cube/references/registry.md
@@ -12,7 +12,7 @@ cube registry add --submit     # forks The-AI-Alliance/cube-registry + creates P
 ```
 
 `cube registry add` reads `pyproject.toml` and pre-fills what it can:
-- `id` ← project name (kebab-case)
+- `id` ← project name with `-cube` suffix stripped (`swebench-verified-cube` → `swebench-verified`). Registry convention is that the id refers to the benchmark, not the wrapper package.
 - `version` ← project version
 - `description` ← project description
 - `package` ← PyPI-normalized name
@@ -85,3 +85,43 @@ These are CI-derived. The bot writes them post-merge:
 5. Show the completed file for review.
 6. Confirm with the user, then run `cube registry add --submit`.
 7. The command forks `The-AI-Alliance/cube-registry`, pushes a branch, opens a PR via `gh`. Show the PR URL to the user.
+
+## What registry CI does on the PR
+
+Four jobs run in sequence; the first three are **hard gates** for auto-merge:
+
+| Gate | What | Hard? |
+|---|---|---|
+| `ownership-check` | submitter is in `OWNERS.yaml` for the entry (or it's brand new) | yes |
+| `quick-compliance` | schema, `pip install`, `Benchmark` import + introspection — hardened Docker sandbox | yes |
+| `slow-compliance` | runs the debug task with `provider=local` on the GHA runner | **no** (informational — most real cubes need Docker/VM environments that don't fit a GHA runner) |
+| `entry-review` | LLM semantic check (`scripts/entry_review.py` in cube-registry) | yes |
+
+The LLM `entry-review` returns a structured verdict:
+
+```yaml
+verdict: PASS | CONCERN
+checks:
+  description_matches_package: pass | fail | unverified
+  authors_consistent_with_git: pass | fail | unverified
+  no_id_squat_vs_existing:     pass | fail | unverified
+  no_brand_impersonation:      pass | fail | unverified
+  wrapper_license_plausible:   pass | fail | unverified
+notes: <freeform>
+```
+
+**Auto-merge fires when all of:**
+- ownership-check ✅ + quick-compliance ✅ + entry-review verdict = `PASS`
+- PR diff is strictly additions/modifications under `entries/<id>.yaml`
+- PR is from the same repo (fork PRs lack the token scope to merge)
+
+**Otherwise → labeled `ready-for-review` + maintainer merges manually.**
+
+Common causes of `CONCERN`:
+
+- **Package not yet on PyPI** (very common): empty PyPI page can't ground `description_matches_package` or `wrapper_license_plausible`; both stay `unverified` and the verdict tips to `CONCERN`. Publishing to PyPI before submitting flips both to `pass`.
+- **README mismatch**: the linked repo's top-level README is for the framework (e.g. `cube-harness`), not the cube subdirectory. Adding a `README.md` inside `cubes/<name>/` covers this.
+- **Author handles not traceable**: `authors[].github` not present in the cube subdirectory's commit history.
+- **`id` near-duplicate** of an existing entry, or `name`/`description` reads like impersonation of a famous benchmark.
+
+If the user knows the package is `dev_install_url`-only (no PyPI yet), let them know up front that the PR will likely land at `ready-for-review` rather than auto-merge — the verdict is still useful as semantic feedback.

--- a/.claude/skills/review-cube/SKILL.md
+++ b/.claude/skills/review-cube/SKILL.md
@@ -80,8 +80,24 @@ Format per `references/report-template.md`. Two sections (Blocking, Suggestions 
 ## References
 
 - `references/pr-detection.md` — how to identify a cube-adding PR in any repo.
-- `references/checks.md` — the full checklist: Registry YAML / Cube code static / Compliance suite / Hygiene.
+- `references/checks.md` — the full checklist: Registry YAML / Cube code static / Compliance suite / Hygiene / Registry LLM-review preview.
 - `references/report-template.md` — report markdown structure.
+
+## Note: cube-registry runs its own LLM semantic review
+
+This skill audits the cube **code and configuration** locally. Once a
+submission lands on a cube-registry PR, the registry CI runs its own LLM
+semantic check (`scripts/entry_review.py`) against the entry YAML that
+pulls PyPI metadata + the linked repo's README + existing entries +
+known-authors. It returns a structured verdict (`PASS` or `CONCERN`)
+that gates auto-merge.
+
+The semantic review is intentionally separate from this skill — it sees
+different evidence (PyPI page, cross-repo author history) and asks a
+different question (is this entry plausibly what it claims to be?). When
+running `/review-cube` pre-submission, include the "Registry LLM-review
+preview" section from `references/checks.md` in your report so the user
+knows what *additional* checks they'll face on the PR.
 
 ## Out of scope
 

--- a/.claude/skills/review-cube/references/checks.md
+++ b/.claude/skills/review-cube/references/checks.md
@@ -87,6 +87,29 @@ Detect which the cube uses by grepping the benchmark module for the ClassVar ass
 - S-25: `authors` list empty in `pyproject.toml`.
 - S-25: No SPDX `LICENSE` file at the repo root, even though `legal.wrapper_license` is declared in the YAML.
 
+## 5. Registry LLM-review preview (advisory)
+
+When `/review-cube` runs pre-submission, surface the five semantic checks
+that `scripts/entry_review.py` in cube-registry will run on the PR. This
+is not a Blocking section — the registry's review is the source of truth
+— but it warns the user about likely-CONCERN paths before they submit.
+
+For each check, walk it mentally against the cube + entry YAML and add a
+**Suggestion** if you see a likely-CONCERN signal:
+
+| Registry check | Common failure mode → suggest |
+|---|---|
+| `description_matches_package` | S-75 if PyPI page for `package` is empty (package not published yet) — the registry can't verify the description from PyPI metadata; verdict will likely be CONCERN. Recommend publishing to PyPI or telling the user the PR will land at `ready-for-review`. |
+| `authors_consistent_with_git` | S-50 if no `authors[].github` handle appears in `git log -- <cube-subdir>/` of the linked `dev_install_url` repo. Recommend either adding the author to the cube subdir's history or noting the discrepancy. |
+| `no_id_squat_vs_existing` | S-50 if `id` is a one-character variant of an existing registry id (e.g. `swe-bench-verified` vs `swebench-verified`). |
+| `no_brand_impersonation` | S-50 if `name` matches a famous benchmark but the description / code looks unrelated. Faithful ports of the same name are fine — flag only if it reads as impersonation. |
+| `wrapper_license_plausible` | S-25 if `legal.wrapper_license` is declared but no `LICENSE` file exists at the cube package root or the SPDX id doesn't match the file's contents. |
+
+For each Suggestion in this section, mark it `[registry preview]` in the
+report so the user can distinguish "this skill flagged it" from "the
+registry will flag it." None of these are Blocking — the registry's LLM
+review is advisory + a maintainer can override on the PR.
+
 ## Finding format
 
 Every finding is a dict / bullet with:

--- a/docs/authoring-a-cube.markdown
+++ b/docs/authoring-a-cube.markdown
@@ -173,7 +173,7 @@ Once `cube test` and `/review-cube` both pass, submit to the registry with one c
 cube registry add --submit
 ```
 
-This generates a `cube-registry-entry.yaml` from your `pyproject.toml`, forks [cube-registry](https://github.com/The-AI-Alliance/cube-registry), commits the entry, and opens a PR. Registry CI validates and auto-merges the happy path — no human review required.
+This generates a `cube-registry-entry.yaml` from your `pyproject.toml`, forks [cube-registry](https://github.com/The-AI-Alliance/cube-registry), commits the entry, and opens a PR. Registry CI runs three hard gates (ownership-check, quick-compliance, LLM semantic review) plus an informational pre-merge slow-check. On hard gates green and a path-isolated diff, the PR auto-merges. If the LLM review flags a `CONCERN` (typical causes: package not yet on PyPI so the page is empty, README doesn't cover the cube subdirectory, author handles can't be confirmed against the linked repo's git history), the PR is labeled `ready-for-review` for a maintainer.
 
 Run `cube registry add` without `--submit` first if you want to generate the YAML locally, edit it, and review the entry before opening the PR.
 

--- a/src/cube/cli.py
+++ b/src/cube/cli.py
@@ -1047,9 +1047,21 @@ _TODO = "<TODO: {}>"
 _REGISTRY_DEFAULT = "The-AI-Alliance/cube-registry"
 
 
+def _guess_entry_id(package_name: str) -> str:
+    """Derive registry id from package name.
+
+    Registry convention strips a trailing ``-cube`` from the wrapper package
+    name so the id refers to the benchmark, not the wrapper (e.g.
+    ``swebench-verified-cube`` → ``swebench-verified``). Package names that
+    don't end in ``-cube`` are left as-is.
+    """
+    return package_name.removesuffix("-cube")
+
+
 def _guess_display_name(package_name: str) -> str:
-    """arithmetic-cube → 'Arithmetic Cube', miniwob-cube → 'Miniwob Cube'."""
-    return " ".join(p.capitalize() for p in package_name.replace("_", "-").split("-"))
+    """arithmetic-cube → 'Arithmetic', swebench-verified-cube → 'Swebench Verified'."""
+    base = _guess_entry_id(package_name)
+    return " ".join(p.capitalize() for p in base.replace("_", "-").split("-"))
 
 
 def _detect_dev_install_url(path: Path) -> str | None:
@@ -1320,7 +1332,7 @@ def cmd_registry_add(path: Path, submit: bool, registry: str) -> None:
             err_console.print("[error]pyproject.toml is missing [cmd]project.version[/cmd][/error]")
             sys.exit(1)
 
-        entry_id = package
+        entry_id = _guess_entry_id(package)
         raw_authors = project.get("authors", [])
         authors = [{"github": None, "name": a.get("name")} for a in raw_authors] or [{}]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,6 +13,7 @@ from cube.cli import (
     _DEFAULT_NAME,
     _build_registry_yaml,
     _guess_display_name,
+    _guess_entry_id,
     _parse_pyproject_license,
     _resolve_debug_module,
     cmd_init,
@@ -659,11 +660,34 @@ def test_cmd_test_demo_reset_repro_shows_reset_error_panel(fake_debug_in_sys_mod
     assert "demo token" in spy.call_args.kwargs["reset_diff"]
 
 
+# ── _guess_entry_id ───────────────────────────────────────────────────────────
+
+
+def test_guess_entry_id_strips_cube_suffix():
+    assert _guess_entry_id("swebench-verified-cube") == "swebench-verified"
+
+
+def test_guess_entry_id_strips_only_trailing_suffix():
+    # Substring "cube" mid-name must be preserved.
+    assert _guess_entry_id("counter-cube-extras") == "counter-cube-extras"
+
+
+def test_guess_entry_id_passthrough_without_suffix():
+    assert _guess_entry_id("miniwob") == "miniwob"
+
+
+def test_guess_entry_id_short_suffix_only():
+    # Edge case: package literally named "-cube" collapses to empty; document
+    # the behavior (callers should never see this, but be explicit).
+    assert _guess_entry_id("-cube") == ""
+
+
 # ── _guess_display_name ───────────────────────────────────────────────────────
 
 
 def test_guess_display_name_hyphenated():
-    assert _guess_display_name("arithmetic-cube") == "Arithmetic Cube"
+    # `-cube` suffix is stripped so the display name refers to the benchmark.
+    assert _guess_display_name("arithmetic-cube") == "Arithmetic"
 
 
 def test_guess_display_name_single_word():
@@ -674,8 +698,8 @@ def test_guess_display_name_underscores_treated_as_hyphens():
     assert _guess_display_name("my_bench_cube") == "My Bench Cube"
 
 
-def test_guess_display_name_mixed_separators():
-    assert _guess_display_name("my_bench-cube") == "My Bench Cube"
+def test_guess_display_name_mixed_separators_strips_trailing_cube():
+    assert _guess_display_name("my_bench-cube") == "My Bench"
 
 
 # ── _parse_pyproject_license ─────────────────────────────────────────────────

--- a/tests/test_registry_integration.py
+++ b/tests/test_registry_integration.py
@@ -150,7 +150,10 @@ class TestRegistryAdd:
         assert yaml_path.exists(), "cube-registry-entry.yaml was not created"
 
         content = yaml_path.read_text()
-        assert "id: arithmetic-cube" in content
+        # Registry convention strips the `-cube` suffix from the wrapper
+        # package name so the id refers to the benchmark.
+        assert "id: arithmetic" in content
+        assert "id: arithmetic-cube" not in content
         assert 'version: "0.1.0"' in content
         assert "package: arithmetic-cube" in content
         assert "dev_install_url:" in content


### PR DESCRIPTION
## Summary

cube-registry's Phase 1 ([cube-registry#50](https://github.com/The-AI-Alliance/cube-registry/pull/50)) added a 4-job CI pipeline with an LLM semantic review gate and auto-merge for the path-isolated happy path. This PR closes the resulting drift across cube-standard's docs, skills, and CLI.

Six themes:

| Item | Where | What |
|---|---|---|
| Doc-truth in the public authoring guide | [docs/authoring-a-cube.markdown#L176](docs/authoring-a-cube.markdown#L176) | Replaced "auto-merges the happy path — no human review required" with a description of the 4 gates, the auto-merge condition, and the common CONCERN causes. |
| CLI: `id` strips `-cube` | [src/cube/cli.py](src/cube/cli.py) `_guess_entry_id()` | New helper. Registry convention is `id` refers to the benchmark, not the wrapper (`swebench-verified-cube` → `swebench-verified`). Existing registry entries (`osworld`, `miniwob`) already use the stripped form. |
| CLI: `name` strips `-cube` | Same | `_guess_display_name` goes through `_guess_entry_id` so the auto-guessed name matches ("Swebench Verified", not "Swebench Verified Cube"). |
| `/new-cube` Phase 7 awareness | [.claude/skills/new-cube/SKILL.md](.claude/skills/new-cube/SKILL.md) + [references/registry.md](.claude/skills/new-cube/references/registry.md) | Phase 7 now ends with a "what happens on the PR" paragraph. references/registry.md gets a full "What registry CI does on the PR" section with gate table, verdict schema, and CONCERN catalog. Pre-flight pointer to `/review-cube`. |
| `/review-cube` registry awareness | [.claude/skills/review-cube/SKILL.md](.claude/skills/review-cube/SKILL.md) + new section 5 in [references/checks.md](.claude/skills/review-cube/references/checks.md) | New "Registry LLM-review preview (advisory)" section walks each of the 5 registry checks and gives the reviewer heuristics for adding `[registry preview]` Suggestions. Empty-PyPI is flagged S-75. |
| Tests updated | tests/test_cli.py (+4 new for `_guess_entry_id`, updates to 2 `_guess_display_name`) and tests/test_registry_integration.py (assertion updated for stripped id) | 80/80 pass. |

Lint: `make lint` clean.

## Why

`cube registry add` and `/new-cube` were the entry points cube authors actually touch. After Phase 1 they were promising behavior that no longer matches what the registry's CI does: the LLM review can flip a PR to `ready-for-review` even when the cube author thinks the path is fully automated. Closing this in cube-standard (not cube-registry) is the right move because the expectation is set at the authoring side.

The `-cube` suffix strip is the #1 quirk the cube-registry registration probe surfaced — every entry I hand-wrote in cube-registry PR #50 had to manually strip `-cube` because the CLI default produced the wrong id. This brings the default in line with the existing registry entries.

## Not in scope (separate PRs)

- `terminalbench2-cube`'s stale `from cube.tools.terminal import …` import that breaks slow-check at PR-time — that's a cube-harness fix.
- The registry's pre-merge slow-check `[✗]` icon-but-non-blocking UX — that's a cube-registry workflow tweak.
- Auto-population of `authors[].github` from a GitHub API lookup — out of scope; deferred until auth-handling design.

## Test plan

- [x] `make lint` clean.
- [x] `pytest tests/test_cli.py tests/test_registry_integration.py tests/test_registry_integration_sandbox.py -m ""` — 80/80 pass.
- [ ] Manual: open a fresh cube directory, run `cube registry add .`, confirm `id:` line has no `-cube` suffix and the auto-guessed `name:` matches.

## Companion PR

[cube-registry#50](https://github.com/The-AI-Alliance/cube-registry/pull/50) — the Phase 1 implementation that motivated this cleanup.