### PR TITLE
fix(infra-local): make qemu install best-effort so non-VM cubes can use local infra

### DIFF
--- a/src/cube/infra_local.py
+++ b/src/cube/infra_local.py
@@ -491,7 +491,12 @@ class LocalInfraConfig(InfraConfig):
     # ── InfraConfig interface ─────────────────────────────────────────────────
 
     def install(self) -> None:
-        """Install qemu and docker system dependencies if not already present."""
+        """Install local system dependencies if not already present.
+
+        qemu (VM-backed cubes only) is best-effort: a failed qemu install warns but does
+        NOT abort, so offline / Docker / browser cubes stay runnable on `local` infra even
+        where qemu can't build (e.g. Homebrew on Apple Silicon). See the script's comment
+        and cube-standard #191 (scope provisioning to declared task capabilities)."""
         ref = importlib.resources.files("cube").joinpath("scripts/install_local_infra.sh")
         with importlib.resources.as_file(ref) as script:
             if script.exists():

--- a/src/cube/scripts/install_local_infra.sh
+++ b/src/cube/scripts/install_local_infra.sh
@@ -3,21 +3,31 @@
 # Called automatically by LocalInfraConfig.install() — safe to run multiple times.
 set -euo pipefail
 
+# QEMU is only needed by VM-backed cubes (osworld, windows-agent-arena). Its install
+# is therefore BEST-EFFORT: a failure (e.g. Homebrew's qemu bottle not building on
+# Apple Silicon) must NOT abort local-infra setup, or offline / Docker / browser cubes
+# — which need no qemu at all — become unrunnable on `local` infra. A VM cube then
+# fails later with a clear "qemu-system-x86_64 not found" when it actually boots a VM.
+# (Proper fix: scope provisioning to declared task capabilities — cube-standard #191.)
+qemu_warn() {
+  echo "WARNING: could not install qemu — VM-backed cubes (osworld, windows-agent-arena) " \
+       "won't run until you install it manually. Other cubes (offline / Docker / browser) " \
+       "are unaffected." >&2
+}
+
 case "$(uname)" in
   Linux)
     if ! command -v qemu-system-x86_64 &>/dev/null; then
-      sudo apt-get update -qq
-      sudo apt-get install -y qemu-system-x86 qemu-utils
+      { sudo apt-get update -qq && sudo apt-get install -y qemu-system-x86 qemu-utils; } || qemu_warn
     fi
     ;;
   Darwin)
     if ! command -v qemu-system-x86_64 &>/dev/null; then
-      brew install qemu
+      brew install qemu || qemu_warn
     fi
     ;;
   *)
-    echo "Unsupported platform: $(uname). Install qemu-system-x86_64 manually." >&2
-    exit 1
+    echo "Unsupported platform: $(uname). Install qemu-system-x86_64 manually if you need VM cubes." >&2
     ;;
 esac
 


### PR DESCRIPTION
## What
`install_local_infra.sh` no longer aborts local-infra setup when qemu can't be installed. qemu install becomes best-effort (warn + continue); the unsupported-platform branch warns instead of `exit 1`.

## Why (found by the Auto-CUBE config-UX audit)
`LocalInfraConfig.install()` runs the script under `set -euo pipefail`, doing `brew install qemu` unconditionally on macOS. qemu is only needed by **VM-backed cubes** (osworld, windows-agent-arena), but its failure — e.g. Homebrew's qemu bottle **not building on Apple Silicon** — aborted the **entire** setup with a raw `CalledProcessError`. Result: `INFRA_CONFIGS["local"]` was unusable for *every* cube, including ones needing no qemu at all:
- offline (arithmetic), Docker (terminalbench/swebench), browser (miniwob) — all blocked by a qemu build failure.

Concrete repro (this PR's origin): `Experiment(..., infra=INFRA_CONFIGS["local"])` on `arithmetic-cube` →
```
CalledProcessError: ['bash', '.../install_local_infra.sh'] returned non-zero exit status 1
  (brew: qemu — "not a Tier 1 configuration" build failure)
```

## Fix
- qemu install is best-effort: on failure it warns — *"VM-backed cubes won't run until you install qemu manually; other cubes (offline / Docker / browser) are unaffected"* — and the script continues. A VM cube then fails later with a clear `qemu-system-x86_64 not found` when it actually boots a VM, rather than blocking everyone up front.
- Unsupported-platform branch: `exit 1` → warning (same rationale).

## Scope
**Interim fix.** The principled fix is to scope provisioning to a benchmark's declared capabilities (only install qemu when a VM-backed task is requested) — that's cube-standard **#191** (task permission requirements + infra capability gate). This unblocks the common case now without that larger change.

## Test
Shell script (no Python unit test — bash, awkward to unit-test; the fix is a `|| warn` guard):
- `bash -n` syntax check passes.
- Simulated qemu-install failure (stub `brew` → exit 1, qemu absent): script now **exits 0** with the warning (was exit 1). `LocalInfraConfig.install()` only runs the script with `check=True`, so install now succeeds for non-VM cubes. `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)