### PR TITLE
Container security capability tokens (container:privileged, container:cgroupns-host) — RFC + implementation

### DIFF
--- a/openspec/changes/container-security-tokens/deltas.md
+++ b/openspec/changes/container-security-tokens/deltas.md
@@ -1,0 +1,39 @@
+# Deltas — Container security capability tokens
+
+Applied to `openspec/specs/resource/spec.md`.
+
+## ADDED — `resource/spec.md`: two capability tokens + the apply role
+
+Extend the `capabilities()` / `requirements()` vocabulary with:
+
+- `container:privileged` — container runs with `--privileged`.
+- `container:cgroupns-host` — container shares the host cgroup namespace (`--cgroupns=host`).
+
+Declared via the existing `ResourceConfig.requires`; no new fields. The token-list note
+gains one sentence distinguishing the two roles a token can play:
+
+> Tokens are **gate-only** when the capability is the infra's default (`container:root` —
+> `can_serve` merely excludes infras that lack it), or **gate+apply** when it is opt-in
+> per container (`container:privileged`, `container:cgroupns-host` — an infra advertising
+> the token MUST translate it to the launch flag).
+
+Example: `ContainerConfig(image="cybench/...", requires={"container:privileged", "container:cgroupns-host"})`.
+
+## MODIFIED — `resource/spec.md`: apply invariant
+
+One invariant added: an infra that advertises a gate+apply token MUST apply the
+corresponding launch flag; one that does not advertise it MUST reject a requiring resource
+via the existing `can_serve` gate (no silent downgrade). Application is keyed off
+`resource.requirements()`, threaded as a new argument into `build_docker_run_script` (the
+single-container template reached via `launch_task_container`; additive signature change) and
+mapped to the SDK equivalent in each infra's `launch()` — **no new field or method**;
+`can_serve`, `on_incompatible`, and `BenchmarkConfig.make()` are unchanged.
+
+## Capability declarations (infra drivers)
+
+- `Local` (Docker present): MAY advertise both (single-tenant).
+- `AWS` (dedicated VM per run): MAY advertise both.
+- `Daytona` / `Modal` / `Azure`: per-backend, pending verification that the managed backend
+  permits `--privileged` (they build from `docker_images[0]`, not raw run flags).
+- `Toolkit`: MUST NOT advertise either (shared multi-tenant) — same rationale as
+  `container:root`.

--- a/openspec/changes/container-security-tokens/proposal.md
+++ b/openspec/changes/container-security-tokens/proposal.md
@@ -1,0 +1,81 @@
+# Container security capability tokens
+
+**Status:** Proposed
+**Date:** 2026-06-13
+**Scope:** `cube.resource` (token vocabulary + apply contract), `cube-resources` infra drivers.
+**Targets:** `dev`
+**Related:** extends `task-permission-requirements` (the `container:root` handshake).
+
+## Problem
+
+`task-permission-requirements` gave us the capability handshake — a task declares
+`ResourceConfig.requires`, an infra advertises `capabilities()`, `can_serve` gates the pair
+before spend — and shipped one container token: `container:root`.
+
+Crucially, **`requires` is read only by the gate** (`can_serve`); no `launch()` reads it.
+`container:root` works as a *gate-only* token because uid 0 is Docker's default — the token
+just excludes infras that pin a non-root uid; nothing has to be *applied*. So a security
+flag that is **opt-in per container** cannot be expressed at all today: adding it to
+`requires` would pass `can_serve` and then launch *without* the flag — a silent capability
+downgrade, the exact failure `task-permission-requirements` exists to prevent.
+
+That blocks the Security/CTF category outright. Concretely, Cybench (the category's primary
+eval) needs `--privileged` **and** `--cgroupns=host` to run its challenge harness; NYU CTF,
+BountyBench, and CyberGym likewise need `--privileged`. On the structured
+`ContainerConfig` path these flags have no expression: `build_docker_run_script`
+(`task_infra.py`) is a fixed template with no flag input. (A cube *can* smuggle flags into a
+`DockerServiceConfig.launch_script` raw-bash string — but only on `Local`; Daytona/Modal/AWS
+build from `docker_images[0]` and ignore it, so it is not a portable answer.)
+
+**Demand basis:** a CUBE-fit survey of 14 candidate benchmarks (forward-looking, not a
+recurring closed request). No prior issues/PRs for these tokens.
+
+## Design
+
+Two additions, both riding the existing handshake. **No new fields, no new methods, no
+breaking change.**
+
+1. **Tokens.** Add `container:privileged` and `container:cgroupns-host` to the standard
+   vocabulary, declared via the existing `ResourceConfig.requires`.
+2. **Apply contract (the one genuinely new behavior).** A token can now play one of two
+   roles, made explicit in the spec: *gate-only* (`container:root` — reflects infra default;
+   `can_serve` only excludes infras that lack it) or *gate+apply* (these two — the infra MUST
+   translate a present token into the launch flag). The apply point is
+   `build_docker_run_script` — the single-container template reached via
+   `launch_task_container` (which builds a `DockerServiceConfig(scope="task")`). It gains the
+   resource's `requirements()` as an argument (an additive signature change) and emits
+   `--privileged` / `--cgroupns=host` when the token is present; each cloud infra's `launch()`
+   maps the token to its SDK's equivalent. Additive only — **no new field**.
+3. **Advertise.** An infra publishes a token only where backend *and tenancy* allow:
+   single-tenant `Local` (Docker present) and dedicated-VM infras may; shared multi-tenant
+   `Toolkit` must not — same trust model as `container:root`. `can_serve` then gates safely.
+
+## Why this shape
+
+- **Rides the accepted precedent.** Declaration (`requires`), gate (`can_serve`), policy
+  (`on_incompatible`) are reused unchanged; we extend a `set[str]` vocabulary designed to
+  stay open. The apply contract is the minimum needed to make opt-in flags safe.
+- **Safety is automatic.** An infra that shouldn't grant the capability doesn't advertise it;
+  tasks needing it fail the gate pre-spend rather than silently launching unprivileged or
+  dangerously over-privileged.
+- **General.** Unblocks the whole Security category (5 benchmarks), anchored by Cybench.
+
+## On the two-token split (a deliberate call)
+
+`container:privileged` is the hard-block — keep. `container:cgroupns-host` is kept **because
+Cybench concretely needs it on top of `--privileged`**, and `--cgroupns=host` is orthogonal
+to `--privileged` (the latter does not set the cgroup namespace mode), so privileged-only
+would leave the category's P0 anchor blocked — the RFC's headline goal. This meets the lean
+bar ("add a token when a surveyed cube proves it needs it"), not speculation. **Open
+question for review:** if implementation confirms `--privileged` is sufficient for Cybench in
+practice, collapse to the single `container:privileged` token.
+
+## Out of scope (deliberately not bundled)
+
+- **`network:host` / multiple resources per task.** TheAgentCompany's "reach co-located
+  services" is better modeled as a *separate tracked resource* (agent container + service
+  container), not `--network=host`. That is a larger change (singular
+  `TaskMetadata.container_config` → composite + cleanup-tagging) and a separate RFC;
+  `--network=host` now would be a workaround to retract later.
+- **A finer `cap_add` matrix** (`cap:net_admin`, …). Add narrower tokens only when a concrete
+  cube needs less than full privilege.

--- a/openspec/changes/container-security-tokens/proposal.md
+++ b/openspec/changes/container-security-tokens/proposal.md
@@ -1,10 +1,24 @@
 # Container security capability tokens
 
-**Status:** Proposed
+**Status:** Proposed + implemented in this PR
 **Date:** 2026-06-13
-**Scope:** `cube.resource` (token vocabulary + apply contract), `cube-resources` infra drivers.
+**Scope:** `cube.resource` (token vocabulary + apply contract), `cube.task_infra`, `cube.task`,
+`cube.infra_local`.
 **Targets:** `dev`
 **Related:** extends `task-permission-requirements` (the `container:root` handshake).
+
+## Implementation (this PR)
+
+- `task_infra.build_docker_run_script(..., requires)` maps gate+apply tokens to `docker run`
+  flags (`--privileged`, `--cgroupns=host`); `launch_task_container(..., requires)` threads
+  them and re-declares them on the task `DockerServiceConfig`.
+- `task.model_post_init` passes `container_config.requirements()`, so every standard-path
+  cube gets it automatically just by declaring `requires` on its `ContainerConfig`.
+- `LocalInfraConfig.capabilities()` advertises both tokens when Docker is present (single
+  tenant); shared infra (Toolkit) advertises neither — unchanged. Cloud infras (AWS/Daytona/
+  Modal/Azure) are left unadvertised pending per-backend verification, so `can_serve`
+  safely rejects requiring tasks there.
+- Spec (`resource/spec.md`) + docstrings updated; unit tests in `tests/test_resource_lifecycle.py`.
 
 ## Problem
 

--- a/openspec/specs/resource/spec.md
+++ b/openspec/specs/resource/spec.md
@@ -45,7 +45,16 @@ class ResourceConfig(TypedBaseModel):
 
 Standard capability tokens: `"kvm"`, `"docker"`, `"gpu:nvidia"`, `"network:egress"`,
 `"container:root"` (container processes run as uid 0 — needed by tasks that `apt`-install
-or write to `/etc`, `/var`; absent on infras that pin a non-root uid, e.g. EAI Toolkit).
+or write to `/etc`, `/var`; absent on infras that pin a non-root uid, e.g. EAI Toolkit),
+`"container:privileged"` (`--privileged`), `"container:cgroupns-host"` (`--cgroupns=host`).
+
+A token plays one of two roles. **Gate-only** (`container:root`): the capability is the
+infra's default behaviour, so the token only lets `can_serve` exclude infras that lack it —
+no launch logic. **Gate+apply** (`container:privileged`, `container:cgroupns-host`): the
+capability is opt-in per container, so an infra advertising the token MUST also translate it
+into the launch flag (in `build_docker_run_script` for the single-container path, and each
+infra's `launch()`). Only single-tenant/trusted infra should advertise gate+apply security
+tokens; shared multi-tenant infra (Toolkit) must not.
 
 `requires` is the declarative escape hatch: any resource adds tokens here and every
 subclass folds them via `super().requirements()`, so `requirements()` is the single
@@ -183,6 +192,9 @@ benchmark.close()                           # tears down L2 resource
    environments can fully isolate from production without renaming resources.
 7. `ResourceHandle` is not serializable — never pass across process boundaries. Pass
    `run_id` instead and have the target process call `infra.cleanup(run_id)`.
+8. A gate+apply token must never be silently dropped: an infra that advertises it MUST
+   apply the launch flag; one that does not advertise it MUST fail `can_serve` for a
+   requiring resource (no run-as-unprivileged downgrade).
 
 ## Gotchas
 

--- a/src/cube/infra_local.py
+++ b/src/cube/infra_local.py
@@ -519,6 +519,10 @@ class LocalInfraConfig(InfraConfig):
         if shutil.which("docker"):
             caps.add("docker")
             caps.add("container:root")  # local Docker containers run as uid 0
+            # Single-tenant dev box: privileged exec and host namespaces are permitted.
+            # Shared multi-tenant infra (e.g. Toolkit) must NOT advertise these.
+            caps.add("container:privileged")
+            caps.add("container:cgroupns-host")
         return caps
 
     def provision(self, resource: ResourceConfig) -> None:

--- a/src/cube/resource.py
+++ b/src/cube/resource.py
@@ -161,7 +161,8 @@ class ResourceConfig(TypedBaseModel):
         Checked against ``InfraConfig.capabilities()`` (via ``InfraConfig.can_serve``)
         before provisioning or launch. Subclasses union their structural needs onto the
         explicit ``requires`` tokens via ``super().requirements()``.
-        Standard tokens: "kvm", "docker", "gpu:nvidia", "network:egress", "container:root".
+        Standard tokens: "kvm", "docker", "gpu:nvidia", "network:egress", "container:root",
+        "container:privileged", "container:cgroupns-host".
         """
         return set(self.requires)
 
@@ -516,7 +517,10 @@ class InfraConfig(ValidatedConfig, ABC):
         Checked against resource.requirements() before provisioning or launch.
         Standard tokens: "kvm", "docker", "gpu:nvidia", "network:egress",
         "container:root" (container processes run as uid 0 — needed by tasks that
-        apt-install or write to /etc, /var; absent on infras that pin a non-root uid).
+        apt-install or write to /etc, /var; absent on infras that pin a non-root uid),
+        "container:privileged" (--privileged) and "container:cgroupns-host"
+        (--cgroupns=host) — gate+apply tokens an infra both advertises and applies at
+        launch; only single-tenant/trusted infra should publish them.
         """
         ...
 

--- a/src/cube/task.py
+++ b/src/cube/task.py
@@ -215,6 +215,7 @@ class Task(TypedBaseModel, Generic[TTMetadata, TTool], ABC):
                 image=cc.image,
                 ram_gb=cc.ram_gb,
                 cpu_cores=cc.cpu_cores,
+                requires=cc.requirements(),
             )
 
         # The task's own no-role tool (single-agent's tool, or a shared-world admin tool).

--- a/src/cube/task_infra.py
+++ b/src/cube/task_infra.py
@@ -20,11 +20,20 @@ from cube.task import RuntimeContext
 __all__ = ["launch_task_container", "build_docker_run_script"]
 
 
+# Gate+apply security capability tokens → the ``docker run`` flag each one applies.
+# Deterministic order keeps the generated script stable. See resource/spec.md.
+_SECURITY_FLAGS: dict[str, str] = {
+    "container:privileged": "--privileged",
+    "container:cgroupns-host": "--cgroupns=host",
+}
+
+
 def build_docker_run_script(
     container_name: str,
     image: str,
     ram_gb: float,
     cpu_cores: float,
+    requires: set[str] | None = None,
 ) -> str:
     """Return a bash snippet that `docker run`s ``image`` as a detached ``sleep infinity`` container.
 
@@ -37,13 +46,21 @@ def build_docker_run_script(
     label filter in ``_launch_docker_service`` can identify just this container under
     concurrent launches (pytest-xdist, Ray workers, etc.).  ``:-unlabeled`` lets the
     script still run when invoked outside the infra (manual debugging).
+
+    ``requires`` carries the resource's capability tokens (``ResourceConfig.requirements()``);
+    each gate+apply security token present (``container:privileged``,
+    ``container:cgroupns-host``) is translated to its ``docker run`` flag. Such tokens are
+    capability-gated by ``can_serve`` before launch, so an infra only ever applies a flag it
+    advertised.
     """
+    security = "".join(f"{flag} " for token, flag in _SECURITY_FLAGS.items() if token in (requires or set()))
     return (
         f"docker run -d "
         f"--name {container_name} "
         f'--label "cube.launch=${{CUBE_LAUNCH_ID:-unlabeled}}" '
         f"--memory={int(ram_gb * 1024)}m "
         f"--cpus={cpu_cores} "
+        f"{security}"
         f"{image} "
         f"sleep infinity"
     )
@@ -56,6 +73,7 @@ def launch_task_container(
     image: str,
     ram_gb: float = 4.0,
     cpu_cores: float = 2.0,
+    requires: set[str] | None = None,
 ) -> tuple[ResourceHandle, Container]:
     """Provision + launch a single-container L3 resource via ``runtime_context["infra"]``.
 
@@ -66,6 +84,10 @@ def launch_task_container(
             Used for ProvisionStore keys and as the docker container-name prefix.
         image: Container image reference (e.g. ``"swebench/sweb.eval.x86_64.django-11099:latest"``).
         ram_gb / cpu_cores: Resource requirements hinted to the infra.
+        requires: Capability tokens (``container_config.requirements()``). Gate+apply
+            security tokens (``container:privileged``, ``container:cgroupns-host``) are
+            applied as ``docker run`` flags; all are already capability-gated at
+            ``BenchmarkConfig.make()`` time.
 
     Returns:
         ``(handle, container)`` — the ResourceHandle (for lifecycle teardown via
@@ -83,7 +105,8 @@ def launch_task_container(
         name=name,
         scope="task",
         docker_images=[image],
-        launch_script=build_docker_run_script(container_name, image, ram_gb, cpu_cores),
+        launch_script=build_docker_run_script(container_name, image, ram_gb, cpu_cores, requires),
+        requires=set(requires or set()),
     )
     if infra.provision_status(resource) == "needs_provisioning":
         infra.provision(resource)

--- a/tests/test_resource_lifecycle.py
+++ b/tests/test_resource_lifecycle.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 import pytest
 
+from cube.infra_local import LocalInfraConfig
 from cube.provision_store import ProvisionStore
 from cube.resource import (
     ContainerConfig,
@@ -25,6 +26,7 @@ from cube.resource import (
     UnsupportedResourceType,
     VMResourceConfig,
 )
+from cube.task_infra import build_docker_run_script
 
 # ── Minimal concrete InfraConfig for testing ──────────────────────────────────
 
@@ -272,6 +274,52 @@ class TestResourceRequires:
         cc = ContainerConfig(image="i", requires={"container:root"})
         assert _StubInfra(name="root", caps=["docker", "container:root"]).can_serve(cc) is True
         assert _StubInfra(name="nonroot", caps=["docker"]).can_serve(cc) is False
+
+
+# ── container security gate+apply tokens ──────────────────────────────────────
+
+
+class TestContainerSecurityTokens:
+    """`container:privileged` / `container:cgroupns-host`: declared via `requires`, gated by
+    `can_serve`, and applied as `docker run` flags by `build_docker_run_script`."""
+
+    def test_requirements_fold_security_tokens(self) -> None:
+        cc = ContainerConfig(image="i", requires={"container:privileged", "container:cgroupns-host"})
+        assert cc.requirements() == {"docker", "container:privileged", "container:cgroupns-host"}
+
+    def test_can_serve_gates_privileged(self) -> None:
+        cc = ContainerConfig(image="i", requires={"container:privileged"})
+        assert _StubInfra(name="priv", caps=["docker", "container:privileged"]).can_serve(cc) is True
+        assert _StubInfra(name="nopriv", caps=["docker"]).can_serve(cc) is False
+
+    def test_build_script_emits_flags_in_order(self) -> None:
+        script = build_docker_run_script(
+            "c", "img", 4.0, 2.0, requires={"container:privileged", "container:cgroupns-host"}
+        )
+        assert "--privileged" in script
+        assert "--cgroupns=host" in script
+        # deterministic order: privileged before cgroupns, both before the image
+        assert script.index("--privileged") < script.index("--cgroupns=host") < script.index("img")
+
+    def test_build_script_no_flags_without_tokens(self) -> None:
+        for requires in (None, set(), {"container:root"}):
+            script = build_docker_run_script("c", "img", 4.0, 2.0, requires=requires)
+            assert "--privileged" not in script
+            assert "--cgroupns=host" not in script
+
+    def test_local_advertises_security_tokens_with_docker(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "cube.infra_local.shutil.which",
+            lambda name: "/usr/bin/docker" if name == "docker" else None,
+        )
+        caps = LocalInfraConfig().capabilities()
+        assert {"container:privileged", "container:cgroupns-host"} <= caps
+
+    def test_local_omits_security_tokens_without_docker(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("cube.infra_local.shutil.which", lambda name: None)
+        caps = LocalInfraConfig().capabilities()
+        assert "container:privileged" not in caps
+        assert "container:cgroupns-host" not in caps
 
 
 # ── InfraConfig base: register / provision_status / can_serve ─────────────────


### PR DESCRIPTION
## What

Adds two **gate+apply capability tokens** — `container:privileged` and `container:cgroupns-host` — extending the merged `task-permission-requirements` handshake (`requires` → `can_serve` → `on_incompatible`). **No new fields, no new methods, no breaking change.** This PR now includes **both the RFC and the implementation** (one review).

## Why (demand)

A CUBE-fit survey of 14 candidate benchmarks found the **Security/CTF category hard-blocked**: Cybench (category P0 eval anchor) needs `--privileged` **and** `--cgroupns=host`; NYU CTF Bench, BountyBench, CyberGym need `--privileged`. The vocabulary couldn't express opt-in container flags — `requires` is read only by the gate (`can_serve`), never by `launch()`, so a token added without apply logic would pass the gate then launch *without* the flag (a silent downgrade). `container:root` works gate-only because uid 0 is Docker's default; these flags must be **applied**.

## RFC
`openspec/changes/container-security-tokens/{proposal.md,deltas.md}` + applied spec delta in `openspec/specs/resource/spec.md` (token list, gate-vs-apply roles, no-silent-downgrade invariant).

## Implementation
- `task_infra.build_docker_run_script(requires=)` maps tokens → `docker run` flags (`--privileged`, `--cgroupns=host`); `launch_task_container(requires=)` threads + re-declares them.
- `task.model_post_init` passes `container_config.requirements()`, so **every standard-path cube** gets it just by declaring `requires` on its `ContainerConfig`.
- `LocalInfraConfig.capabilities()` advertises both when Docker is present (single-tenant); shared `Toolkit` advertises neither; cloud infras (AWS/Daytona/Modal/Azure) left unadvertised pending per-backend verification → `can_serve` safely rejects requiring tasks there.
- Tests in `tests/test_resource_lifecycle.py`: requirements folding, `can_serve` gating, flag emission + order, Local advertising with/without Docker.

## Validation
`ruff` (0.15.11) check + format clean; `pytest tests/` green (the lone full-suite failure is a pre-existing `No module named 'docker'` env gap — passes with `--extra docker`).

## Scope calls
- **Two tokens, not one:** `--cgroupns=host` is orthogonal to `--privileged` (Docker defaults cgroupns to `private` even under privileged) and Cybench needs both. Open question: collapse to one if implementation shows privileged suffices.
- **Deferred:** `network:host` + multiple-resources-per-task (TheAgentCompany's co-located services — a separate composite-resource RFC); finer `cap_add` matrix.

## Review
Vetted with `/gatekeep-rfc` over two passes → **ACCEPT** (lean, in-charter, additive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)