### PR TITLE
gatekeep-rfc: workaround-hunt step + need-sizing axes

### DIFF
--- a/.claude/skills/gatekeep-rfc/SKILL.md
+++ b/.claude/skills/gatekeep-rfc/SKILL.md
@@ -20,17 +20,57 @@ at once, in tension — hold both:
 
 ## What you're really doing
 
-- **Separate the real *need* from the proposed *mechanism*.** Almost all your value is
-  here. Most over-reaching proposals bundle one genuine need inside a large mechanism;
-  naming the need on its own is what lets you offer something smaller.
-- **Find the smallest thing that serves the need.** Usually it lives in the contributor's
-  own repo or their own code; sometimes a tiny additive hook in CUBE; rarely a core
-  change. Lead with the escape hatches (`references/cube-charter.md`).
+- **Pin the purpose, not the API they asked for.** Almost all your value is here. Most
+  over-reaching proposals bundle one genuine need inside a large mechanism; naming the
+  end goal on its own — *what usage pattern are they actually trying to reach?* — is what
+  lets you offer something smaller. Don't accept the proposed symbol as the need.
+- **Brainstorm workarounds in today's API — out loud, with the contributor.** Before you
+  weigh any new symbol, try to serve that purpose with what already exists, even if it's
+  undocumented, indirect, inelegant, or inefficient: chaining existing methods, a
+  subclass, composing in their own code. This is a diagnostic, not a chore — and it has
+  two payoffs. Often the contributor realizes mid-discussion that they didn't need the
+  change. And whatever you do or don't find is *exactly* the signal the verdict turns on:
+  a clean path means the gap is cosmetic; an ugly-but-working path means it's ergonomic; a
+  genuine dead end means it's real. Actually try each workaround against the live API —
+  don't assert one works without checking, and don't skip the hunt because the proposal
+  says there's no workaround (it is often wrong about this).
+- **Find the smallest thing that serves the need.** If the brainstorm leaves a real gap,
+  the fix usually still lives in the contributor's own repo or their own code; sometimes a
+  tiny additive hook in CUBE; rarely a core change. Lead with the escape hatches
+  (`references/cube-charter.md`).
 - **Defend the broader picture — humbly.** Argue from the charter, but stay open to being
   wrong: a principled challenge to an invariant is a gap to *escalate*, not a nuisance to
   decline.
 - **Teach the why, keep the door open.** Your read is advisory. A contributor may push
   back, insist, and reach a human — that's the system working, not a failure of the gate.
+
+## Sizing the need — the axes a verdict turns on
+
+Once you've hunted for workarounds, place the *need* (not the proposal) on a few
+orthogonal axes. They feed the verdict; they don't replace judgment, and you won't always
+score all of them.
+
+- **Blocking power — the primary axis, and the one the workaround hunt resolves.** Does
+  the absence *hard-block* a cube (no workaround exists at all) → *impede a usage pattern*
+  (a workaround exists but is ugly / inefficient / verbose / undocumented) → cost only
+  *elegance or convenience* (a clean path already exists; cosmetic or nice-to-have)? Most
+  proposals land further down this ladder than they claim. Cosmetic rarely earns core
+  space; a true hard-block earns the most.
+- **Generality.** Would many cubes benefit, or just this one? (charter §7) A one-cube
+  need — however real — almost always belongs in a subclass or the contributor's own repo,
+  not the shared contract.
+- **Contract cost.** Where on the mechanism spectrum does the *smallest* fix sit:
+  additive (a new optional field/method — cheap, but never free) → breaking / rename /
+  removal (expensive, needs a deprecation path and a human call)? Cosmetic gains never
+  justify the breaking end.
+- **Bloat vs value.** Even a purely additive change is permanent surface to learn,
+  document, test, and keep consistent. Weigh the value delivered against that forever-cost
+  — "additive" is not the same as "worth it." When the value is marginal, leave it out.
+
+These compose into the verdict rather than dictating it: *cosmetic, or one-cube* → DECLINE
+/ REDIRECT to an escape hatch; *impedes a real pattern + general + additive + value beats
+bloat* → the case for ACCEPT or a small RESHAPE; *hard-block, or breaking, or a principled
+challenge to an invariant* → ESCALATE (with your smallest alternative attached).
 
 ## Verdicts — a vocabulary, not a flowchart
 
@@ -89,9 +129,10 @@ Produce two things every run, shaped to fit the case — there is no fixed templ
   need first, ground the reason concretely (name the symbols / blast radius), and make
   explicit they can push back and reach a human. Warm and clear, as long as it needs to be.
 - **A one-screen maintainer summary — here brevity genuinely serves** (a human triaging a
-  queue wants the gist fast). Verdict, the real need, blast radius, the smaller
-  alternative, escalate-to-human y/n + why, and — when relevant — the **prior-demand
-  pattern** (links to related/recurring requests and how they were resolved).
+  queue wants the gist fast). Verdict, the real need, **blocking power** (hard-block /
+  impedes-a-pattern / cosmetic — and the workaround that places it), blast radius, the
+  smaller alternative, escalate-to-human y/n + why, and — when relevant — the
+  **prior-demand pattern** (links to related/recurring requests and how they were resolved).
 
 ## Modes & I/O
 

--- a/.claude/skills/gatekeep-rfc/references/example-task-selection.md
+++ b/.claude/skills/gatekeep-rfc/references/example-task-selection.md
@@ -5,8 +5,11 @@ combines patterns that recur in framework RFCs so the skill has a concrete refer
 how to reason. Treat it as a teaching fixture, not a verdict on anyone's PR.
 
 **The scenario.** An RFC targets `openspec/specs/benchmark/spec.md` and proposes a broad
-rework of how `BenchmarkConfig` selects tasks. It is a textbook **RESHAPE**: one genuine
-capability gap bundled with a large breaking refactor that fights the existing design.
+rework of how `BenchmarkConfig` selects tasks. It looks like a textbook **RESHAPE** —
+a capability gap bundled with a large breaking refactor — but the lesson here is that a
+disciplined *workaround hunt* (Step 2.5) collapses the "gap" almost to nothing: most of it
+already works today, and what's left is small and demand-gated. The hunt is the move that
+separates a real gap from a cosmetic one.
 
 ## Step 1 — ground in the live spec
 
@@ -26,16 +29,44 @@ capability gap bundled with a large breaking refactor that fights the existing d
 - **N1.** Select tasks at construction time by a subset name or a glob, not only by an
   explicit id list ("users rarely keep a list of task IDs in their scripts").
 - **N2.** Select by a **combination** of attribute globs — e.g. `split == train` AND
-  `language == en`. The current `named_subsets` and `subset_from_glob` support only a
-  single glob. **This is the one genuine capability gap.**
+  `language == en`. The current `named_subsets` and `subset_from_glob` take a single glob.
+  The proposal calls this its central gap — *candidate* gap until Step 2.5 tests it.
+
+## Step 2.5 — hunt for workarounds in today's API (before granting any new symbol)
+
+Don't take the proposal's "there's no workaround" at face value — try it against the live
+code.
+
+- **N2 at the call site is already expressible.** `subset_from_glob` filters from
+  `self.tasks()` — the *already-narrowed* view, not the full catalog (`benchmark.py`,
+  `current = self.tasks()`). So chaining ANDs:
+  ```python
+  cfg.subset_from_glob("split", "train").subset_from_glob("language", "en")
+  #   → split == train  AND  language == en, today, no change
+  ```
+  That demotes N2 from "hard-block / genuine gap" to **cosmetic for the call-site case** —
+  a clean path exists. The proposal (and a first-pass reshape) missed this; the hunt is
+  what catches it.
+- **The only residue is the *declarative* form.** `named_subsets: dict[str, tuple]` holds
+  one glob per name, and a data structure can't "chain" — so a *named subset whose
+  definition is an AND* genuinely can't be declared today. Even that is reachable without
+  core: a cube can override `named_subset()` in its own subclass to map a name onto chained
+  globs (escape hatch — their own code). So the core-only residue is narrow and
+  subclass-able, and it only earns core space if **more than this one cube** wants it
+  (Step 4, generality).
+- **N1** ("construct pre-scoped") is served by one chained call —
+  `MyConfig().named_subset("l1")` — so it's ergonomic, not blocking.
+
+Net: the workaround hunt collapses a "broad rework for a central gap" down to *at most* a
+small, demand-gated widening of declarative `named_subsets`.
 
 ## Step 3 — the mechanism it proposes (five kernels)
 
 | Kernel | What | Verdict |
 |--------|------|---------|
-| K1 | `AttrGlob(attr, pattern)` callable type | ACCEPT — additive, clean |
-| K2 | `named_subsets` value type → `list[AttrGlob]` (multi-glob subsets) | RESHAPE — keep additive/back-compat; serves N2 |
-| K3 | Constructor `attr_globs` + `subset_name` fields + a cascade validator | RESHAPE — serves N1 but multiplies sources of truth |
+| K1 | `AttrGlob(attr, pattern)` callable type | ACCEPT *only if* K2 lands — additive, but pointless on its own |
+| K2 | `named_subsets` value type → `list[AttrGlob]` (multi-glob subsets) | RESHAPE, demand-gated — the only residue after Step 2.5; additive/back-compat; keep on the table only if a second cube wants declarative multi-glob |
+| K3 | Constructor `attr_globs` + `subset_name` fields + a cascade validator | DECLINE — N1 is already a one-method chain; the fields multiply sources of truth |
 | K4 | Rename ClassVar `task_metadata` → `_full_task_catalog` (+ `full_task_catalog`/`task_catalog` props) | DECLINE — cosmetic, breaks every cube |
 | K5 | Remove `subset_from_list()` and `named_subset()` | DECLINE — load-bearing elsewhere |
 
@@ -58,9 +89,11 @@ capability gap bundled with a large breaking refactor that fights the existing d
   a validator that writes each from the previous. This directly contradicts the spec's
   single-source-of-truth invariant (principle 2): subsets are *represented entirely by
   `task_ids`*. On a serialize→deserialize round trip all three persist and re-derive;
-  that's the drift the current design deliberately removed. The *need* (N1, construct
-  pre-scoped) is real — but resolve the inputs **into `task_ids` and don't keep the
-  intermediate selectors as authority.**
+  that's the drift the current design deliberately removed. And the *need* it serves (N1,
+  construct pre-scoped) is already a one-method chain — `MyConfig().named_subset("l1")`
+  (Step 2.5) — so this is cost with no capability gain. **Decline;** if a maintainer later
+  wants constructor sugar, it must resolve inputs *into* `task_ids` with no persisted
+  intermediate selectors.
 - **Internal consistency (quality note, not a verdict input):** when a proposal names the
   same thing two ways, leaves duplicate step numbering, or references a symbol it never
   defines, that signals it isn't fully baked. Note it as a courtesy fix; never decline
@@ -71,56 +104,49 @@ capability gap bundled with a large breaking refactor that fights the existing d
 
 ## Step 5 — verdict
 
-**RESHAPE.** Accept K1 + the multi-glob capability (K2). Fold N1 into a thin constructor
-path that resolves into `task_ids`. Decline the rename (K4) and the removals (K5).
+**RESHAPE, mostly down to nothing.** The workaround hunt (Step 2.5) already serves N2 at
+the call site (chaining) and N1 (one method) — so most of the proposal is cosmetic. The
+*only* core candidate left is declarative multi-glob `named_subsets` (K2 + its K1 type),
+and that's **demand-gated**: keep it on the table only if a second cube wants it; otherwise
+the subclass override is enough. Decline the rename (K4), the removals (K5), and the
+constructor fields/validator (K3).
 
 ## Step 6 — the counter-proposal handed to the author
 
-Deliver the whole N2 gap **additively**, no breaking changes:
+**Lead with the zero-code answer.** Most of what the proposal wants already works:
 
 ```python
-# Additive: AttrGlob is fine as proposed.
-class AttrGlob(TypedBaseModel):
-    attr: str
-    pattern: str
-    def __call__(self, t: Any) -> bool:
-        return hasattr(t, self.attr) and fnmatch.fnmatchcase(str(getattr(t, self.attr)), self.pattern)
+# N2 — AND of globs at the call site: chain. subset_from_glob narrows the current view.
+cfg.subset_from_glob("split", "train").subset_from_glob("language", "en")
 
-# Widen named_subsets to accept multiple globs, staying back-compatible:
-#   dict[str, tuple[str, str]]  →  dict[str, list[AttrGlob]]
-# (one-glob subsets become a single-element list; a validator can up-convert old tuples.)
-
-# subset_from_glob gains an AND-of-globs form WITHOUT losing the single-glob signature:
-def subset_from_glob(self, *globs: AttrGlob | tuple[str, str]) -> Self:
-    norm = [g if isinstance(g, AttrGlob) else AttrGlob(attr=g[0], pattern=g[1]) for g in globs]
-    ids = [tid for tid, md in self.tasks().items() if all(g(md) for g in norm)]
-    return self.model_copy(update={"task_ids": ids})   # task_ids stays the only source of truth
-
-# Constructor-time selection (N1): keep it as a classmethod factory that resolves into
-# task_ids — no persisted attr_globs/subset_name authority, no cascade validator.
-@classmethod
-def select(cls, *, subset_name: str | None = None, globs: list[AttrGlob] | None = None,
-           task_ids: list[str] | None = None) -> Self:
-    cfg = cls()
-    if subset_name is not None:
-        return cfg.named_subset(subset_name)         # reuses existing path
-    if globs is not None:
-        return cfg.subset_from_glob(*globs)
-    if task_ids is not None:
-        return cfg.subset_from_list(task_ids)
-    return cfg
+# N1 — construct pre-scoped: one method, today.
+MyConfig().named_subset("l1")           # or .subset_from_glob(...) / .subset_from_list(...)
 ```
 
-This gives the author 100% of N1 + N2 with **zero** broken public symbols, one source of
-truth preserved, and no validator cascade. `task_metadata` keeps its name;
-`subset_from_list` / `named_subset` stay. The author keeps what they actually wanted.
+No new symbols, no break, `task_ids` stays the only source of truth.
 
-**Apply the leanness bar to your own counter-proposal too.** The genuine new capability
-here is multi-glob (`AttrGlob` + the widened `subset_from_glob`) — that earns its place.
-The `select()` factory is *convenience* over methods that already exist
-(`named_subset` / `subset_from_glob` / `subset_from_list`); under the lean default it's
-optional, not core. Offer it as a nice-to-have the author can drop, not as a requirement
-— don't trade one over-reach for a smaller one.
+**The one thing chaining can't do** is declare an AND *inside* `named_subsets` (data can't
+chain). Two paths, smallest first:
+
+```python
+# Path A (no core change): the cube overrides named_subset() to chain its own globs.
+class MyConfig(BenchmarkConfig):
+    def named_subset(self, name: str) -> Self:
+        if name == "train_en":
+            return self.subset_from_glob("split", "train").subset_from_glob("language", "en")
+        return super().named_subset(name)
+
+# Path B (small, additive, ONLY if a second cube wants declarative multi-glob):
+#   AttrGlob(attr, pattern) callable type  +  named_subsets: dict[str, tuple] -> dict[str, list[AttrGlob]]
+#   with a validator up-converting legacy single-tuple values. named_subset() unpacks the
+#   list and chains. No rename, no removals, no constructor fields.
+```
+
+**Apply the leanness bar to your own counter-proposal too.** Path A costs core nothing and
+should be the default offer. Path B is the *only* part that touches the shared contract,
+and even it is gated on generality (Step 4) — if only this cube needs it, Path A is the
+answer and B stays out. Don't trade the proposal's over-reach for a smaller core change
+that still isn't pulling its weight.
 
 **Prior-demand check.** Sweep `openspec/changes/` + archive and `gh issue/pr list
 --search` for the same underlying need (multi-glob / attribute-based task selection)
@@ -130,6 +156,7 @@ asked for and declined two or three times before, that recurrence would outweigh
 per-RFC view: escalate the pattern to a human ("this keeps coming back — should the
 default selection API just support it?"), rather than reshaping it down a fourth time.
 
-**Escalate to human?** No for the reshape (it's a clean additive change). The *only*
-thing worth a maintainer's nod is whether to also deprecate `named_subset` once
-multi-glob lands — a small lifecycle call, flag it but don't block on it.
+**Escalate to human?** No. There's no breaking change to weigh and no principled
+challenge to an invariant. The single judgment call — whether declarative multi-glob
+(Path B) clears the generality bar or stays a subclass override (Path A) — is a small,
+demand-gated lean decision; flag it, don't block on it.


### PR DESCRIPTION
## What

Two additions to the `/gatekeep-rfc` skill, distilled from triaging cube-standard #216 (task-selection RFC):

1. **Workaround-hunt step** (`SKILL.md` → "What you're really doing"). Before weighing any new symbol, actively try to serve the proposal's *purpose* with today's API — even undocumented, indirect, or inelegant paths (chaining, subclassing, composing in the contributor's own code), out loud with the contributor. Two payoffs: the contributor often realizes they don't need the change; and whatever you do/don't find is the signal that places the need on the blocking-power axis.

2. **"Sizing the need" axes** (new `SKILL.md` section feeding the verdict vocabulary): **blocking power** (hard-block / impedes-a-pattern / cosmetic) · **generality** · **contract cost** (additive → breaking+deprecation) · **bloat vs value**. The maintainer-summary output now reports blocking power.

This is the refined form of Alex's ontology (collapsed "additive" + "breaking/deprecation" into one *contract-cost* axis; folded "preventing a CUBE / workarounds" + "cosmetic/nice-to-have" into one *blocking-power* axis; kept generality and bloat-vs-value).

## Why

#216 was the case study: chaining `subset_from_glob(...).subset_from_glob(...)` already ANDs at the call site (it filters from the narrowed `self.tasks()`), so the proposal's "central gap" was largely cosmetic — but neither the original proposal nor a first-pass reshape did the workaround hunt to find that. The skill now forces the hunt first.

## Also

- `references/example-task-selection.md` realigned to model the new step: new **Step 2.5 (workaround hunt)** showing the chaining solution; K3 (constructor fields) moves to DECLINE; counter-proposal leads with the zero-code answer and a subclass `named_subset()` override, with the declarative `named_subsets` widening kept as a demand-gated Path B.

Docs-only change to the skill; universal principles stay in cube-standard (the cube-harness gatekeeper points here rather than duplicating).

🤖 Generated with [Claude Code](https://claude.com/claude-code)