### PR TITLE
feat(benchmark): record subset_name on configs from named_subset()

### DIFF
--- a/openspec/specs/benchmark/spec.md
+++ b/openspec/specs/benchmark/spec.md
@@ -79,6 +79,7 @@ time — `install()` MUST NOT mutate it.
 **Instance fields (Pydantic, serializable):**
 ```python
 task_ids: list[str] | None = None          # None = all; populated by subset_from_*
+subset_name: str | None = None             # registered named_subsets key, set by named_subset(); None for full / subset_from_list / raw subset_from_glob
 resources: list[ResourceConfig] = []       # resource dependencies (L2/L3)
 tool_config: ToolConfig | None             # applied to every task by the default get_task_configs(); override get_task_configs() for per-task variation
 seed_generator: AbstractSeedGenerator | None # yields seeds per TaskMetadata

--- a/src/cube/benchmark.py
+++ b/src/cube/benchmark.py
@@ -228,6 +228,17 @@ class BenchmarkConfig[TTMetadata: TaskMetadata](ValidatedConfig, ABC):
             "``named_subset`` to narrow the set without touching the ClassVar."
         ),
     )
+    subset_name: str | None = Field(
+        default=None,
+        description=(
+            "Registered ``named_subsets`` key this config was produced by, set by "
+            "``named_subset(name)`` (e.g. 'lite-gold'). None for the full benchmark, an "
+            "ad-hoc ``subset_from_list``, or a raw ``subset_from_glob``. Records which "
+            "official subset the config represents, so reproducibility tooling can treat a "
+            "complete run of it as a first-class, reproducible subset rather than a "
+            "hand-picked task list — without re-deriving the membership."
+        ),
+    )
     # ``SerializeAsAny`` on every polymorphic field so subclass-specific state
     # survives JSON round-trip. Without it Pydantic dumps only the declared
     # base type's fields — subclass extras are silently stripped and the
@@ -585,6 +596,8 @@ class BenchmarkConfig[TTMetadata: TaskMetadata](ValidatedConfig, ABC):
         self,
         tasks: Sequence[str] | Sequence[TaskMetadata],
         benchmark_name_suffix: str = "custom",  # noqa: ARG002 — accepted for call-site compat
+        *,
+        subset_name: str | None = None,
     ) -> Self:
         """Return a new ``BenchmarkConfig`` restricted to the given tasks.
 
@@ -599,6 +612,12 @@ class BenchmarkConfig[TTMetadata: TaskMetadata](ValidatedConfig, ABC):
         has no effect in the new design; subsets inherit their name from the
         parent class's ``benchmark_metadata``. Use a display-layer convention
         if you need a distinct label.
+
+        ``subset_name`` records the registered named-subset key this selection
+        represents; ``named_subset`` threads it through so a single ``model_copy``
+        sets both ``task_ids`` and the provenance. It defaults to None — an
+        explicit hand-picked list is not a named subset, and any ``subset_name``
+        inherited from a parent ``named_subset`` is dropped.
         """
         current = self.tasks()
         existing_ids = set(current.keys())
@@ -619,15 +638,18 @@ class BenchmarkConfig[TTMetadata: TaskMetadata](ValidatedConfig, ABC):
         ordered = list(dict.fromkeys(task_ids))
         if not ordered:
             raise ValueError("The resulting task list cannot be empty.")
-        return self.model_copy(update={"task_ids": ordered})
+        return self.model_copy(update={"task_ids": ordered, "subset_name": subset_name})
 
-    def subset_from_glob(self, glob_key: str, glob_pattern: str) -> Self:
+    def subset_from_glob(self, glob_key: str, glob_pattern: str, *, subset_name: str | None = None) -> Self:
         """Return a new ``BenchmarkConfig`` containing only tasks whose ``glob_key`` matches ``glob_pattern``.
 
         ``glob_key`` is any top-level field on the (subclassed) ``TaskMetadata``
         — built-ins like ``id`` / ``split`` / ``abstract_description``, or any
         named field declared by a ``TaskMetadata`` subclass.
         ``glob_pattern`` is a standard Unix shell wildcard.
+
+        ``subset_name`` is forwarded to the recorded provenance — ``named_subset``
+        passes the registered key; a raw glob leaves it None (not an official subset).
         """
         current = self.tasks()
         matches = [
@@ -637,7 +659,9 @@ class BenchmarkConfig[TTMetadata: TaskMetadata](ValidatedConfig, ABC):
         ]
         if not matches:
             raise ValueError(f"No tasks found matching glob pattern '{glob_pattern}' on key '{glob_key}'")
-        return self.subset_from_list(tasks=matches, benchmark_name_suffix=f"[{glob_key}={glob_pattern}]")
+        return self.subset_from_list(
+            tasks=matches, benchmark_name_suffix=f"[{glob_key}={glob_pattern}]", subset_name=subset_name
+        )
 
     @classmethod
     def named_subsets(cls) -> list[str]:
@@ -647,13 +671,16 @@ class BenchmarkConfig[TTMetadata: TaskMetadata](ValidatedConfig, ABC):
     def named_subset(self, name: str) -> Self:
         """Return a filtered config for a pre-defined named subset.
 
-        Equivalent to ``subset_from_glob(*benchmark_metadata.named_subsets[name])``.
+        Equivalent to ``subset_from_glob(*benchmark_metadata.named_subsets[name])``,
+        and additionally records ``subset_name=name`` so the config carries which
+        official subset it represents (read by reproducibility tooling without
+        re-deriving the membership).
         """
         named = type(self).benchmark_metadata.named_subsets
         if name not in named:
             raise KeyError(f"Unknown subset {name!r}. Available: {list(named.keys())}")
         glob_key, glob_pattern = named[name]
-        return self.subset_from_glob(glob_key, glob_pattern)
+        return self.subset_from_glob(glob_key, glob_pattern, subset_name=name)
 
     # ──────────────────────────────────────────────────────────────────────────
     # Data lifecycle (class-level; shared across all instances of a subclass)

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -441,6 +441,46 @@ def test_named_subsets_and_named_subset():
 
     sub = ConfigWithNamed().named_subset("easy")
     assert set(sub.task_ids or ()) == {"t1", "t3"}
+    # named_subset records which official subset this config represents.
+    assert sub.subset_name == "easy"
+
+
+def test_subset_name_is_none_for_full_list_and_raw_glob():
+    """Only named_subset records subset_name; full / subset_from_list / subset_from_glob don't."""
+    assert MyBenchmarkConfig().subset_name is None
+    assert MyBenchmarkConfig().subset_from_list(["t1", "t2"]).subset_name is None
+    assert MyBenchmarkConfig().subset_from_glob("split", "train").subset_name is None
+
+
+def test_subset_name_survives_serialization():
+    """subset_name round-trips through JSON so it reaches workers / storage intact."""
+    cfg = MyBenchmarkConfig().model_copy(update={"subset_name": "lite-gold"})
+    restored = MyBenchmarkConfig.model_validate_json(cfg.model_dump_json())
+    assert restored.subset_name == "lite-gold"
+
+
+def test_subset_name_cleared_when_named_subset_is_further_narrowed():
+    """Narrowing a named subset yields a different (hand-picked) set, so subset_name is dropped."""
+
+    class _NTaskConfig(_TaskConfig):
+        pass
+
+    class ConfigWithNamed(BenchmarkConfig):
+        benchmark_metadata = BenchmarkMetadata(
+            name="Named",
+            version="1",
+            description="x",
+            num_tasks=4,
+            named_subsets={"easy": ("difficulty", "easy")},
+        )
+        task_metadata = MyBenchmarkConfig.task_metadata
+        task_config_class = _NTaskConfig
+        benchmark_class = MyBenchmark
+
+    easy = ConfigWithNamed().named_subset("easy")
+    assert easy.subset_name == "easy"
+    assert easy.subset_from_list(["t1"]).subset_name is None
+    assert easy.subset_from_glob("split", "train").subset_name is None
 
 
 def test_named_subset_unknown_raises():


### PR DESCRIPTION
## What

Adds one additive field — `subset_name: str | None` — to `BenchmarkConfig`, set by `named_subset(name)` to the registered `named_subsets` key (e.g. `"lite-gold"`).

## Why

It records **which** official subset a config represents *at the moment it's chosen*, so downstream reproducibility tooling (cube-harness `eval_log` / journal scan) can recognize a complete run of a registered named subset as a first-class, reproducible subset by **reading the provenance** rather than reverse-engineering it (re-applying every named subset and matching task-id sets).

## Behavior

- `named_subset(name)` stamps `subset_name=name`.
- `subset_from_list` clears it to `None` — an explicit list is hand-picked, not a named subset.
- a raw `subset_from_glob` leaves it `None` — only *registered* named subsets are official.
- default `None` → full benchmark. **Backward compatible**: old configs/serialized payloads deserialize with `subset_name=None`, identical to today.

## Tests

`tests/test_benchmark.py`: `named_subset` sets it; full / `subset_from_list` / raw `subset_from_glob` leave it `None`; narrowing a named subset clears it; JSON round-trip preserves it. (Pre-existing `test_make_threads_infra_to_runtime` failure is environmental — a subprocess `make` that breaks in this sandbox, unrelated.)

Consumed by cube-harness PR #491.

🤖 Generated with [Claude Code](https://claude.com/claude-code)