### PR TITLE
Update to AIA website URL

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -71,7 +71,7 @@ heading_anchors: true
 # Aux links for the upper right navigation
 aux_links:
   "The AI Alliance":
-    - "https://aialliance.org"
+    - "https://thealliance.ai"
 
 nav_external_links:
   - title: "The AI Alliance repo for CUBE Standard"

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -42,7 +42,7 @@ layout: table_wrappers
 
   <div class="side-bar resizable-content">
     <div class="site-header-logo banner">
-      <a href="https://aialliance.org" target="_aia" class="no-glyph"><img alt="AI Alliance Banner" class="side-bar-banner" src="{{site.baseurl}}/assets/images/ai-alliance-logo-horiz-pos-blue-cmyk-trans.png"/></a>
+      <a href="https://thealliance.ai" target="_aia" class="no-glyph"><img alt="AI Alliance Banner" class="side-bar-banner" src="{{site.baseurl}}/assets/images/ai-alliance-logo-horiz-pos-blue-cmyk-trans.png"/></a>
     </div>
     <div class="site-header">
       <a href="{{ '/' | absolute_url }}" class="site-title lh-tight">{% include title.html %}</a>
@@ -70,7 +70,7 @@ layout: table_wrappers
     </nav>
     <footer class="site-footer">
       <p>
-        Copyright &copy; {{ site.copyright_years }}, <a href="https://aialliance.org" target="_aia">The AI Alliance</a>.
+        Copyright &copy; {{ site.copyright_years }}, <a href="https://thealliance.ai" target="_aia">The AI Alliance</a>.
       </p>
       <p xmlns:cc="http://creativecommons.org/ns#" >This work is licensed under <a href="https://creativecommons.org/licenses/by/4.0/?ref=chooser-v1" target="_blank" rel="license noopener noreferrer" style="display:inline-block;">CC BY 4.0<img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg?ref=chooser-v1" alt=""><img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/by.svg?ref=chooser-v1" alt=""></a>
       </p> 

--- a/docs/about.markdown
+++ b/docs/about.markdown
@@ -82,11 +82,11 @@ When an evaluation platform supports CUBE:
 
 ## About The AI Alliance
 
-**CUBE Standard** is a project of the [The AI Alliance](https://aialliance.org){:target="ai-alliance"}.
+**CUBE Standard** is a project of the [The AI Alliance](https://thealliance.ai){:target="ai-alliance"}.
 
 The AI Alliance is a global collaboration of startups, enterprises, academic, and other research institutions interested in advancing the state of the art, the availability, and the safety of AI technology and uses. The AI Alliance's core projects seek to address substantial cross-community challenges and are an opportunity for contributors to collaborate, build, and make an impact on the future of AI. Core Projects are managed directly by the AI Alliance and governed as described in our [community GitHub repository](https://github.com/The-AI-Alliance/community){:target="community"}.
 
-You can find information about all AI Alliance projects on [our website](https://aialliance.org/){:target="aia"} and our [GitHub organization](https://the-ai-alliance.github.io/){:target="aia-github"}.
+You can find information about all AI Alliance projects on [our website](https://thealliance.ai/){:target="aia"} and our [GitHub organization](https://the-ai-alliance.github.io/){:target="aia-github"}.
 
 If you have any questions or concerns about this effort, please contact us at [contact@thealliance.ai](mailto:contact@thealliance.ai?subject=Questions about CUBE Standard).
 
@@ -103,6 +103,6 @@ See our [Contributing Guide]({{site.baseurl}}/contributing) to get involved.
 
 ### Other AI Alliance Information
 
-- [More About the AI Alliance](https://aialliance.org/about){:target="aia"}
+- [More About the AI Alliance](https://thealliance.ai/about){:target="aia"}
 - [Contact Us](mailto:contact@thealliance.ai?subject=Questions about the AI Alliance) (email)
 - Follow us on [LinkedIn](https://www.linkedin.com/company/the-aialliance/){:target="linkedin"} and [Bluesky](https://bsky.app/profile/aialliance.bsky.social){:target="bluesky"}

--- a/docs/contributing.markdown
+++ b/docs/contributing.markdown
@@ -27,7 +27,7 @@ The link is used by the default docs/_includes/header_buttons_custom.html, for e
 <a name="join-this-project"></a>
 ## Join the Alliance or This Project Work Group
 
-Want to help us drive the evolution of this project? Please join our work group or the Alliance as a whole. See [this page](https://www.aialliance.org/join){:target="aia-join"} for more information.
+Want to help us drive the evolution of this project? Please join our work group or the Alliance as a whole. See [this page](https://www.thealliance.ai/join){:target="aia-join"} for more information.
 
 ## Other Notes on Contributing
 


### PR DESCRIPTION
# Revert to thealliance.ai domain from aialliance.org

We decided to stay with the old domain, although the .org domain still works and redirects. This PR changes links to the .ai domain.

## Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide
- [x] My changes follow the documentation style guide
- [x] I have updated any related documentation
- [ ] I have added/updated tests if applicable
- [ ] I have included necessary screenshots or examples
